### PR TITLE
chore: Fix adapter CI test timeout

### DIFF
--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -12,7 +12,7 @@
 		".": "./index.ts"
 	},
 	"scripts": {
-		"test": "bun test",
+		"test": "bun test --timeout 30000",
 		"lint": "tsgo --noEmit"
 	},
 	"dependencies": {


### PR DESCRIPTION
Increases the timeout for adapter tests to 30s so docker can pull Redis and Memcached images.