### PR TITLE
test(adapters): isolate db and kv tests for parallel execution

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -7,7 +7,7 @@
 	],
 	"scripts": {
 		"dev": "bun --watch deployments/standalone.ts",
-		"test": "bun test --concurrent",
+		"test": "bun test --parallel",
 		"lint": "tsgo --noEmit",
 		"start": "bun run deployments/standalone.ts",
 		"build": "bun build deployments/standalone.ts --outdir=dist --bundle --target bun --minify --sourcemap=linked",

--- a/packages/adapters/db/mongoDbAdapter.test.ts
+++ b/packages/adapters/db/mongoDbAdapter.test.ts
@@ -18,7 +18,7 @@ const containerName = "fluxify-mongo-adapter-test";
 const exposedPort = 27017;
 
 let container: Docker.Container | null = null;
-let adapter: MongoAdapter;
+let db: any;
 let client: MongoClient;
 let vm: JsVM = {} as JsVM;
 
@@ -86,14 +86,10 @@ beforeAll(async () => {
 
 	if (!ready) throw new Error("MongoDB container did not become ready.");
 
-	const db = client.db("testdb");
-	adapter = new MongoAdapter(client, db, vm);
+	db = client.db("testdb");
 }, 120000);
 
-beforeEach(async () => {
-	// Equivalent to TRUNCATE TABLE
-	await adapter.delete("users", []);
-});
+
 
 afterAll(async () => {
 	if (client) await client.close();
@@ -129,24 +125,26 @@ describe("MongoAdapter Integration Tests", () => {
 	});
 
 	test("CRUD: Single Record Lifecycle", async () => {
+		const adapter = new MongoAdapter(client, db, vm);
+		const collectionName = "users_" + faker.string.alphanumeric(8).toLowerCase();
 		const user = {
 			name: faker.person.firstName(),
 			email: faker.internet.email(),
 			age: faker.number.int({ min: 18, max: 65 }),
 		};
 
-		const inserted = (await adapter.insert("users", user)) as typeof user & {
+		const inserted = (await adapter.insert(collectionName, user)) as typeof user & {
 			id: string;
 		};
 
 		expect(inserted.id).toBeDefined(); // Verifies _id mapped to id
 
-		const fetched = await adapter.getSingle("users", [
+		const fetched = await adapter.getSingle(collectionName, [
 			{ attribute: "id", operator: "eq", value: inserted.id, chain: "and" },
 		]);
 		expect(fetched).toMatchObject(user);
 
-		const notFound = await adapter.getSingle("users", [
+		const notFound = await adapter.getSingle(collectionName, [
 			{
 				attribute: "id",
 				operator: "eq",
@@ -156,32 +154,34 @@ describe("MongoAdapter Integration Tests", () => {
 		]);
 		expect(notFound).toBeNull();
 
-		await adapter.update("users", { age: 29 }, [
+		await adapter.update(collectionName, { age: 29 }, [
 			{ attribute: "id", operator: "eq", value: inserted.id, chain: "and" },
 		]);
 
-		const updated = (await adapter.getSingle("users", [
+		const updated = (await adapter.getSingle(collectionName, [
 			{ attribute: "id", operator: "eq", value: inserted.id, chain: "and" },
 		])) as any;
 		expect(updated.age).toBe(29);
 
-		const isDeleted = await adapter.delete("users", [
+		const isDeleted = await adapter.delete(collectionName, [
 			{ attribute: "id", operator: "eq", value: inserted.id, chain: "and" },
 		]);
 		expect(isDeleted).toBe(true);
 	});
 
 	test("Advanced Filtering & Operators", async () => {
+		const adapter = new MongoAdapter(client, db, vm);
+		const collectionName = "users_" + faker.string.alphanumeric(8).toLowerCase();
 		const users = Array.from({ length: 20 }).map(() => ({
 			name: faker.person.firstName(),
 			email: faker.internet.email(),
 			age: faker.number.int({ min: 18, max: 65 }),
 			score: faker.number.int({ min: 5, max: 40 }),
 		}));
-		await adapter.insertBulk("users", users);
+		await adapter.insertBulk(collectionName, users);
 
 		const filtered = (await adapter.getAll(
-			"users",
+			collectionName,
 			[
 				{ attribute: "age", operator: "gt", value: 10, chain: "and" },
 				{ attribute: "age", operator: "lte", value: 25, chain: "and" },
@@ -195,7 +195,7 @@ describe("MongoAdapter Integration Tests", () => {
 		expect(filtered).toHaveLength(filteredUsers.length);
 
 		const orFiltered = (await adapter.getAll(
-			"users",
+			collectionName,
 			[
 				{ attribute: "age", operator: "eq", value: 5, chain: "or" },
 				{ attribute: "score", operator: "gte", value: 40, chain: "or" },
@@ -212,16 +212,18 @@ describe("MongoAdapter Integration Tests", () => {
 	});
 
 	test("Pagination & Sorting", async () => {
+		const adapter = new MongoAdapter(client, db, vm);
+		const collectionName = "users_" + faker.string.alphanumeric(8).toLowerCase();
 		const users = Array.from({ length: 20 }).map((_, i) => ({
 			name: faker.person.firstName(),
 			email: faker.internet.email(),
 			age: 40 + i,
 		}));
-		await adapter.insertBulk("users", users);
+		await adapter.insertBulk(collectionName, users);
 
 		const skip = 2,
 			limit = 4;
-		const page = (await adapter.getAll("users", [], limit, skip, {
+		const page = (await adapter.getAll(collectionName, [], limit, skip, {
 			attribute: "age",
 			direction: "desc",
 		})) as any[];
@@ -233,18 +235,20 @@ describe("MongoAdapter Integration Tests", () => {
 	});
 
 	test("Bulk Edge Cases & Mass Mutations", async () => {
-		const emptyInsert = await adapter.insertBulk("users", []);
+		const adapter = new MongoAdapter(client, db, vm);
+		const collectionName = "users_" + faker.string.alphanumeric(8).toLowerCase();
+		const emptyInsert = await adapter.insertBulk(collectionName, []);
 		expect(emptyInsert).toEqual([]);
 
-		await adapter.insert("users", { name: "Mass", age: 88 });
-		await adapter.insert("users", { name: "Mass", age: 88 });
+		await adapter.insert(collectionName, { name: "Mass", age: 88 });
+		await adapter.insert(collectionName, { name: "Mass", age: 88 });
 
-		await adapter.update("users", { score: 777 }, [
+		await adapter.update(collectionName, { score: 777 }, [
 			{ attribute: "age", operator: "eq", value: 88, chain: "and" },
 		]);
 
 		const verifyUpdate = (await adapter.getAll(
-			"users",
+			collectionName,
 			[{ attribute: "score", operator: "eq", value: 777, chain: "and" }],
 			10,
 			0,
@@ -252,30 +256,34 @@ describe("MongoAdapter Integration Tests", () => {
 		)) as any[];
 		expect(verifyUpdate.length).toBeGreaterThanOrEqual(2);
 
-		const deleteSuccess = await adapter.delete("users", [
+		const deleteSuccess = await adapter.delete(collectionName, [
 			{ attribute: "score", operator: "eq", value: 777, chain: "and" },
 		]);
 		expect(deleteSuccess).toBe(true);
 	});
 
 	test("Raw Queries (Command API)", async () => {
-		await adapter.insert("users", { name: "Raw", age: 100 });
+		const adapter = new MongoAdapter(client, db, vm);
+		const collectionName = "users_" + faker.string.alphanumeric(8).toLowerCase();
+		await adapter.insert(collectionName, { name: "Raw", age: 100 });
 
 		// In Mongo, raw uses DB commands. We can use the 'count' command here.
-		const db = await adapter.raw();
-		const count = await db.collection("users").countDocuments({ age: 100 });
+		const rawDb = await adapter.raw();
+		const count = await rawDb.collection(collectionName).countDocuments({ age: 100 });
 		expect(count).toBeGreaterThan(0);
 	});
 
 	test("Transaction Lifecycle & Rollbacks", async () => {
+		const adapter = new MongoAdapter(client, db, vm);
+		const collectionName = "users_" + faker.string.alphanumeric(8).toLowerCase();
 		await adapter.startTransaction();
-		const tUser = (await adapter.insert("users", {
+		const tUser = (await adapter.insert(collectionName, {
 			name: "TrxTest",
 			age: 55,
 		})) as any;
 		await adapter.rollbackTransaction();
 
-		const verifyRollback = await adapter.getSingle("users", [
+		const verifyRollback = await adapter.getSingle(collectionName, [
 			{ attribute: "id", operator: "eq", value: tUser.id, chain: "and" },
 		]);
 		expect(verifyRollback).toBeNull();

--- a/packages/adapters/db/mySqlAdapter.test.ts
+++ b/packages/adapters/db/mySqlAdapter.test.ts
@@ -18,7 +18,7 @@ const containerName = "fluxify-mysql-adapter-test";
 const exposedPort = 33006;
 
 let container: Docker.Container | null = null;
-let adapter: MySqlAdapter;
+let db: any;
 let pool: Pool;
 let vm: JsVM = {} as JsVM;
 
@@ -72,23 +72,10 @@ beforeAll(async () => {
 	if (!ready) throw new Error("MySQL container did not become ready in time.");
 
 	pool = createPool(connInfo);
-	const db = MySqlAdapter.createKysely(pool);
-	adapter = new MySqlAdapter(db, pool, vm);
-
-	await adapter.raw(`
-		CREATE TABLE users (
-			id INT AUTO_INCREMENT PRIMARY KEY,
-			name VARCHAR(255) NOT NULL,
-			email VARCHAR(255) NOT NULL,
-			age INT NOT NULL,
-			score INT DEFAULT 0
-		)
-	`);
+	db = MySqlAdapter.createKysely(pool);
 }, 120000);
 
-beforeEach(async () => {
-	await adapter.raw("TRUNCATE TABLE users");
-});
+
 
 afterAll(async () => {
 	if (pool) await pool.promise().end();
@@ -123,52 +110,76 @@ describe("MySqlAdapter Integration Tests", () => {
 	});
 
 	test("CRUD: Single Record Lifecycle", async () => {
+		const adapter = new MySqlAdapter(db, pool, vm);
+		const tableName = "users_" + faker.string.alphanumeric(8).toLowerCase();
+		await adapter.raw(`
+			CREATE TABLE ${tableName} (
+				id INT AUTO_INCREMENT PRIMARY KEY,
+				name VARCHAR(255) NOT NULL,
+				email VARCHAR(255) NOT NULL,
+				age INT NOT NULL,
+				score INT DEFAULT 0
+			)
+		`);
+
 		const user = {
 			name: faker.person.firstName(),
 			email: faker.internet.email(),
 			age: faker.number.int({ min: 18, max: 65 }),
 		};
 
-		const inserted = await adapter.insert("users", user);
+		const inserted = await adapter.insert(tableName, user);
 		expect(inserted.id).toBeGreaterThan(0);
 
-		const fetched = await adapter.getSingle("users", [
+		const fetched = await adapter.getSingle(tableName, [
 			{ attribute: "id", operator: "eq", value: inserted.id, chain: "and" },
 		]);
 		expect(fetched).toMatchObject(user);
 
-		const notFound = await adapter.getSingle("users", [
+		const notFound = await adapter.getSingle(tableName, [
 			{ attribute: "id", operator: "eq", value: -1, chain: "and" },
 		]);
 		expect(notFound).toBeNull();
 
-		await adapter.update("users", { age: 29 }, [
+		await adapter.update(tableName, { age: 29 }, [
 			{ attribute: "id", operator: "eq", value: inserted.id, chain: "and" },
 		]);
 
-		const updated = (await adapter.getSingle("users", [
+		const updated = (await adapter.getSingle(tableName, [
 			{ attribute: "id", operator: "eq", value: inserted.id, chain: "and" },
 		])) as any;
 		expect(updated.age).toBe(29);
 
-		const isDeleted = await adapter.delete("users", [
+		const isDeleted = await adapter.delete(tableName, [
 			{ attribute: "id", operator: "eq", value: inserted.id, chain: "and" },
 		]);
 		expect(isDeleted).toBe(true);
 	});
 
 	test("Advanced Filtering & Operators", async () => {
+		const adapter = new MySqlAdapter(db, pool, vm);
+		const tableName = "users_" + faker.string.alphanumeric(8).toLowerCase();
+		await adapter.raw(`
+			CREATE TABLE ${tableName} (
+				id INT AUTO_INCREMENT PRIMARY KEY,
+				name VARCHAR(255) NOT NULL,
+				email VARCHAR(255) NOT NULL,
+				age INT NOT NULL,
+				score INT DEFAULT 0
+			)
+		`);
+
 		const users = Array.from({ length: 20 }).map((_, i) => ({
 			name: faker.person.firstName(),
 			email: faker.internet.email(),
 			age: faker.number.int({ min: 18, max: 65 }),
 			score: faker.number.int({ min: 5, max: 40 }),
 		}));
-		await adapter.insertBulk("users", users);
+		await adapter.insertBulk(tableName, users);
 
 		// Greater than / Less than or equal
 		const filtered = (await adapter.getAll(
-			"users",
+			tableName,
 			[
 				{ attribute: "age", operator: "gt", value: 10, chain: "and" },
 				{ attribute: "age", operator: "lte", value: 25, chain: "and" },
@@ -185,7 +196,7 @@ describe("MySqlAdapter Integration Tests", () => {
 
 		// OR chaining
 		const orFiltered = (await adapter.getAll(
-			"users",
+			tableName,
 			[
 				{ attribute: "age", operator: "eq", value: 5, chain: "or" },
 				{ attribute: "score", operator: "gte", value: 40, chain: "or" },
@@ -201,15 +212,27 @@ describe("MySqlAdapter Integration Tests", () => {
 	});
 
 	test("Pagination & Sorting", async () => {
+		const adapter = new MySqlAdapter(db, pool, vm);
+		const tableName = "users_" + faker.string.alphanumeric(8).toLowerCase();
+		await adapter.raw(`
+			CREATE TABLE ${tableName} (
+				id INT AUTO_INCREMENT PRIMARY KEY,
+				name VARCHAR(255) NOT NULL,
+				email VARCHAR(255) NOT NULL,
+				age INT NOT NULL,
+				score INT DEFAULT 0
+			)
+		`);
+
 		const users = Array.from({ length: 20 }).map((_, i) => ({
 			name: faker.person.firstName(),
 			email: faker.internet.email(),
 			age: 40 + i,
 		}));
-		await adapter.insertBulk("users", users);
+		await adapter.insertBulk(tableName, users);
 		const skip = 2,
 			limit = 4;
-		const page = (await adapter.getAll("users", [], limit, skip, {
+		const page = (await adapter.getAll(tableName, [], limit, skip, {
 			attribute: "age",
 			direction: "desc",
 		})) as any[];
@@ -220,26 +243,38 @@ describe("MySqlAdapter Integration Tests", () => {
 	});
 
 	test("Bulk Edge Cases & Mass Mutations", async () => {
-		const emptyInsert = await adapter.insertBulk("users", []);
+		const adapter = new MySqlAdapter(db, pool, vm);
+		const tableName = "users_" + faker.string.alphanumeric(8).toLowerCase();
+		await adapter.raw(`
+			CREATE TABLE ${tableName} (
+				id INT AUTO_INCREMENT PRIMARY KEY,
+				name VARCHAR(255) NOT NULL,
+				email VARCHAR(255) NOT NULL,
+				age INT NOT NULL,
+				score INT DEFAULT 0
+			)
+		`);
+
+		const emptyInsert = await adapter.insertBulk(tableName, []);
 		expect(emptyInsert).toEqual([]);
 
-		await adapter.insert("users", {
+		await adapter.insert(tableName, {
 			name: faker.person.firstName(),
 			email: faker.internet.email(),
 			age: 88,
 		});
-		await adapter.insert("users", {
+		await adapter.insert(tableName, {
 			name: faker.person.firstName(),
 			email: faker.internet.email(),
 			age: 88,
 		});
 
-		await adapter.update("users", { score: 777 }, [
+		await adapter.update(tableName, { score: 777 }, [
 			{ attribute: "age", operator: "eq", value: 88, chain: "and" },
 		]);
 
 		const verifyUpdate = (await adapter.getAll(
-			"users",
+			tableName,
 			[{ attribute: "score", operator: "eq", value: 777, chain: "and" }],
 			10,
 			0,
@@ -247,36 +282,60 @@ describe("MySqlAdapter Integration Tests", () => {
 		)) as any[];
 		expect(verifyUpdate.length).toBeGreaterThanOrEqual(2);
 
-		const deleteSuccess = await adapter.delete("users", [
+		const deleteSuccess = await adapter.delete(tableName, [
 			{ attribute: "score", operator: "eq", value: 777, chain: "and" },
 		]);
 		expect(deleteSuccess).toBe(true);
 	});
 
 	test("Raw Queries", async () => {
-		await adapter.insert("users", {
+		const adapter = new MySqlAdapter(db, pool, vm);
+		const tableName = "users_" + faker.string.alphanumeric(8).toLowerCase();
+		await adapter.raw(`
+			CREATE TABLE ${tableName} (
+				id INT AUTO_INCREMENT PRIMARY KEY,
+				name VARCHAR(255) NOT NULL,
+				email VARCHAR(255) NOT NULL,
+				age INT NOT NULL,
+				score INT DEFAULT 0
+			)
+		`);
+
+		await adapter.insert(tableName, {
 			name: faker.person.firstName(),
 			email: faker.internet.email(),
 			age: 100,
 		});
 		// MySQL uses ? instead of $1 for parameters
 		const result = await adapter.raw(
-			"SELECT COUNT(*) as total FROM users WHERE age = ?",
+			`SELECT COUNT(*) as total FROM ${tableName} WHERE age = ?`,
 			[100],
 		);
 		expect(Number(result.rows[0].total)).toBeGreaterThan(0);
 	});
 
 	test("Transaction Lifecycle & Rollbacks", async () => {
+		const adapter = new MySqlAdapter(db, pool, vm);
+		const tableName = "users_" + faker.string.alphanumeric(8).toLowerCase();
+		await adapter.raw(`
+			CREATE TABLE ${tableName} (
+				id INT AUTO_INCREMENT PRIMARY KEY,
+				name VARCHAR(255) NOT NULL,
+				email VARCHAR(255) NOT NULL,
+				age INT NOT NULL,
+				score INT DEFAULT 0
+			)
+		`);
+
 		await adapter.startTransaction();
-		const tUser = await adapter.insert("users", {
+		const tUser = await adapter.insert(tableName, {
 			name: faker.person.firstName(),
 			email: faker.internet.email(),
 			age: 55,
 		});
 		await adapter.rollbackTransaction();
 
-		const verifyRollback = await adapter.getSingle("users", [
+		const verifyRollback = await adapter.getSingle(tableName, [
 			{ attribute: "id", operator: "eq", value: tUser.id, chain: "and" },
 		]);
 		expect(verifyRollback).toBeNull();

--- a/packages/adapters/db/postgresAdapter.test.ts
+++ b/packages/adapters/db/postgresAdapter.test.ts
@@ -18,7 +18,7 @@ const containerName = "fluxify-pg-adapter-test";
 const exposedPort = 54320;
 
 let container: Docker.Container | null = null;
-let adapter: PostgresAdapter;
+let db: any;
 let sql: SQL;
 let vm: JsVM = {} as JsVM;
 
@@ -68,18 +68,7 @@ beforeAll(async () => {
 	if (!ready) throw new Error("PostgreSQL container did not become ready.");
 
 	sql = new SQL(url);
-	const db = PostgresAdapter.createKysely(sql);
-	adapter = new PostgresAdapter(db, sql, vm);
-
-	await adapter.raw(`
-    CREATE TABLE users (
-      id SERIAL PRIMARY KEY,
-      name VARCHAR(255) NOT NULL,
-      email VARCHAR(255) NOT NULL,
-      age INT NOT NULL,
-      score INT DEFAULT 0
-    )
-  `);
+	db = PostgresAdapter.createKysely(sql);
 }, 120000);
 
 afterAll(async () => {
@@ -95,11 +84,6 @@ afterAll(async () => {
 });
 
 describe("PostgresAdapter Integration Tests", () => {
-	beforeEach(async () => {
-		// In Postgres, TRUNCATE RESTART IDENTITY ensures the ID counter resets to 1,
-		// though DELETE FROM works perfectly fine too!
-		await adapter.raw("DELETE FROM users");
-	});
 
 	test("Connection Validation", async () => {
 		const connInfo: Connection = {
@@ -122,48 +106,72 @@ describe("PostgresAdapter Integration Tests", () => {
 	});
 
 	test("CRUD: Single Record Lifecycle", async () => {
+		const adapter = new PostgresAdapter(db, sql, vm);
+		const tableName = "users_" + faker.string.alphanumeric(8).toLowerCase();
+		await adapter.raw(`
+			CREATE TABLE ${tableName} (
+				id SERIAL PRIMARY KEY,
+				name VARCHAR(255) NOT NULL,
+				email VARCHAR(255) NOT NULL,
+				age INT NOT NULL,
+				score INT DEFAULT 0
+			)
+		`);
+
 		const user = {
 			name: faker.person.firstName(),
 			email: faker.internet.email(),
 			age: faker.number.int({ min: 18, max: 65 }),
 		};
 
-		const inserted = (await adapter.insert("users", user)) as any;
+		const inserted = (await adapter.insert(tableName, user)) as any;
 		expect(inserted.id).toBeGreaterThan(0);
 
-		const fetched = await adapter.getSingle("users", [
+		const fetched = await adapter.getSingle(tableName, [
 			{ attribute: "id", operator: "eq", value: inserted.id, chain: "and" },
 		]);
 		expect(fetched).toMatchObject(user);
 
-		const notFound = await adapter.getSingle("users", [
+		const notFound = await adapter.getSingle(tableName, [
 			{ attribute: "id", operator: "eq", value: -1, chain: "and" },
 		]);
 		expect(notFound).toBeNull();
 
-		const updated = (await adapter.update("users", { age: 29 }, [
+		const updated = (await adapter.update(tableName, { age: 29 }, [
 			{ attribute: "id", operator: "eq", value: inserted.id, chain: "and" },
 		])) as any[];
 		expect(updated[0].age).toBe(29);
 
-		const isDeleted = await adapter.delete("users", [
+		const isDeleted = await adapter.delete(tableName, [
 			{ attribute: "id", operator: "eq", value: inserted.id, chain: "and" },
 		]);
 		expect(isDeleted).toBe(true);
 	});
 
 	test("Advanced Filtering & Operators", async () => {
+		const adapter = new PostgresAdapter(db, sql, vm);
+		const tableName = "users_" + faker.string.alphanumeric(8).toLowerCase();
+		await adapter.raw(`
+			CREATE TABLE ${tableName} (
+				id SERIAL PRIMARY KEY,
+				name VARCHAR(255) NOT NULL,
+				email VARCHAR(255) NOT NULL,
+				age INT NOT NULL,
+				score INT DEFAULT 0
+			)
+		`);
+
 		const users = Array.from({ length: 20 }).map(() => ({
 			name: faker.person.firstName(),
 			email: faker.internet.email(),
 			age: faker.number.int({ min: 18, max: 65 }),
 			score: faker.number.int({ min: 5, max: 40 }),
 		}));
-		await adapter.insertBulk("users", users);
+		await adapter.insertBulk(tableName, users);
 
 		// Greater than / Less than or equal
 		const filtered = (await adapter.getAll(
-			"users",
+			tableName,
 			[
 				{ attribute: "age", operator: "gt", value: 10, chain: "and" },
 				{ attribute: "age", operator: "lte", value: 25, chain: "and" },
@@ -181,7 +189,7 @@ describe("PostgresAdapter Integration Tests", () => {
 
 		// OR chaining
 		const orFiltered = (await adapter.getAll(
-			"users",
+			tableName,
 			[
 				{ attribute: "age", operator: "eq", value: 5, chain: "or" },
 				{ attribute: "score", operator: "gte", value: 40, chain: "or" },
@@ -198,16 +206,28 @@ describe("PostgresAdapter Integration Tests", () => {
 	});
 
 	test("Pagination & Sorting", async () => {
+		const adapter = new PostgresAdapter(db, sql, vm);
+		const tableName = "users_" + faker.string.alphanumeric(8).toLowerCase();
+		await adapter.raw(`
+			CREATE TABLE ${tableName} (
+				id SERIAL PRIMARY KEY,
+				name VARCHAR(255) NOT NULL,
+				email VARCHAR(255) NOT NULL,
+				age INT NOT NULL,
+				score INT DEFAULT 0
+			)
+		`);
+
 		const users = Array.from({ length: 20 }).map((_, i) => ({
 			name: faker.person.firstName(),
 			email: faker.internet.email(),
 			age: 40 + i,
 		}));
-		await adapter.insertBulk("users", users);
+		await adapter.insertBulk(tableName, users);
 
 		const skip = 2,
 			limit = 4;
-		const page = (await adapter.getAll("users", [], limit, skip, {
+		const page = (await adapter.getAll(tableName, [], limit, skip, {
 			attribute: "age",
 			direction: "desc",
 		})) as any[];
@@ -219,34 +239,58 @@ describe("PostgresAdapter Integration Tests", () => {
 	});
 
 	test("Bulk Edge Cases & Mass Mutations", async () => {
-		const emptyInsert = await adapter.insertBulk("users", []);
+		const adapter = new PostgresAdapter(db, sql, vm);
+		const tableName = "users_" + faker.string.alphanumeric(8).toLowerCase();
+		await adapter.raw(`
+			CREATE TABLE ${tableName} (
+				id SERIAL PRIMARY KEY,
+				name VARCHAR(255) NOT NULL,
+				email VARCHAR(255) NOT NULL,
+				age INT NOT NULL,
+				score INT DEFAULT 0
+			)
+		`);
+
+		const emptyInsert = await adapter.insertBulk(tableName, []);
 		expect(emptyInsert).toEqual([]);
 
-		await adapter.insert("users", {
+		await adapter.insert(tableName, {
 			name: faker.person.firstName(),
 			email: faker.internet.email(),
 			age: 88,
 		});
-		await adapter.insert("users", {
+		await adapter.insert(tableName, {
 			name: faker.person.firstName(),
 			email: faker.internet.email(),
 			age: 88,
 		});
 
-		const updatedRows = (await adapter.update("users", { score: 999 }, [
+		const updatedRows = (await adapter.update(tableName, { score: 999 }, [
 			{ attribute: "age", operator: "eq", value: 88, chain: "and" },
 		])) as any[];
 		expect(updatedRows.length).toBeGreaterThanOrEqual(2);
 		expect(updatedRows[0].score).toBe(999);
 
-		const deleteSuccess = await adapter.delete("users", [
+		const deleteSuccess = await adapter.delete(tableName, [
 			{ attribute: "score", operator: "eq", value: 999, chain: "and" },
 		]);
 		expect(deleteSuccess).toBe(true);
 	});
 
 	test("Raw Queries", async () => {
-		await adapter.insert("users", {
+		const adapter = new PostgresAdapter(db, sql, vm);
+		const tableName = "users_" + faker.string.alphanumeric(8).toLowerCase();
+		await adapter.raw(`
+			CREATE TABLE ${tableName} (
+				id SERIAL PRIMARY KEY,
+				name VARCHAR(255) NOT NULL,
+				email VARCHAR(255) NOT NULL,
+				age INT NOT NULL,
+				score INT DEFAULT 0
+			)
+		`);
+
+		await adapter.insert(tableName, {
 			name: faker.person.firstName(),
 			email: faker.internet.email(),
 			age: 100,
@@ -254,22 +298,34 @@ describe("PostgresAdapter Integration Tests", () => {
 
 		// Postgres uses $1 for positional parameters
 		const result = (await adapter.raw(
-			"SELECT COUNT(*) as total FROM users WHERE age = $1",
+			`SELECT COUNT(*) as total FROM ${tableName} WHERE age = $1`,
 			[100],
 		)) as any;
 		expect(Number(result.rows[0].total)).toBeGreaterThan(0);
 	});
 
 	test("Transaction Lifecycle & Rollbacks", async () => {
+		const adapter = new PostgresAdapter(db, sql, vm);
+		const tableName = "users_" + faker.string.alphanumeric(8).toLowerCase();
+		await adapter.raw(`
+			CREATE TABLE ${tableName} (
+				id SERIAL PRIMARY KEY,
+				name VARCHAR(255) NOT NULL,
+				email VARCHAR(255) NOT NULL,
+				age INT NOT NULL,
+				score INT DEFAULT 0
+			)
+		`);
+
 		await adapter.startTransaction();
-		const tUser = (await adapter.insert("users", {
+		const tUser = (await adapter.insert(tableName, {
 			name: faker.person.firstName(),
 			email: faker.internet.email(),
 			age: 55,
 		})) as any;
 		await adapter.rollbackTransaction();
 
-		const verifyRollback = await adapter.getSingle("users", [
+		const verifyRollback = await adapter.getSingle(tableName, [
 			{ attribute: "id", operator: "eq", value: tUser.id, chain: "and" },
 		]);
 		expect(verifyRollback).toBeNull();

--- a/packages/adapters/kv/memcached.test.ts
+++ b/packages/adapters/kv/memcached.test.ts
@@ -32,7 +32,7 @@ describe("MemcachedIntegration", () => {
 	});
 
 	it("should perform basic KV operations", async () => {
-		const key = faker.string.alphanumeric(10);
+		const key = "basic_kv_" + faker.string.alphanumeric(10);
 		const value = faker.string.uuid();
 
 		await integration.set(key, value);
@@ -46,7 +46,7 @@ describe("MemcachedIntegration", () => {
 	});
 
 	it("should setex correctly", async () => {
-		const key = faker.string.alphanumeric(10);
+		const key = "setex_" + faker.string.alphanumeric(10);
 		const value = faker.string.uuid();
 
 		await integration.setex(key, 1, value);

--- a/packages/adapters/kv/redis.test.ts
+++ b/packages/adapters/kv/redis.test.ts
@@ -32,7 +32,7 @@ describe("RedisIntegration", () => {
 	});
 
 	it("should perform basic KV operations", async () => {
-		const key = faker.string.alphanumeric(10);
+		const key = "basic_kv_" + faker.string.alphanumeric(10);
 		const value = faker.string.uuid();
 
 		await integration.set(key, value);
@@ -46,7 +46,7 @@ describe("RedisIntegration", () => {
 	});
 
 	it("should setex correctly", async () => {
-		const key = faker.string.alphanumeric(10);
+		const key = "setex_" + faker.string.alphanumeric(10);
 		const value = faker.string.uuid();
 
 		await integration.setex(key, 1, value);

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -12,7 +12,7 @@
 		".": "./index.ts"
 	},
 	"scripts": {
-		"test": "bun test",
+		"test": "bun test --parallel",
 		"lint": "tsgo --noEmit"
 	},
 	"dependencies": {

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -12,7 +12,7 @@
 		".": "./index.ts"
 	},
 	"scripts": {
-		"test": "bun test --parallel",
+		"test": "bun test --parallel --timeout 600000",
 		"lint": "tsgo --noEmit"
 	},
 	"dependencies": {

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -18,7 +18,7 @@
 		"typescript": "^5.9.2"
 	},
 	"scripts": {
-		"test": "bun test",
+		"test": "bun test --parallel",
 		"lint": "tsgo --noEmit"
 	},
 	"dependencies": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -16,7 +16,7 @@
 		"typescript": "^6.0.3"
 	},
 	"scripts": {
-		"test": "bun test",
+		"test": "bun test --parallel",
 		"lint": "tsgo --noEmit"
 	},
 	"dependencies": {

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -9,7 +9,7 @@
 	"license": "MIT",
 	"description": "",
 	"scripts": {
-		"test": "bun test",
+		"test": "bun test --parallel",
 		"lint": "tsgo --noEmit"
 	},
 	"dependencies": {


### PR DESCRIPTION
## Description
Fixes race conditions in adapter integration tests when run with \un test --parallel\.

### Changes
- Replaced shared adapter instances with per-test instances to prevent state pollution.
- Replaced hardcoded \users\ tables/collections with dynamically generated unique names per test.
- Prefixed Redis/Memcached keys to guarantee isolation.
- Added \--parallel\ flag to \un test\ commands in \package.json\ files.