### PR TITLE
feat: Request Validation & Schema Editor (closes #65)

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -45,6 +45,28 @@ When creating branches or Pull Requests via the `gh` CLI:
 
 ---
 
+## Documentation Writing Rules
+
+The `/docs` directory contains **user-facing documentation** — not a technical or contributing guide. These rules apply whenever writing or updating any file inside `/docs`.
+
+### ❌ DO NOT
+
+- Expose internal implementation details (e.g. class names, file paths, library names, database schemas, Redis channels, trie structures, pub/sub signals, or architecture patterns like "adapter pattern").
+- Use jargon that only a backend engineer would know without explanation.
+- Reference source files or internal module names (e.g. `schemaParser.ts`, `HttpRouteParser`, `routesLoader`).
+- Describe *how* the system is built — only describe *what it does* and *what the user can expect*.
+- Write in a tone that assumes the reader is a senior developer.
+
+### ✅ ALWAYS
+
+- Write in plain, natural English that is understandable by **junior developers, non-technical users, and LLM agents** alike.
+- Explain **behavior** (what happens) not **mechanism** (how it works internally).
+- Use tables, callout blocks (`::: tip`, `::: info`), and clear headings to improve scanability.
+- Keep examples concrete and realistic — show inputs and outputs a user would actually see.
+- Ensure every page is self-contained enough that an AI agent reading it cold can understand what the feature does.
+
+---
+
 ## Codebase Discovery (codebase-memory-mcp)
 **CRITICAL:** This project uses `codebase-memory-mcp` to maintain a knowledge graph of the codebase. 
 You MUST ALWAYS use these MCP graph tools for code discovery instead of builtin tools like `grep_search`, `list_dir`, or running grep via terminal commands.

--- a/apps/server/src/api/v1/routes/create/dto.ts
+++ b/apps/server/src/api/v1/routes/create/dto.ts
@@ -1,5 +1,6 @@
 import z from "zod";
 import { ROUTE_REGEX } from "../constants";
+import { routeSchemaValidationRefinement } from "../schema-validator";
 
 export const requestBodySchema = z.object({
   name: z.string().min(2).max(255),
@@ -8,7 +9,10 @@ export const requestBodySchema = z.object({
   projectId: z.string().refine((v) => {
     return z.uuidv7().safeParse(v).success;
   }),
-});
+  bodySchema: z.any().optional(),
+  querySchema: z.any().optional(),
+  paramsSchema: z.any().optional(),
+}).superRefine(routeSchemaValidationRefinement);
 
 export const responseSchema = z.object({
   id: z.uuidv7(),

--- a/apps/server/src/api/v1/routes/get-by-id/dto.ts
+++ b/apps/server/src/api/v1/routes/get-by-id/dto.ts
@@ -1,18 +1,21 @@
 import z from "zod";
 
 export const requestRouteSchema = z.object({
-  id: z.uuidv7(),
+	id: z.uuidv7(),
 });
 
 export const responseSchema = z.object({
-  id: z.string(),
-  name: z.string().min(1).max(255),
-  path: z.string(),
-  active: z.boolean(),
-  method: z.string(),
-  projectId: z.string(),
-  createdAt: z.string(),
-  createdBy: z.string(),
-  updatedAt: z.string(),
-  projectName: z.string(),
+	id: z.string(),
+	name: z.string().min(1).max(255),
+	path: z.string(),
+	active: z.boolean(),
+	method: z.string(),
+	projectId: z.string(),
+	projectName: z.string(),
+	bodySchema: z.any().optional(),
+	querySchema: z.any().optional(),
+	paramsSchema: z.any().optional(),
+	createdAt: z.string(),
+	createdBy: z.string(),
+	updatedAt: z.string(),
 });

--- a/apps/server/src/api/v1/routes/get-by-id/repository.ts
+++ b/apps/server/src/api/v1/routes/get-by-id/repository.ts
@@ -3,22 +3,25 @@ import { db, DbTransactionType } from "../../../../db";
 import { projectsEntity, routesEntity } from "../../../../db/schema";
 
 export async function getRouteById(id: string, tx?: DbTransactionType) {
-  const route = await (tx ?? db)
-    .select({
-      id: routesEntity.id,
-      name: routesEntity.name,
-      path: routesEntity.path,
-      method: routesEntity.method,
-      active: routesEntity.active,
-      createdBy: routesEntity.createdBy,
-      projectId: routesEntity.projectId,
-      createdAt: routesEntity.createdAt,
-      updatedAt: routesEntity.updatedAt,
-      projectName: projectsEntity.name,
-    })
-    .from(routesEntity)
-    .leftJoin(projectsEntity, eq(routesEntity.projectId, projectsEntity.id))
-    .where(eq(routesEntity.id, id))
-    .limit(1);
-  return route.length > 0 ? route[0] : null;
+	const route = await (tx ?? db)
+		.select({
+			id: routesEntity.id,
+			name: routesEntity.name,
+			path: routesEntity.path,
+			method: routesEntity.method,
+			active: routesEntity.active,
+			createdBy: routesEntity.createdBy,
+			projectId: routesEntity.projectId,
+			createdAt: routesEntity.createdAt,
+			updatedAt: routesEntity.updatedAt,
+			projectName: projectsEntity.name,
+			bodySchema: routesEntity.bodySchema,
+			querySchema: routesEntity.querySchema,
+			paramsSchema: routesEntity.paramsSchema,
+		})
+		.from(routesEntity)
+		.leftJoin(projectsEntity, eq(routesEntity.projectId, projectsEntity.id))
+		.where(eq(routesEntity.id, id))
+		.limit(1);
+	return route.length > 0 ? route[0] : null;
 }

--- a/apps/server/src/api/v1/routes/get-by-id/service.ts
+++ b/apps/server/src/api/v1/routes/get-by-id/service.ts
@@ -6,29 +6,32 @@ import { AuthACL } from "../../../../db/schema";
 import { ForbiddenError } from "../../../../errors/forbidError";
 
 export default async function handleRequest(
-  id: string,
-  acl: AuthACL[] = []
+	id: string,
+	acl: AuthACL[] = [],
 ): Promise<z.infer<typeof responseSchema>> {
-  const route = await getRouteById(id);
-  if (!route) {
-    throw new NotFoundError("no route found with id: " + id);
-  }
-  const hasAccess = acl.some(
-    (a) => a.projectId === route.projectId || a.projectId === "*"
-  );
-  if (!hasAccess) {
-    throw new ForbiddenError();
-  }
-  return {
-    id: route.id,
-    name: route.name!,
-    path: route.path!,
-    active: route.active!,
-    projectId: route.projectId!,
-    method: route.method!,
-    createdBy: route.createdBy!,
-    createdAt: route.createdAt.toISOString(),
-    updatedAt: route.updatedAt.toISOString(),
-    projectName: route.projectName!,
-  };
+	const route = await getRouteById(id);
+	if (!route) {
+		throw new NotFoundError("no route found with id: " + id);
+	}
+	const hasAccess = acl.some(
+		(a) => a.projectId === route.projectId || a.projectId === "*",
+	);
+	if (!hasAccess) {
+		throw new ForbiddenError();
+	}
+	return {
+		id: route.id,
+		name: route.name!,
+		path: route.path!,
+		active: route.active!,
+		projectId: route.projectId!,
+		method: route.method!,
+		createdBy: route.createdBy!,
+		createdAt: route.createdAt.toISOString(),
+		updatedAt: route.updatedAt.toISOString(),
+		projectName: route.projectName!,
+		bodySchema: route.bodySchema,
+		querySchema: route.querySchema,
+		paramsSchema: route.paramsSchema,
+	};
 }

--- a/apps/server/src/api/v1/routes/schema-validator.ts
+++ b/apps/server/src/api/v1/routes/schema-validator.ts
@@ -1,0 +1,83 @@
+import { z } from "zod";
+import { ValidationSchemaZod } from "../../../lib/validationSchemaZod";
+
+/**
+ * Validates the route schemas including body, query, and params schemas.
+ * Also verifies that path parameters defined in the route path actually exist in the paramsSchema.
+ */
+export function validateRouteSchemas(data: {
+  path: string;
+  bodySchema?: any;
+  querySchema?: any;
+  paramsSchema?: any;
+}) {
+  const { path, bodySchema, querySchema, paramsSchema } = data;
+  const errors: { path: string; message: string }[] = [];
+
+  // Validate body schema structural correctness
+  if (bodySchema) {
+    const parsed = ValidationSchemaZod.safeParse(bodySchema);
+    if (!parsed.success) {
+      errors.push({ path: "bodySchema", message: "Invalid body schema format" });
+    }
+  }
+
+  // Validate query schema structural correctness
+  if (querySchema) {
+    const parsed = ValidationSchemaZod.safeParse(querySchema);
+    if (!parsed.success) {
+      errors.push({ path: "querySchema", message: "Invalid query schema format" });
+    }
+  }
+
+  // Validate params schema structural correctness
+  if (paramsSchema) {
+    const parsed = ValidationSchemaZod.safeParse(paramsSchema);
+    if (!parsed.success) {
+      errors.push({ path: "paramsSchema", message: "Invalid params schema format" });
+    } else {
+      // Extract path variables from route path (e.g. /users/:userId => ['userId'])
+      const pathParams = Array.from(path.matchAll(/:([a-zA-Z0-9_]+)/g)).map((match) => match[1]);
+      
+      const properties = paramsSchema.properties || [];
+      const schemaParamKeys = properties.map((p: any) => p.key);
+
+      for (const param of pathParams) {
+        if (!schemaParamKeys.includes(param)) {
+          errors.push({
+            path: "paramsSchema",
+            message: `Path parameter '${param}' is missing from paramsSchema`,
+          });
+        }
+      }
+      
+      for (const param of schemaParamKeys) {
+        if (!pathParams.includes(param)) {
+          errors.push({
+            path: "paramsSchema",
+            message: `paramsSchema contains parameter '${param}' which is not in the route path`,
+          });
+        }
+      }
+    }
+  }
+
+  return {
+    success: errors.length === 0,
+    errors,
+  };
+}
+
+// Reusable zod refinement for route schema validations
+export const routeSchemaValidationRefinement = (data: any, ctx: z.RefinementCtx) => {
+  const result = validateRouteSchemas(data);
+  if (!result.success) {
+    for (const error of result.errors) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: [error.path],
+        message: error.message,
+      });
+    }
+  }
+};

--- a/apps/server/src/api/v1/routes/tests/schema-validator.test.ts
+++ b/apps/server/src/api/v1/routes/tests/schema-validator.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe } from "bun:test";
-import { validateRouteSchemas } from "./schema-validator";
+import { validateRouteSchemas } from "../schema-validator";
 
 describe("validateRouteSchemas", () => {
   test("returns success for valid schemas without params", () => {

--- a/apps/server/src/api/v1/routes/tests/schema-validator.test.ts
+++ b/apps/server/src/api/v1/routes/tests/schema-validator.test.ts
@@ -1,0 +1,60 @@
+import { test, expect, describe } from "bun:test";
+import { validateRouteSchemas } from "./schema-validator";
+
+describe("validateRouteSchemas", () => {
+  test("returns success for valid schemas without params", () => {
+    const result = validateRouteSchemas({
+      path: "/api/users",
+      bodySchema: {
+        dataType: "object",
+        properties: [{ key: "name", dataType: "str" }]
+      }
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("validates that all path params exist in paramsSchema", () => {
+    const result = validateRouteSchemas({
+      path: "/api/users/:userId/posts/:postId",
+      paramsSchema: {
+        dataType: "object",
+        properties: [
+          { key: "userId", dataType: "str" },
+          { key: "postId", dataType: "str" }
+        ]
+      }
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("fails if path param is missing in paramsSchema", () => {
+    const result = validateRouteSchemas({
+      path: "/api/users/:userId/posts/:postId",
+      paramsSchema: {
+        dataType: "object",
+        properties: [
+          { key: "userId", dataType: "str" }
+        ]
+      }
+    });
+    expect(result.success).toBe(false);
+    expect(result.errors.length).toBe(1);
+    expect(result.errors[0].message).toContain("missing from paramsSchema");
+  });
+
+  test("fails if paramsSchema has extra params not in path", () => {
+    const result = validateRouteSchemas({
+      path: "/api/users/:userId",
+      paramsSchema: {
+        dataType: "object",
+        properties: [
+          { key: "userId", dataType: "str" },
+          { key: "extraParam", dataType: "str" }
+        ]
+      }
+    });
+    expect(result.success).toBe(false);
+    expect(result.errors.length).toBe(1);
+    expect(result.errors[0].message).toContain("not in the route path");
+  });
+});

--- a/apps/server/src/api/v1/routes/update-partial/service.ts
+++ b/apps/server/src/api/v1/routes/update-partial/service.ts
@@ -45,7 +45,7 @@ export default async function handleRequest(
         ...patchedRoute,
         id,
         updatedAt: new Date(),
-      },
+      } as any,
       tx
     );
   });

--- a/apps/server/src/api/v1/routes/update/dto.ts
+++ b/apps/server/src/api/v1/routes/update/dto.ts
@@ -1,23 +1,29 @@
 import { HttpMethod } from "../../../../db/schema";
 import { z } from "zod";
 import { ROUTE_REGEX } from "../constants";
+import { routeSchemaValidationRefinement } from "../schema-validator";
 
-export const requestBodySchema = z.object({
-  name: z.string().min(2).max(255),
-  path: z.string().min(1).regex(ROUTE_REGEX),
-  method: z.enum(HttpMethod, "Must be a HTTP Method"),
-  active: z.boolean(),
-});
+export const requestBodySchema = z
+	.object({
+		name: z.string().min(2).max(255),
+		path: z.string().min(1).regex(ROUTE_REGEX),
+		method: z.enum(HttpMethod, "Must be a HTTP Method"),
+		active: z.boolean(),
+		bodySchema: z.any().optional(),
+		querySchema: z.any().optional(),
+		paramsSchema: z.any().optional(),
+	})
+	.superRefine(routeSchemaValidationRefinement);
 
 export const requestRouteSchema = z.object({
-  id: z.uuidv7(),
+	id: z.uuidv7(),
 });
 
 export const responseSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  path: z.string(),
-  method: z.string(),
-  createdAt: z.string(),
-  updatedAt: z.string(),
+	id: z.string(),
+	name: z.string(),
+	path: z.string(),
+	method: z.string(),
+	createdAt: z.string(),
+	updatedAt: z.string(),
 });

--- a/apps/server/src/db/migrations/0025_awesome_darkhawk.sql
+++ b/apps/server/src/db/migrations/0025_awesome_darkhawk.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "routes" ADD COLUMN "body_schema" jsonb;--> statement-breakpoint
+ALTER TABLE "routes" ADD COLUMN "query_schema" jsonb;--> statement-breakpoint
+ALTER TABLE "routes" ADD COLUMN "params_schema" jsonb;

--- a/apps/server/src/db/migrations/meta/0025_snapshot.json
+++ b/apps/server/src/db/migrations/meta/0025_snapshot.json
@@ -1,0 +1,1582 @@
+{
+  "id": "3015e4d3-3c28-4f7b-b54e-42304a981252",
+  "prevId": "1df298a2-ad50-40c1-b157-378f8cecc3ba",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.access_control": {
+      "name": "access_control",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "access_control_roles",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_access_control_user_id": {
+          "name": "idx_access_control_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_access_control_project_id": {
+          "name": "idx_access_control_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "access_control_user_id_user_id_fk": {
+          "name": "access_control_user_id_user_id_fk",
+          "tableFrom": "access_control",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "access_control_project_id_projects_id_fk": {
+          "name": "access_control_project_id_projects_id_fk",
+          "tableFrom": "access_control",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_chat_conversations": {
+      "name": "ai_chat_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'New chat'"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ai_chat_conversation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'not_started'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_chat_conversations_user_id_user_id_fk": {
+          "name": "ai_chat_conversations_user_id_user_id_fk",
+          "tableFrom": "ai_chat_conversations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_chat_conversations_project_id_projects_id_fk": {
+          "name": "ai_chat_conversations_project_id_projects_id_fk",
+          "tableFrom": "ai_chat_conversations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_chat_history": {
+      "name": "ai_chat_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ai_chat_conversation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'running'"
+        },
+        "user_query": {
+          "name": "user_query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "final_output": {
+          "name": "final_output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_execution_history": {
+          "name": "workflow_execution_history",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_chat_history_conversation_id_ai_chat_conversations_id_fk": {
+          "name": "ai_chat_history_conversation_id_ai_chat_conversations_id_fk",
+          "tableFrom": "ai_chat_history",
+          "tableTo": "ai_chat_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_config": {
+      "name": "app_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key_name": {
+          "name": "key_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_encrypted": {
+          "name": "is_encrypted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "encoding_type": {
+          "name": "encoding_type",
+          "type": "encoding_types",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "app_config_data_types",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'string'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_app_config_key_name": {
+          "name": "idx_app_config_key_name",
+          "columns": [
+            {
+              "expression": "key_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_app_config_project_id": {
+          "name": "idx_app_config_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_app_config_is_encrypted": {
+          "name": "idx_app_config_is_encrypted",
+          "columns": [
+            {
+              "expression": "is_encrypted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_app_config_encoding_type": {
+          "name": "idx_app_config_encoding_type",
+          "columns": [
+            {
+              "expression": "encoding_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_config_project_id_projects_id_fk": {
+          "name": "app_config_project_id_projects_id_fk",
+          "tableFrom": "app_config",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocks": {
+      "name": "blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_id": {
+          "name": "route_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_blocks_route_id": {
+          "name": "idx_blocks_route_id",
+          "columns": [
+            {
+              "expression": "route_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blocks_route_id_routes_id_fk": {
+          "name": "blocks_route_id_routes_id_fk",
+          "tableFrom": "blocks",
+          "tableTo": "routes",
+          "columnsFrom": [
+            "route_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.edges": {
+      "name": "edges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "from": {
+          "name": "from",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to": {
+          "name": "to",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_handle": {
+          "name": "from_handle",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_handle": {
+          "name": "to_handle",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_id": {
+          "name": "route_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_edges_from": {
+          "name": "idx_edges_from",
+          "columns": [
+            {
+              "expression": "from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_edges_to": {
+          "name": "idx_edges_to",
+          "columns": [
+            {
+              "expression": "to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_edges_route_id": {
+          "name": "idx_edges_route_id",
+          "columns": [
+            {
+              "expression": "route_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "edges_from_blocks_id_fk": {
+          "name": "edges_from_blocks_id_fk",
+          "tableFrom": "edges",
+          "tableTo": "blocks",
+          "columnsFrom": [
+            "from"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edges_to_blocks_id_fk": {
+          "name": "edges_to_blocks_id_fk",
+          "tableFrom": "edges",
+          "tableTo": "blocks",
+          "columnsFrom": [
+            "to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edges_route_id_routes_id_fk": {
+          "name": "edges_route_id_routes_id_fk",
+          "tableFrom": "edges",
+          "tableTo": "routes",
+          "columnsFrom": [
+            "route_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integrations": {
+      "name": "integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group": {
+          "name": "group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_integrations_name": {
+          "name": "idx_integrations_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integrations_group": {
+          "name": "idx_integrations_group",
+          "columns": [
+            {
+              "expression": "group",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integrations_variant": {
+          "name": "idx_integrations_variant",
+          "columns": [
+            {
+              "expression": "variant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integrations_tags": {
+          "name": "idx_integrations_tags",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integrations_project_id": {
+          "name": "idx_integrations_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integrations_project_id_projects_id_fk": {
+          "name": "integrations_project_id_projects_id_fk",
+          "tableFrom": "integrations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_settings": {
+      "name": "project_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_project_settings_project_id": {
+          "name": "idx_project_settings_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_settings_key": {
+          "name": "idx_project_settings_key",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_settings_project_id_projects_id_fk": {
+          "name": "project_settings_project_id_projects_id_fk",
+          "tableFrom": "project_settings",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_projects_id": {
+          "name": "idx_projects_id",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_projects_name": {
+          "name": "idx_projects_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_projects_updated_at": {
+          "name": "idx_projects_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.routes": {
+      "name": "routes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "NULL"
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_schema": {
+          "name": "body_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query_schema": {
+          "name": "query_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "params_schema": {
+          "name": "params_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_routes_project_id": {
+          "name": "idx_routes_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_routes_path": {
+          "name": "idx_routes_path",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "routes_project_id_projects_id_fk": {
+          "name": "routes_project_id_projects_id_fk",
+          "tableFrom": "routes",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_suites": {
+      "name": "test_suites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_id": {
+          "name": "route_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "query_params": {
+          "name": "query_params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "route_params": {
+          "name": "route_params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "body": {
+          "name": "body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assertions": {
+          "name": "assertions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_suites_route_id_routes_id_fk": {
+          "name": "test_suites_route_id_routes_id_fk",
+          "tableFrom": "test_suites",
+          "tableTo": "routes",
+          "columnsFrom": [
+            "route_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system_admin": {
+          "name": "is_system_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.access_control_roles": {
+      "name": "access_control_roles",
+      "schema": "public",
+      "values": [
+        "viewer",
+        "creator",
+        "project_admin",
+        "system_admin"
+      ]
+    },
+    "public.ai_chat_conversation_status": {
+      "name": "ai_chat_conversation_status",
+      "schema": "public",
+      "values": [
+        "not_started",
+        "running",
+        "completed"
+      ]
+    },
+    "public.app_config_data_types": {
+      "name": "app_config_data_types",
+      "schema": "public",
+      "values": [
+        "string",
+        "number",
+        "boolean"
+      ]
+    },
+    "public.encoding_types": {
+      "name": "encoding_types",
+      "schema": "public",
+      "values": [
+        "plaintext",
+        "base64",
+        "hex"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/server/src/db/migrations/meta/_journal.json
+++ b/apps/server/src/db/migrations/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1783300282745,
       "tag": "0024_zippy_chameleon",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1783380122288,
+      "tag": "0025_awesome_darkhawk",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/db/schema.ts
+++ b/apps/server/src/db/schema.ts
@@ -149,6 +149,9 @@ export const routesEntity = pgTable(
 			})
 			.default(sql`NULL`),
 		method: varchar({ length: 8 }),
+		bodySchema: jsonb("body_schema"),
+		querySchema: jsonb("query_schema"),
+		paramsSchema: jsonb("params_schema"),
 		createdAt: timestamp("created_at").defaultNow().notNull(),
 		createdBy: varchar("created_by", { length: 50 }),
 		updatedAt: timestamp("updated_at")

--- a/apps/server/src/lib/schemaParser.ts
+++ b/apps/server/src/lib/schemaParser.ts
@@ -1,0 +1,151 @@
+import { z } from 'zod';
+import { ValidationSchemaZod } from './validationSchemaZod';
+import { JsVM } from '@fluxify/lib';
+
+export class ValidationError extends Error {
+  payload: any;
+  constructor(payload: any) {
+    super('Validation failed');
+    this.name = 'ValidationError';
+    this.payload = payload;
+  }
+}
+
+type ParserContext = {
+  vm: JsVM;
+  coerce?: boolean;
+};
+
+// Map primitive types to base Zod schemas
+function getBaseZodType(dataType: string, coerce = false): z.ZodTypeAny {
+  switch (dataType) {
+    case 'str': return coerce ? z.coerce.string() : z.string();
+    case 'int': return (coerce ? z.coerce.number() : z.number()).int();
+    case 'float': return coerce ? z.coerce.number() : z.number();
+    case 'bool': return coerce ? z.coerce.boolean() : z.boolean();
+    case 'object': return z.object({});
+    case 'arr': return z.array(z.any());
+    default: return z.any();
+  }
+}
+
+// Apply validation rules to a Zod schema
+function applyRules(schema: z.ZodTypeAny, dataType: string, rules: any[] = []): z.ZodTypeAny {
+  let s = schema as any;
+  for (const rule of rules) {
+    if (dataType === 'str') {
+      if (rule.type === 'minLength' && rule.value != null) s = s.min(Number(rule.value));
+      if (rule.type === 'maxLength' && rule.value != null) s = s.max(Number(rule.value));
+      if (rule.type === 'regex' && rule.value) s = s.regex(new RegExp(rule.value));
+      if (rule.type === 'startsWith' && rule.value) s = s.startsWith(rule.value);
+      if (rule.type === 'endsWith' && rule.value) s = s.endsWith(rule.value);
+      if (rule.type === 'contains' && rule.value) s = s.includes(rule.value);
+      if (rule.type === 'notContains' && rule.value) {
+         s = s.refine((val: string) => !val.includes(rule.value), { message: `Must not contain ${rule.value}` });
+      }
+    }
+    
+    if (dataType === 'int' || dataType === 'float') {
+      if (rule.type === 'min' && rule.value != null) s = s.min(Number(rule.value));
+      if (rule.type === 'max' && rule.value != null) s = s.max(Number(rule.value));
+    }
+    
+    if (dataType === 'arr') {
+      if (rule.type === 'minItems' && rule.value != null) s = s.min(Number(rule.value));
+      if (rule.type === 'maxItems' && rule.value != null) s = s.max(Number(rule.value));
+    }
+  }
+  return s;
+}
+
+export function buildZodSchema(schemaDef: any, context: ParserContext): z.ZodTypeAny {
+  const { dataType, properties, items, rules, js, required } = schemaDef;
+
+  let zSchema: z.ZodTypeAny;
+
+  if (dataType === 'js') {
+    zSchema = z.any().superRefine(async (val, ctx) => {
+      if (!js) return;
+      try {
+        const result = await context.vm.runAsync(js, val);
+        if (!result) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Custom JS validation failed' });
+        }
+      } catch (err: any) {
+        if (err?.name === 'ValidationError' || err?.constructor?.name === 'ValidationError') {
+          const payload = err.payload || err;
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: JSON.stringify(payload) });
+        } else {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: err?.message || 'Error executing JS validation' });
+        }
+      }
+    });
+  } else if (dataType === 'enum') {
+    const enumRule = rules?.find((r: any) => r.type === 'values');
+    const vals = enumRule?.value && Array.isArray(enumRule.value) ? enumRule.value : [];
+    if (vals.length > 0) {
+      if (vals.every((v: any) => typeof v === 'string')) {
+        zSchema = z.enum(vals as [string, ...string[]]);
+      } else {
+        zSchema = z.union(vals.map((v: any) => z.literal(v)) as any);
+      }
+    } else {
+      zSchema = z.any(); // fallback if no enum values defined
+    }
+  } else {
+    zSchema = getBaseZodType(dataType, context.coerce);
+
+    if (dataType === 'object' && properties) {
+      const shape: Record<string, z.ZodTypeAny> = {};
+      for (const prop of properties) {
+        shape[prop.key] = buildZodSchema(prop, context);
+      }
+      zSchema = z.object(shape);
+    } else if (dataType === 'arr' && items) {
+      zSchema = z.array(buildZodSchema(items, context));
+    }
+    
+    zSchema = applyRules(zSchema, dataType, rules);
+  }
+
+  if (required === false) {
+    zSchema = zSchema.optional();
+  }
+
+  return zSchema;
+}
+
+export const parseRequestSchema = async (schemaJson: any, requestData: any, context: ParserContext) => {
+  // Validate schema JSON itself against DB Zod schema
+  const parsedDef = ValidationSchemaZod.safeParse(schemaJson);
+  if (!parsedDef.success) {
+    return { 
+      success: false, 
+      errors: [{ path: 'schema', property: 'schema', errors: ['Invalid schema definition format'] }] 
+    };
+  }
+
+  const executableSchema = buildZodSchema(parsedDef.data, context);
+  const result = await executableSchema.safeParseAsync(requestData);
+
+  if (result.success) {
+    return { success: true };
+  } else {
+    const formattedErrors = result.error.issues.map(issue => {
+      let customErrorObj = null;
+      try { 
+        customErrorObj = JSON.parse(issue.message); 
+      } catch (e) {
+        // Not a JSON string (standard zod error message)
+      }
+
+      return {
+        path: issue.path.join('.'),
+        property: issue.path[issue.path.length - 1]?.toString() || '',
+        errors: customErrorObj ? [customErrorObj] : [issue.message]
+      };
+    });
+    
+    return { success: false, errors: formattedErrors };
+  }
+};

--- a/apps/server/src/lib/tests/schemaParser.test.ts
+++ b/apps/server/src/lib/tests/schemaParser.test.ts
@@ -1,0 +1,204 @@
+import { test, expect, describe } from 'bun:test';
+import { parseRequestSchema } from '../schemaParser';
+import { JsVM } from '@fluxify/lib';
+
+describe('schemaParser Exhaustive Test Suite', () => {
+  const context = { vm: new JsVM({}) };
+
+  describe('Primitive Types and Boundary Rules', () => {
+    test('String validations (length, regex, startsWith, endsWith, contains, notContains)', async () => {
+      const schema = {
+        dataType: 'str',
+        rules: [
+          { type: 'minLength', value: 3 },
+          { type: 'maxLength', value: 50 },
+          { type: 'regex', value: '^[a-zA-Z\\s]+$' },
+          { type: 'startsWith', value: 'hello' },
+          { type: 'endsWith', value: 'world' },
+          { type: 'contains', value: 'beautiful' },
+          { type: 'notContains', value: 'ugly' }
+        ]
+      };
+
+      expect((await parseRequestSchema(schema, 'hello beautiful world', context)).success).toBe(true);
+      expect((await parseRequestSchema(schema, 'hello world', context)).success).toBe(false); // missing 'beautiful'
+      expect((await parseRequestSchema(schema, 'hello beautiful ugly world', context)).success).toBe(false); // contains 'ugly'
+      expect((await parseRequestSchema(schema, 'hi beautiful world', context)).success).toBe(false); // bad startsWith
+      expect((await parseRequestSchema(schema, 'hello beautiful planet', context)).success).toBe(false); // bad endsWith
+      expect((await parseRequestSchema(schema, 'he', context)).success).toBe(false); // minLength
+      expect((await parseRequestSchema(schema, 'hello beautiful world forever', context)).success).toBe(false); // maxLength
+      expect((await parseRequestSchema(schema, 'hello b3autiful world', context)).success).toBe(false); // regex failure
+    });
+
+    test('Integer and Float validations (min, max)', async () => {
+      const schemaInt = {
+        dataType: 'int',
+        rules: [ { type: 'min', value: -10 }, { type: 'max', value: 100 } ]
+      };
+
+      expect((await parseRequestSchema(schemaInt, 50, context)).success).toBe(true);
+      expect((await parseRequestSchema(schemaInt, -10, context)).success).toBe(true);
+      expect((await parseRequestSchema(schemaInt, -11, context)).success).toBe(false);
+      expect((await parseRequestSchema(schemaInt, 101, context)).success).toBe(false);
+      expect((await parseRequestSchema(schemaInt, 50.5, context)).success).toBe(false); // float fails int schema
+
+      const schemaFloat = {
+        dataType: 'float',
+        rules: [ { type: 'min', value: 0 }, { type: 'max', value: 9.99 } ]
+      };
+      
+      expect((await parseRequestSchema(schemaFloat, 5.5, context)).success).toBe(true);
+      expect((await parseRequestSchema(schemaFloat, 9.99, context)).success).toBe(true);
+      expect((await parseRequestSchema(schemaFloat, 10, context)).success).toBe(false);
+    });
+
+    test('Boolean validation', async () => {
+      const schema = { dataType: 'bool' };
+      expect((await parseRequestSchema(schema, true, context)).success).toBe(true);
+      expect((await parseRequestSchema(schema, false, context)).success).toBe(true);
+      expect((await parseRequestSchema(schema, 'true', context)).success).toBe(false); // strict typing
+    });
+
+    test('Enum validation (strings and numbers)', async () => {
+      const schemaStrEnum = {
+        dataType: 'enum',
+        rules: [ { type: 'values', value: ['admin', 'user', 'guest'] } ]
+      };
+
+      expect((await parseRequestSchema(schemaStrEnum, 'user', context)).success).toBe(true);
+      expect((await parseRequestSchema(schemaStrEnum, 'superadmin', context)).success).toBe(false);
+
+      const schemaNumEnum = {
+        dataType: 'enum',
+        rules: [ { type: 'values', value: [1, 2, 3] } ]
+      };
+
+      expect((await parseRequestSchema(schemaNumEnum, 2, context)).success).toBe(true);
+      expect((await parseRequestSchema(schemaNumEnum, 4, context)).success).toBe(false);
+    });
+  });
+
+  describe('Complex Structural Types (Objects and Arrays)', () => {
+    test('Nested Arrays with max/min items and item typing', async () => {
+      const schema = {
+        dataType: 'arr',
+        rules: [ { type: 'minItems', value: 1 }, { type: 'maxItems', value: 3 } ],
+        items: { key: '', dataType: 'int', rules: [{ type: 'min', value: 5 }] }
+      };
+
+      expect((await parseRequestSchema(schema, [5, 10], context)).success).toBe(true);
+      expect((await parseRequestSchema(schema, [], context)).success).toBe(false); // minItems
+      expect((await parseRequestSchema(schema, [5, 10, 15, 20], context)).success).toBe(false); // maxItems
+      expect((await parseRequestSchema(schema, [5, '10'], context)).success).toBe(false); // wrong item type
+      expect((await parseRequestSchema(schema, [4], context)).success).toBe(false); // item below min rule
+    });
+
+    test('Deeply nested objects and arrays combined', async () => {
+      const schema = {
+        dataType: 'object',
+        properties: [
+          { key: 'id', dataType: 'int', required: true },
+          { key: 'tags', dataType: 'arr', required: false, items: { key: '', dataType: 'str', rules: [{ type: 'minLength', value: 2 }] } },
+          { 
+            key: 'metadata', 
+            dataType: 'object', 
+            required: true,
+            properties: [
+              { key: 'createdAt', dataType: 'str', required: true },
+              { key: 'flags', dataType: 'arr', required: true, items: { key: '', dataType: 'bool' } }
+            ]
+          }
+        ]
+      };
+
+      const validPayload = {
+        id: 123,
+        tags: ['js', 'ts'],
+        metadata: {
+          createdAt: '2023-01-01',
+          flags: [true, false, true]
+        }
+      };
+
+      expect((await parseRequestSchema(schema, validPayload, context)).success).toBe(true);
+
+      const invalidPayload1 = { ...validPayload, tags: ['a'] }; // tag too short
+      expect((await parseRequestSchema(schema, invalidPayload1, context)).success).toBe(false);
+
+      const invalidPayload2 = { ...validPayload, metadata: { createdAt: '2023-01-01' } }; // missing flags array
+      expect((await parseRequestSchema(schema, invalidPayload2, context)).success).toBe(false);
+    });
+  });
+
+  describe('Custom JavaScript Validations in VM', () => {
+    test('Returns boolean pass/fail', async () => {
+      const schema = {
+        dataType: 'js',
+        js: 'return input && input.startsWith("token_");'
+      };
+
+      expect((await parseRequestSchema(schema, 'token_123', context)).success).toBe(true);
+      
+      const failResult = await parseRequestSchema(schema, 'bad_token', context);
+      expect(failResult.success).toBe(false);
+      expect(failResult.errors?.[0]?.errors?.[0]).toBe('Custom JS validation failed');
+    });
+
+    test('Intercepts thrown standard Error', async () => {
+      const schema = {
+        dataType: 'js',
+        js: 'if (input < 18) throw new Error("Must be 18 or older"); return true;'
+      };
+      
+      const result = await parseRequestSchema(schema, 16, context);
+      expect(result.success).toBe(false);
+      expect(result.errors?.[0]?.errors?.[0]).toBe('Must be 18 or older');
+    });
+
+    test('Intercepts custom ValidationError and extracts payload', async () => {
+      const schema = {
+        dataType: 'js',
+        js: `
+          if (input.email !== "admin@test.com") {
+            throw { 
+              name: "ValidationError", 
+              payload: { code: "UNAUTHORIZED", message: "Invalid admin email" } 
+            };
+          }
+          return true;
+        `
+      };
+
+      const result = await parseRequestSchema(schema, { email: 'hacker@test.com' }, context);
+      expect(result.success).toBe(false);
+      
+      const customPayload = result.errors?.[0]?.errors?.[0];
+      expect(customPayload).toEqual({ code: 'UNAUTHORIZED', message: 'Invalid admin email' });
+    });
+
+    test('Handles syntax errors gracefully', async () => {
+      const schema = {
+        dataType: 'js',
+        js: 'this is not valid javascript syntax;'
+      };
+
+      const result = await parseRequestSchema(schema, 'test', context);
+      expect(result.success).toBe(false);
+      // It should capture the JS execution error gracefully instead of crashing the server
+      expect(result.errors?.[0]?.errors?.[0]).toContain('Unexpected identifier'); 
+    });
+  });
+
+  describe('DB Zod Schema Protection', () => {
+    test('Rejects malformed JSON definitions entirely before execution', async () => {
+      const malformedSchema = {
+        dataType: 'imaginary_type',
+        properties: 'should be an array'
+      };
+
+      const result = await parseRequestSchema(malformedSchema, {}, context);
+      expect(result.success).toBe(false);
+      expect(result.errors?.[0]?.errors?.[0]).toBe('Invalid schema definition format');
+    });
+  });
+});

--- a/apps/server/src/lib/validationSchemaZod.ts
+++ b/apps/server/src/lib/validationSchemaZod.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod';
+
+export const DataTypeZod = z.enum([
+  'str', 'int', 'float', 'bool', 'object', 'arr', 'js', 'enum'
+]);
+
+export const ChainTypeZod = z.enum(['or', 'and']);
+
+export const RuleZod = z.object({
+  type: z.string(),
+  value: z.any().optional(),
+  message: z.string().optional(),
+}).catchall(z.any());
+
+// Need base schema to define recursive types
+const baseSchemaProperty = z.object({
+  id: z.string().optional(),
+  key: z.string(),
+  dataType: DataTypeZod,
+  rules: z.array(RuleZod).optional(),
+  required: z.boolean().optional(),
+  js: z.string().optional(),
+});
+
+type SchemaPropertyType = z.infer<typeof baseSchemaProperty> & {
+  properties?: SchemaPropertyType[];
+  items?: SchemaPropertyType;
+  chain?: {
+    chainType: z.infer<typeof ChainTypeZod>;
+    properties?: SchemaPropertyType[];
+  }[];
+};
+
+export const SchemaPropertyZod: z.ZodType<SchemaPropertyType> = baseSchemaProperty.extend({
+  properties: z.lazy(() => z.array(SchemaPropertyZod)).optional(),
+  items: z.lazy(() => SchemaPropertyZod).optional(),
+  chain: z.lazy(() => z.array(SchemaChainZod)).optional(),
+});
+
+export const SchemaChainZod = z.object({
+  chainType: ChainTypeZod,
+  properties: z.array(SchemaPropertyZod).optional(),
+});
+
+export const ValidationSchemaZod = z.object({
+  dataType: DataTypeZod,
+  properties: z.array(SchemaPropertyZod).optional(),
+  items: z.lazy(() => SchemaPropertyZod).optional(),
+  chain: z.array(SchemaChainZod).optional(),
+  rules: z.array(RuleZod).optional(),
+  js: z.string().optional(),
+});

--- a/apps/server/src/loaders/routesLoader.ts
+++ b/apps/server/src/loaders/routesLoader.ts
@@ -39,6 +39,9 @@ async function fetchRoutes() {
 			routeId: routesEntity.id,
 			projectId: routesEntity.projectId,
 			projectName: projectsEntity.name,
+			bodySchema: routesEntity.bodySchema,
+			querySchema: routesEntity.querySchema,
+			paramsSchema: routesEntity.paramsSchema,
 		})
 		.from(routesEntity)
 		.leftJoin(projectsEntity, eq(routesEntity.projectId, projectsEntity.id))

--- a/apps/server/src/modules/requestRouter/service.ts
+++ b/apps/server/src/modules/requestRouter/service.ts
@@ -21,6 +21,7 @@ import { ContentfulStatusCode } from "hono/utils/http-status";
 import { JsVM } from "@fluxify/lib";
 import { startBlocksExecution } from "../../loaders/blocksLoader";
 import { getAppConfig } from "../../loaders/appconfigLoader";
+import { parseRequestSchema } from "../../lib/schemaParser";
 import { createObservabilityLogger, DbFactory } from "@fluxify/adapters";
 import {
 	dbIntegrationsCache,
@@ -64,6 +65,37 @@ export async function handleRequest(
 		path.routeParams,
 	);
 	const vm = createJsVM(vars);
+
+	if (path.bodySchema && Object.keys(path.bodySchema).length > 0) {
+		const result = await parseRequestSchema(path.bodySchema, requestBody, { vm });
+		if (!result.success) {
+			return {
+				status: 400,
+				data: { message: "Body validation failed", errors: result.errors },
+			};
+		}
+	}
+	
+	if (path.querySchema && Object.keys(path.querySchema).length > 0) {
+		const result = await parseRequestSchema(path.querySchema, ctx.req.query(), { vm, coerce: true });
+		if (!result.success) {
+			return {
+				status: 400,
+				data: { message: "Query validation failed", errors: result.errors },
+			};
+		}
+	}
+	
+	if (path.paramsSchema && Object.keys(path.paramsSchema).length > 0) {
+		const result = await parseRequestSchema(path.paramsSchema, path.routeParams || {}, { vm, coerce: true });
+		if (!result.success) {
+			return {
+				status: 400,
+				data: { message: "Path parameters validation failed", errors: result.errors },
+			};
+		}
+	}
+
 	const dbFactory = createDbFactory(vm);
 	const context = createContext(
 		path,

--- a/apps/web/src/app/[projectId]/create-route/page.tsx
+++ b/apps/web/src/app/[projectId]/create-route/page.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import React, { useState } from "react";
+import { Box, Title, Container } from "@mantine/core";
+import { RouteFormStepper, RouteFormValues } from "@/components/forms/RouteFormStepper";
+import { routesService } from "@/services/routes";
+import { useRouter, useParams } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
+import { routesQueries } from "@/query/routerQuery";
+import { notifications } from "@mantine/notifications";
+import { useLayoutStore } from "@/store/layout";
+
+export default function CreateRoutePage() {
+  const router = useRouter();
+  const params = useParams();
+  const projectId = params.projectId?.toString() || "";
+  const [loading, setLoading] = useState(false);
+  const { invalidate: useInvalidate } = routesQueries.getAll;
+  const client = useQueryClient();
+  const { setSidebarOpened } = useLayoutStore();
+
+  const handleSubmit = async (values: RouteFormValues) => {
+    try {
+      setLoading(true);
+      await routesService.create({
+        name: values.name,
+        path: values.path,
+        method: values.method as any,
+        projectId,
+        bodySchema: values.bodySchema,
+        querySchema: values.querySchema,
+        paramsSchema: values.paramsSchema,
+      });
+      notifications.show({
+        title: "Success",
+        message: "Route created successfully",
+        color: "green",
+      });
+      useInvalidate(client);
+      setSidebarOpened(true);
+      router.push(`/${projectId}/routes`); // Redirect to routes list (or wherever is appropriate)
+    } catch (error: any) {
+      notifications.show({
+        title: "Error creating route",
+        message: error?.response?.data?.message || error.message || "Unknown error",
+        color: "red",
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Container size="xl" py="xl">
+      <Box mb="xl">
+        <Title order={2}>Create New Route</Title>
+      </Box>
+      <RouteFormStepper
+        onSubmit={handleSubmit}
+        loading={loading}
+        onCancel={() => {
+          setSidebarOpened(true);
+          router.back();
+        }}
+      />
+    </Container>
+  );
+}

--- a/apps/web/src/app/[projectId]/layout.tsx
+++ b/apps/web/src/app/[projectId]/layout.tsx
@@ -9,8 +9,10 @@ import {
 	NavLink,
 	ActionIcon,
 	Text,
+	Burger,
 } from "@mantine/core";
 import { usePathname, useRouter, useParams } from "next/navigation";
+import { useDisclosure } from "@mantine/hooks";
 import {
 	TbArrowLeft,
 	TbSparkles,
@@ -19,6 +21,8 @@ import {
 	TbCloudCog,
 	TbSquareKey,
 	TbSettings,
+	TbLayoutSidebarLeftCollapse,
+	TbLayoutSidebarLeftExpand,
 } from "react-icons/tb";
 import { APP_ROUTES } from "@/constants/routes";
 import { AuthProvider } from "@/components/auth/authProvider";
@@ -27,6 +31,7 @@ import ProfileNav from "@/components/homepage/ProfileNav";
 import { useAuthStore } from "@/store/auth";
 import type { AccessControlRole } from "@fluxify/server";
 import RequireRole from "@/components/auth/requireRole";
+import { useLayoutStore } from "@/store/layout";
 
 const NewProjectLayout = ({ children }: { children: React.ReactNode }) => {
 	const router = useRouter();
@@ -34,6 +39,7 @@ const NewProjectLayout = ({ children }: { children: React.ReactNode }) => {
 	const { projectId } = useParams();
 	const { acl } = useAuthStore();
 	const id = projectId as string;
+	const { sidebarOpened, toggleSidebar } = useLayoutStore();
 
 	const { data: projectsData } = projectsQuery.getAll.useQuery({
 		page: 1,
@@ -78,13 +84,25 @@ const NewProjectLayout = ({ children }: { children: React.ReactNode }) => {
 	return (
 		<AppShell
 			header={{ height: 60 }}
-			navbar={{ width: 250, breakpoint: "sm" }}
+			navbar={{ 
+				width: 250, 
+				breakpoint: "sm",
+				collapsed: { mobile: !sidebarOpened, desktop: !sidebarOpened }
+			}}
 			padding="0"
 		>
 			<AuthProvider>
 				<AppShell.Header>
 					<Group h="100%" px="md" justify="space-between">
 						<Group gap="lg">
+							<ActionIcon 
+								variant="subtle" 
+								color="dark" 
+								size="lg" 
+								onClick={toggleSidebar} 
+							>
+								{sidebarOpened ? <TbLayoutSidebarLeftCollapse size={24} /> : <TbLayoutSidebarLeftExpand size={24} />}
+							</ActionIcon>
 							<Image
 								src="/_/admin/ui/logo_title.webp"
 								alt="Fluxify Logo"

--- a/apps/web/src/app/[projectId]/routes/page.tsx
+++ b/apps/web/src/app/[projectId]/routes/page.tsx
@@ -4,6 +4,7 @@ import { Stack, Text, Group } from "@mantine/core";
 import RoutesPanel from "@/components/panels/routesPanel";
 import RouterFilter from "@/components/filters/routerFilter";
 import RouterPagination from "@/components/filters/routerPagination";
+import CreateNewMenu from "@/components/createNewMenu";
 import { useParams } from "next/navigation";
 
 const ProjectRoutesPage = () => {
@@ -13,6 +14,7 @@ const ProjectRoutesPage = () => {
 		<Stack style={{ height: "100%" }} p="md" gap="md">
 			<Group justify="end" align="center">
 				<Group>
+					<CreateNewMenu />
 					<RouterPagination />
 					<RouterFilter />
 				</Group>

--- a/apps/web/src/app/editor/[id]/settings/page.tsx
+++ b/apps/web/src/app/editor/[id]/settings/page.tsx
@@ -1,5 +1,5 @@
 "use server";
-import BackToEditorButton from "@/components/editor/backToEditorButton";
+import EditRouteSettings from "@/components/forms/EditRouteSettings";
 import { authClient } from "@/lib/auth";
 import { canAccess } from "@fluxify/server/src/lib/acl";
 import { Stack } from "@mantine/core";
@@ -22,8 +22,8 @@ const Page = async ({ params }: { params: Promise<{ id: string }> }) => {
     redirect("/");
   }
   return (
-    <Stack p={"xs"}>
-      <BackToEditorButton routeId={routeId} />
+    <Stack p={"xs"} h="100%">
+      <EditRouteSettings routeId={routeId} />
     </Stack>
   );
 };

--- a/apps/web/src/app/test-schema/page.tsx
+++ b/apps/web/src/app/test-schema/page.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import React, { useRef, useState } from 'react';
+import { SchemaEditor } from '../../components/editors/schemaEditor/SchemaEditor';
+import { SchemaEditorRef, ValidationSchema } from '../../types/schemaEditor';
+import { Button, Container, Title, Box, Text } from '@mantine/core';
+
+export default function TestSchemaPage() {
+  const editorRef = useRef<SchemaEditorRef>(null);
+  const [savedData, setSavedData] = useState<ValidationSchema | null>(null);
+
+  const handleSave = (data: ValidationSchema) => {
+    setSavedData(data);
+  };
+
+  const triggerSave = () => {
+    if (editorRef.current) {
+      editorRef.current.save();
+    }
+  };
+
+  return (
+    <Container size="lg" py="xl">
+      <Title order={2} mb="md">Schema Editor Test</Title>
+      
+      <SchemaEditor 
+        ref={editorRef} 
+        onSave={handleSave} 
+      />
+
+      <Box mt="xl">
+        <Button onClick={triggerSave}>Trigger Save from Parent</Button>
+      </Box>
+
+      {savedData && (
+        <Box mt="md" p="md" style={{ backgroundColor: '#f8f9fa', borderRadius: '8px' }}>
+          <Text fw={500}>Saved JSON Output:</Text>
+          <pre>{JSON.stringify(savedData, null, 2)}</pre>
+        </Box>
+      )}
+    </Container>
+  );
+}

--- a/apps/web/src/components/createNewMenu.tsx
+++ b/apps/web/src/components/createNewMenu.tsx
@@ -1,21 +1,21 @@
 "use client";
 
 import { Button, Group } from "@mantine/core";
-import { useDisclosure } from "@mantine/hooks";
-import React, { useState } from "react";
-import FormDialog from "./dialog/formDialog";
-import RouteForm from "./forms/routeForm";
-import { routesService } from "@/services/routes";
-import { routesQueries } from "@/query/routerQuery";
-import { useQueryClient } from "@tanstack/react-query";
+import React from "react";
+import { useParams, useRouter } from "next/navigation";
+import { useLayoutStore } from "@/store/layout";
 
 const CreateNewMenu = () => {
-  const [opened, { open, close }] = useDisclosure(false);
-  const [selectedItem, setSelectedItem] = useState("");
+  const router = useRouter();
+  const params = useParams();
+  const projectId = params.projectId?.toString();
+  const { setSidebarOpened } = useLayoutStore();
 
   function onMenuItemClicked(label: string) {
-    setSelectedItem(label);
-    open();
+    if (label === "Route") {
+      setSidebarOpened(false);
+      router.push(`/${projectId}/create-route`);
+    }
   }
 
   return (
@@ -23,55 +23,8 @@ const CreateNewMenu = () => {
       <Button onClick={() => onMenuItemClicked("Route")} color="violet">
         Create Route
       </Button>
-      <FormDialog
-        title={`Create new ${selectedItem}`}
-        open={opened}
-        onClose={close}
-      >
-        {selectedItem === "Route" && <CreateRouteForm close={close} />}
-      </FormDialog>
     </Button.Group>
   );
 };
-
-export function CreateRouteForm({ close }: { close?: () => void }) {
-  const [loading, setLoading] = useState(false);
-  const { invalidate: useInvalidate } = routesQueries.getAll;
-  const client = useQueryClient();
-
-  async function onSubmit(values: any) {
-    try {
-      await routesService.create(values);
-      close?.();
-      useInvalidate(client);
-    } catch (error) {
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  return (
-    <RouteForm
-      onSubmit={onSubmit}
-      zodSchema={routesService.createRequestSchema}
-      newForm
-      actionSection={
-        <Group gap={4} mt={"sm"} w={"fit-content"} ml={"auto"}>
-          <Button
-            loading={loading}
-            type="submit"
-            variant="outline"
-            color="violet"
-          >
-            Submit
-          </Button>
-          <Button variant="subtle" color="dark">
-            Cancel
-          </Button>
-        </Group>
-      }
-    />
-  );
-}
 
 export default CreateNewMenu;

--- a/apps/web/src/components/dialog/jsEditorDialog.tsx
+++ b/apps/web/src/components/dialog/jsEditorDialog.tsx
@@ -9,6 +9,7 @@ type PropTypes = {
   value?: string;
   readonly?: boolean;
   title?: string;
+  description?: React.ReactNode;
 };
 
 const JsEditorDialog = (props: PropTypes) => {
@@ -21,6 +22,7 @@ const JsEditorDialog = (props: PropTypes) => {
       opened={props.opened}
       onKeyDown={(e) => e.stopPropagation()}
     >
+      {props.description}
       <JsEditor
         defaultValue={js}
         readonly={props.readonly}

--- a/apps/web/src/components/editor/activeToggle.tsx
+++ b/apps/web/src/components/editor/activeToggle.tsx
@@ -44,7 +44,8 @@ const ActiveToggle = (props: Props) => {
         });
       setActive((p) => !p);
       await routesService.updatePartial(props.routeId, { active: !active });
-      invalidate(client, loaderId!.toString());
+      routesQueries.getById.invalidate(client, props.routeId);
+      routesQueries.getAll.invalidate(client);
       props.showToggleNotifications &&
         notifications.update({
           id: loaderId,

--- a/apps/web/src/components/editor/panels/testing/Playground.tsx
+++ b/apps/web/src/components/editor/panels/testing/Playground.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo } from "react";
-import { Box, Button, Loader, Stack, Text } from "@mantine/core";
+import { Box, Button, Loader, Stack, Text, Tooltip } from "@mantine/core";
 import { TbPlayerPlayFilled } from "react-icons/tb";
 import axios from "axios";
 import { useQuery } from "@tanstack/react-query";
@@ -9,29 +9,82 @@ import ResponseSection from "./components/ResponseSection";
 import z from "zod";
 import { responseSchema as getByIdResponseSchema } from "@fluxify/server/src/api/v1/routes/get-by-id/dto";
 import { showNotification } from "@mantine/notifications";
+import { ValidationSchema, SchemaProperty } from "@/types/schemaEditor";
+
+function generateSampleData(prop: ValidationSchema | SchemaProperty): unknown {
+	if (!prop) return null;
+	if (prop.dataType === 'str') return "string";
+	if (prop.dataType === 'int') return 0;
+	if (prop.dataType === 'float') return 0.0;
+	if (prop.dataType === 'bool') return false;
+	if (prop.dataType === 'enum') {
+		const enumRule = prop.rules?.find((r: any) => r.type === 'enum');
+		if (enumRule && Array.isArray(enumRule.value) && enumRule.value.length > 0) {
+			return enumRule.value[0];
+		}
+		return "enum_value";
+	}
+	if (prop.dataType === 'arr') {
+		const p = prop as SchemaProperty;
+		if (p.items) return [generateSampleData(p.items)];
+		return [];
+	}
+	if (prop.dataType === 'object') {
+		const obj: Record<string, unknown> = {};
+		if (prop.properties) {
+			prop.properties.forEach((p: SchemaProperty) => {
+				if (p.key) {
+					obj[p.key] = generateSampleData(p);
+				}
+			});
+		}
+		return obj;
+	}
+	return null;
+}
 
 const Playground = ({
 	route,
 }: {
 	route: z.infer<typeof getByIdResponseSchema>;
 }) => {
-	const [pathParams, setPathParams] = useState<Record<string, string>>({});
-	const [queryParams, setQueryParams] = useState<Record<string, string>>({});
-	const [headers, setHeaders] = useState<Record<string, string>>({
-		"Content-Type": "application/json",
-	});
-	const [body, setBody] = useState<string>("{\n  \n}");
-
-	useEffect(() => {
+	const [pathParams, setPathParams] = useState<Record<string, string>>(() => {
 		const params = route.path.match(/:[a-zA-Z0-9_]+/g);
+		const initial: Record<string, string> = {};
 		if (params) {
-			const initial: Record<string, string> = {};
 			params.forEach((p: string) => {
 				initial[p.substring(1)] = "";
 			});
-			setPathParams(initial);
 		}
-	}, [route.path]);
+		return initial;
+	});
+	const [queryParams, setQueryParams] = useState<Record<string, string>>(() => {
+		const initialQuery: Record<string, string> = {};
+		const querySchema = route.querySchema as ValidationSchema | undefined;
+		if (querySchema?.properties) {
+			querySchema.properties.forEach((p: SchemaProperty) => {
+				if (p.key) {
+					initialQuery[p.key] = "";
+				}
+			});
+		}
+		return initialQuery;
+	});
+	const [headers, setHeaders] = useState<Record<string, string>>({
+		"Content-Type": "application/json",
+	});
+	const [body, setBody] = useState<string>(() => {
+		const bodySchema = route.bodySchema as ValidationSchema | undefined;
+		if (bodySchema) {
+			const sampleData = generateSampleData(bodySchema);
+			if (sampleData && typeof sampleData === 'object' && Object.keys(sampleData).length > 0) {
+				return JSON.stringify(sampleData, null, 2);
+			} else if (Array.isArray(sampleData) && sampleData.length > 0) {
+				return JSON.stringify(sampleData, null, 2);
+			}
+		}
+		return "{\n  \n}";
+	});
 
 	const resolvedUrl = useMemo(() => {
 		let finalPath = route.path;
@@ -159,26 +212,30 @@ const Playground = ({
 					method={route.method}
 					path={route.path}
 					rightSection={
-						<Button
-							color="violet.6"
-							size="md"
-							px="xl"
-							leftSection={
-								loading ? (
-									<Loader size="xs" color="white" />
-								) : (
-									<TbPlayerPlayFilled size={16} />
-								)
-							}
-							onClick={handleSend}
-							disabled={loading}
-							style={{ fontWeight: 700 }}
-							variant="filled"
-							radius={"sm"}
-							h={44}
-						>
-							Send
-						</Button>
+						<Tooltip label="Route is disabled" disabled={route.active}>
+							<Box style={{ display: 'inline-block' }}>
+								<Button
+									color="violet.6"
+									size="md"
+									px="xl"
+									leftSection={
+										loading ? (
+											<Loader size="xs" color="white" />
+										) : (
+											<TbPlayerPlayFilled size={16} />
+										)
+									}
+									onClick={handleSend}
+									disabled={loading || !route.active}
+									style={{ fontWeight: 700 }}
+									variant="filled"
+									radius={"sm"}
+									h={44}
+								>
+									Send
+								</Button>
+							</Box>
+						</Tooltip>
 					}
 				/>
 				<Box mt="xs" px={4}>
@@ -211,6 +268,7 @@ const Playground = ({
 						onPathParamsChange={setPathParams}
 						queryParams={queryParams}
 						onQueryParamsChange={setQueryParams}
+						querySchema={route.querySchema as ValidationSchema | undefined}
 						headers={headers}
 						onHeadersChange={setHeaders}
 						body={body}

--- a/apps/web/src/components/editor/panels/testing/components/RequestConfig.tsx
+++ b/apps/web/src/components/editor/panels/testing/components/RequestConfig.tsx
@@ -4,12 +4,15 @@ import KVPEditor from "@/components/editors/kvpEditor";
 import Editor from "@monaco-editor/react";
 import PathVariablesEditor from "./PathVariablesEditor";
 
+import { ValidationSchema } from "@/types/schemaEditor";
+
 interface RequestConfigProps {
   method: string;
   pathParams: Record<string, string>;
   onPathParamsChange: (data: Record<string, string>) => void;
   queryParams: Record<string, string>;
   onQueryParamsChange: (data: Record<string, string>) => void;
+  querySchema?: ValidationSchema;
   headers: Record<string, string>;
   onHeadersChange: (data: Record<string, string>) => void;
   body: string;
@@ -22,6 +25,7 @@ const RequestConfig = ({
   onPathParamsChange,
   queryParams,
   onQueryParamsChange,
+  querySchema,
   headers,
   onHeadersChange,
   body,
@@ -52,6 +56,7 @@ const RequestConfig = ({
                 onDataChange={onQueryParamsChange}
                 addButtonText="Add Query Parameter"
                 inputType="text"
+                schemaProperties={querySchema?.properties}
               />
             </Box>
           </Tabs.Panel>

--- a/apps/web/src/components/editors/kvpEditor.tsx
+++ b/apps/web/src/components/editors/kvpEditor.tsx
@@ -1,7 +1,8 @@
-import { ActionIcon, Button, Grid, Stack, TextInput } from "@mantine/core";
-import React, { useState } from "react";
+import { ActionIcon, Button, Grid, Stack, TextInput, Select, NumberInput } from "@mantine/core";
+import React, { useState, useEffect } from "react";
 import { TbTrashFilled } from "react-icons/tb";
 import JsTextInput from "./jsTextInput";
+import { SchemaProperty } from "@/types/schemaEditor";
 
 type InputType = "text" | "js text";
 
@@ -13,6 +14,7 @@ type PropTypes = {
   inputType?: InputType;
   allowDuplicateKeys?: boolean;
   addButtonText?: string;
+  schemaProperties?: SchemaProperty[];
 };
 
 const KVPEditor = ({
@@ -22,10 +24,18 @@ const KVPEditor = ({
   valuePlaceholder = "Value",
   inputType = "text",
   addButtonText = "Add New Key-Value Pair",
+  schemaProperties,
 }: PropTypes) => {
-  const [tempData, setTempData] = useState<[string, string][]>(
-    Object.entries(data)
-  );
+  const [tempData, setTempData] = useState<[string, string][]>(() => Object.entries(data));
+
+  // Sync when data changes structurally (e.g., initialized asynchronously)
+  useEffect(() => {
+    // Only update if lengths differ to avoid overwriting typed uncommitted changes, 
+    // or if the component just mounted with new keys. This is a basic sync.
+    if (Object.keys(data).length !== tempData.length && Object.keys(data).length > 0) {
+      setTempData(Object.entries(data));
+    }
+  }, [data]);
 
   const handleKeyValueChange = (key: string, value: string, index: number) => {
     const newData = [...tempData];
@@ -66,6 +76,50 @@ const KVPEditor = ({
     );
   };
 
+  const renderValueInput = (
+    key: string,
+    value: string,
+    onChange: (value: string) => void,
+    placeholder: string
+  ) => {
+    const propDef = schemaProperties?.find((p) => p.key === key);
+    if (propDef) {
+      if (propDef.dataType === "bool") {
+        return (
+          <Select
+            data={["true", "false"]}
+            value={value || "false"}
+            onChange={(v) => onChange(v || "false")}
+            placeholder={placeholder}
+          />
+        );
+      }
+      if (propDef.dataType === "int" || propDef.dataType === "float") {
+        return (
+          <NumberInput
+            value={value ? Number(value) : ""}
+            onChange={(v) => onChange(v === "" ? "" : String(v))}
+            placeholder={placeholder}
+          />
+        );
+      }
+      if (propDef.dataType === "enum") {
+        const enumRule = propDef.rules?.find((r) => r.type === "enum");
+        if (enumRule && Array.isArray(enumRule.value)) {
+          return (
+            <Select
+              data={enumRule.value.map(String)}
+              value={value}
+              onChange={(v) => onChange(v || "")}
+              placeholder={placeholder}
+            />
+          );
+        }
+      }
+    }
+    return renderInput(value, onChange, placeholder);
+  };
+
   return (
     <Stack>
       {tempData.map(([key, value], index) => (
@@ -78,7 +132,8 @@ const KVPEditor = ({
             )}
           </Grid.Col>
           <Grid.Col span={6}>
-            {renderInput(
+            {renderValueInput(
+              key,
               value,
               (newValue) => handleKeyValueChange(key, newValue, index),
               valuePlaceholder

--- a/apps/web/src/components/editors/schemaEditor/ConfigurationDrawer.tsx
+++ b/apps/web/src/components/editors/schemaEditor/ConfigurationDrawer.tsx
@@ -1,0 +1,64 @@
+import React, { useMemo } from 'react';
+import { useSchemaEditorStore } from './store';
+import { Drawer, Title, Box } from '@mantine/core';
+import StringRuleEditor from './rules/StringRuleEditor';
+import NumberRuleEditor from './rules/NumberRuleEditor';
+import ArrayRuleEditor from './rules/ArrayRuleEditor';
+import EnumRuleEditor from './rules/EnumRuleEditor';
+import JSRuleEditor from './rules/JSRuleEditor';
+
+const ConfigurationDrawer = () => {
+  const drawerOpen = useSchemaEditorStore(state => state.drawerOpen);
+  const closeDrawer = useSchemaEditorStore(state => state.closeDrawer);
+  const activePropertyPath = useSchemaEditorStore(state => state.activePropertyPath);
+  const schema = useSchemaEditorStore(state => state.schema);
+  const updateProperty = useSchemaEditorStore(state => state.updateProperty);
+
+  const activeProperty = useMemo(() => {
+    if (!activePropertyPath) return null;
+    let current: any = schema;
+    for (const idx of activePropertyPath) {
+      if (current.properties) {
+        current = current.properties[idx];
+      } else {
+        return null;
+      }
+    }
+    return current;
+  }, [schema, activePropertyPath]);
+
+  const handleUpdate = (updates: any) => {
+    if (activePropertyPath) {
+      updateProperty(activePropertyPath, updates);
+    }
+  };
+
+  const renderEditor = () => {
+    if (!activeProperty) return null;
+    switch (activeProperty.dataType) {
+      case 'str': return <StringRuleEditor property={activeProperty} onUpdate={handleUpdate} />;
+      case 'int': 
+      case 'float': return <NumberRuleEditor property={activeProperty} onUpdate={handleUpdate} />;
+      case 'arr': return <ArrayRuleEditor property={activeProperty} onUpdate={handleUpdate} />;
+      case 'enum': return <EnumRuleEditor property={activeProperty} onUpdate={handleUpdate} />;
+      case 'js': return <JSRuleEditor property={activeProperty} onUpdate={handleUpdate} />;
+      default: return <Box p="md">No specific configuration available for this type.</Box>;
+    }
+  };
+
+  return (
+    <Drawer
+      opened={drawerOpen}
+      onClose={closeDrawer}
+      position="right"
+      size="50%"
+      title={<Title order={4}>Configure {activeProperty?.key ? `"${activeProperty.key}"` : 'Field'}</Title>}
+    >
+      <Box p="md">
+        {renderEditor()}
+      </Box>
+    </Drawer>
+  );
+};
+
+export default ConfigurationDrawer;

--- a/apps/web/src/components/editors/schemaEditor/PropertyRow.tsx
+++ b/apps/web/src/components/editors/schemaEditor/PropertyRow.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { SchemaProperty, DataType } from '../../../types/schemaEditor';
+import { useSchemaEditorStore } from './store';
+import { Grid, TextInput, Select, Checkbox, ActionIcon, Box, Alert } from '@mantine/core';
+import { TbSettings, TbTrash } from 'react-icons/tb';
+import { TbInfoCircle } from 'react-icons/tb';
+import { IoLogoJavascript } from "react-icons/io5";
+import { useDisclosure } from '@mantine/hooks';
+import JsEditorDialog from '../../dialog/jsEditorDialog';
+
+interface PropertyRowProps {
+  property: SchemaProperty;
+  index: number;
+  onUpdate: (updates: Partial<SchemaProperty>) => void;
+  onRemove: () => void;
+  onConfigure: () => void;
+  pathStr: string;
+}
+
+const DATA_TYPES = [
+  { value: 'str', label: 'String' },
+  { value: 'int', label: 'Integer' },
+  { value: 'float', label: 'Float' },
+  { value: 'bool', label: 'Boolean' },
+  { value: 'arr', label: 'Array' },
+  { value: 'object', label: 'Object' },
+  { value: 'enum', label: 'Enum' },
+  { value: 'js', label: 'Use JavaScript' },
+];
+
+const PropertyRow = ({ property, index, onUpdate, onRemove, onConfigure, pathStr }: PropertyRowProps) => {
+  const [jsDialogOpened, { open: openJsDialog, close: closeJsDialog }] = useDisclosure(false);
+
+  const locked = useSchemaEditorStore(state => state.locked);
+  const typeOverrides = useSchemaEditorStore(state => state.typeOverrides);
+
+  const overrideAllowedTypes = typeOverrides?.[pathStr];
+  const isDataTypeLocked = locked && !overrideAllowedTypes;
+  
+  const allowedDataTypesOptions = overrideAllowedTypes 
+    ? DATA_TYPES.filter(d => overrideAllowedTypes.includes(d.value as DataType))
+    : DATA_TYPES;
+
+  const handleJsSave = (val: string) => {
+    onUpdate({ js: val });
+    closeJsDialog();
+  };
+
+  const jsCode = property.js || 'return true;';
+
+  return (
+    <>
+      <Grid align="center" mt="sm">
+        <Grid.Col span={4}>
+          <TextInput
+            placeholder="Property Key"
+            value={property.key}
+            onChange={(e) => onUpdate({ key: e.currentTarget.value })}
+            readOnly={locked}
+            variant={locked ? 'filled' : 'default'}
+          />
+        </Grid.Col>
+        <Grid.Col span={4}>
+          <Select
+            allowDeselect={false}
+            data={allowedDataTypesOptions}
+            value={property.dataType}
+            onChange={(val) => onUpdate({ dataType: val as DataType })}
+            readOnly={isDataTypeLocked}
+            variant={isDataTypeLocked ? 'filled' : 'default'}
+          />
+        </Grid.Col>
+        <Grid.Col span={2}>
+          <Checkbox
+            label="Required"
+            color="violet"
+            checked={property.required}
+            onChange={(e) => onUpdate({ required: e.currentTarget.checked })}
+            readOnly={locked}
+            style={locked ? { pointerEvents: 'none', opacity: 0.6 } : undefined}
+          />
+        </Grid.Col>
+        <Grid.Col span={2} style={{ display: 'flex', gap: '8px' }}>
+          {property.dataType === 'js' ? (
+            <ActionIcon variant="light" color="violet" onClick={openJsDialog}>
+              <IoLogoJavascript size={20} />
+            </ActionIcon>
+          ) : property.dataType !== 'bool' ? (
+            <ActionIcon variant="light" color="violet" onClick={onConfigure}>
+              <TbSettings size={18} />
+            </ActionIcon>
+          ) : (
+            <Box w={28} /> // Placeholder to keep layout consistent
+          )}
+          {!locked && (
+            <ActionIcon variant="light" color="red" onClick={onRemove}>
+              <TbTrash size={18} />
+            </ActionIcon>
+          )}
+        </Grid.Col>
+      </Grid>
+      
+      {property.dataType === 'js' && (
+        <JsEditorDialog
+          opened={jsDialogOpened}
+          onClose={closeJsDialog}
+          value={jsCode}
+          onSave={handleJsSave}
+          title={`Configure Custom JS for "${property.key || 'Field'}"`}
+          description={
+            <Alert icon={<TbInfoCircle size={16} />} color="violet" variant="light" mb="md">
+              Write custom JavaScript to validate this property. Return a boolean to indicate pass/fail.
+              To return a custom error response, use: <code>throw new ValidationError({`{ "your": "custom error object" }`})</code>.
+            </Alert>
+          }
+        />
+      )}
+    </>
+  );
+};
+
+export default PropertyRow;

--- a/apps/web/src/components/editors/schemaEditor/SchemaEditor.tsx
+++ b/apps/web/src/components/editors/schemaEditor/SchemaEditor.tsx
@@ -1,0 +1,117 @@
+import React, { forwardRef, useImperativeHandle, useRef } from 'react';
+import { SchemaEditorContext, createSchemaStore, useSchemaEditorStore } from './store';
+import { ValidationSchema, SchemaEditorRef, DataType } from '../../../types/schemaEditor';
+import { Box, Paper, Tabs, Alert } from '@mantine/core';
+import SchemaSlide from './SchemaSlide';
+import ConfigurationDrawer from './ConfigurationDrawer';
+import { TbLayoutDashboard, TbInfoCircle, TbEye } from 'react-icons/tb';
+import { IoLogoJavascript } from 'react-icons/io5';
+import JsEditor from '../jsEditor';
+import { SchemaPreview } from './SchemaPreview';
+
+interface SchemaEditorProps {
+  initialData?: ValidationSchema;
+  onSave?: (data: ValidationSchema) => void;
+  locked?: boolean;
+  typeOverrides?: Record<string, DataType[]>;
+  allowedRootSchemaTypes?: DataType[];
+}
+
+const SchemaEditorContent = forwardRef<SchemaEditorRef, SchemaEditorProps>(({ onSave }, ref) => {
+  const schema = useSchemaEditorStore(state => state.schema);
+  const setSchema = useSchemaEditorStore(state => state.setSchema);
+
+  useImperativeHandle(ref, () => ({
+    save: () => {
+      onSave?.(schema);
+    }
+  }));
+
+  const isRootJs = schema.dataType === 'js';
+  const rootJsCode = schema.js || 'return true;';
+
+  const [activeTab, setActiveTab] = React.useState<string | null>(isRootJs ? 'js' : 'ui');
+
+  const handleTabChange = (val: string | null) => {
+    setActiveTab(val);
+    if (val === 'js') {
+      setSchema({ 
+        ...schema, 
+        dataType: 'js', 
+        js: schema.js || 'return true;' 
+      });
+    } else if (val === 'ui') {
+      if (schema.dataType === 'js') {
+        setSchema({ 
+          ...schema, 
+          dataType: 'object' 
+        });
+      }
+    }
+  };
+
+  const handleRootJsChange = (val: string) => {
+    setSchema({
+      ...schema,
+      js: val
+    });
+  };
+
+  return (
+    <Box style={{ position: 'relative' }}>
+      <Tabs value={activeTab} onChange={handleTabChange} color="violet">
+        <Tabs.List>
+          <Tabs.Tab value="ui" leftSection={<TbLayoutDashboard size={16} />}>Schema Editor</Tabs.Tab>
+          <Tabs.Tab value="js" leftSection={<IoLogoJavascript size={16} />}>Custom JS</Tabs.Tab>
+          {!isRootJs && <Tabs.Tab value="preview" leftSection={<TbEye size={16} />}>Preview</Tabs.Tab>}
+        </Tabs.List>
+        
+        <Tabs.Panel value="ui" pt="md">
+          <Paper withBorder p="md" radius="md">
+            <SchemaSlide />
+          </Paper>
+          <ConfigurationDrawer />
+        </Tabs.Panel>
+        
+        <Tabs.Panel value="js" pt="md">
+          <Paper withBorder p="md" radius="md">
+            <Alert icon={<TbInfoCircle size={16} />} color="violet" variant="light" mb="md">
+              Write custom JavaScript to validate the entire request. Return a boolean to indicate pass/fail. 
+              To return a custom error response, use: <code>throw new ValidationError({`{ "your": "custom error object" }`})</code>.
+            </Alert>
+            <Box style={{ border: '1px solid var(--mantine-color-gray-3)', borderRadius: 4, overflow: 'hidden' }}>
+              <JsEditor
+                value={rootJsCode}
+                onChange={handleRootJsChange}
+                height={400}
+              />
+            </Box>
+          </Paper>
+        </Tabs.Panel>
+
+        {!isRootJs && (
+          <Tabs.Panel value="preview" pt="md">
+            <Paper withBorder p="md" radius="md">
+              <SchemaPreview schema={schema} />
+            </Paper>
+          </Tabs.Panel>
+        )}
+      </Tabs>
+    </Box>
+  );
+});
+
+SchemaEditorContent.displayName = 'SchemaEditorContent';
+
+export const SchemaEditor = forwardRef<SchemaEditorRef, SchemaEditorProps>(({ initialData, locked, typeOverrides, allowedRootSchemaTypes, ...props }, ref) => {
+  const storeRef = useRef(createSchemaStore(initialData, locked, typeOverrides, allowedRootSchemaTypes));
+
+  return (
+    <SchemaEditorContext.Provider value={storeRef.current}>
+      <SchemaEditorContent ref={ref} {...props} />
+    </SchemaEditorContext.Provider>
+  );
+});
+
+SchemaEditor.displayName = 'SchemaEditor';
+export default SchemaEditor;

--- a/apps/web/src/components/editors/schemaEditor/SchemaPreview.tsx
+++ b/apps/web/src/components/editors/schemaEditor/SchemaPreview.tsx
@@ -1,0 +1,80 @@
+import React, { useState } from 'react';
+import { SchemaProperty, ValidationSchema, Rule } from '../../../types/schemaEditor';
+import { Box, Collapse, Group, Text, ActionIcon } from '@mantine/core';
+import { TbChevronRight, TbChevronDown } from 'react-icons/tb';
+
+const renderRules = (rules?: Rule[]) => {
+  if (!rules || rules.length === 0) return null;
+  const parts = rules.filter(r => r.type !== 'jsCode').map(r => `${r.type}: ${r.value}`);
+  if (parts.length === 0) return null;
+  return ` (${parts.join(', ')})`;
+};
+
+const PreviewNode = ({ property }: { property: SchemaProperty }) => {
+  const [opened, setOpened] = useState(true);
+  const isObject = property.dataType === 'object' && (property.properties?.length ?? 0) > 0;
+  const isArray = property.dataType === 'arr' && property.items;
+  
+  const hasChildren = isObject || isArray;
+
+  return (
+    <Box ml="md" mt={4}>
+      <Group gap="xs" wrap="nowrap" align="flex-start">
+        {hasChildren ? (
+          <ActionIcon 
+            size="xs" 
+            variant="transparent" 
+            color="gray"
+            onClick={() => setOpened(!opened)}
+            style={{ marginTop: 2 }}
+          >
+            {opened ? <TbChevronDown size={14} /> : <TbChevronRight size={14} />}
+          </ActionIcon>
+        ) : (
+          <Box w={16} />
+        )}
+        <Box>
+          <Text size="sm" style={{ display: 'inline', fontFamily: 'monospace' }}>
+            <Text span fw={600} c="violet">{property.key || '<unnamed>'}</Text>
+            <Text span c="dimmed" ml="xs">
+              : {property.dataType} 
+              {property.required ? <Text span c="red"> *</Text> : ''}
+              {renderRules(property.rules)}
+            </Text>
+          </Text>
+          
+          {hasChildren && (
+            <Collapse in={opened}>
+              <Box style={{ borderLeft: '1px solid var(--mantine-color-gray-3)' }}>
+                {isObject && property.properties?.map((child, idx) => (
+                  <PreviewNode key={child.id || child.key || idx} property={child} />
+                ))}
+                {isArray && property.items && (
+                  <PreviewNode property={{ ...property.items, key: '[Item]' } as SchemaProperty} />
+                )}
+              </Box>
+            </Collapse>
+          )}
+        </Box>
+      </Group>
+    </Box>
+  );
+};
+
+export const SchemaPreview = ({ schema }: { schema: ValidationSchema }) => {
+  if (schema.dataType === 'js') return null;
+
+  return (
+    <Box>
+      {schema.properties?.length === 0 ? (
+        <Text size="sm" c="dimmed" fs="italic">No properties defined.</Text>
+      ) : (
+        <Box style={{ border: '1px solid var(--mantine-color-gray-3)', borderRadius: 4, padding: '12px 0' }}>
+          {schema.properties?.map((prop, idx) => (
+            <PreviewNode key={prop.id || prop.key || idx} property={prop} />
+          ))}
+        </Box>
+      )}
+    </Box>
+  );
+};

--- a/apps/web/src/components/editors/schemaEditor/SchemaSlide.tsx
+++ b/apps/web/src/components/editors/schemaEditor/SchemaSlide.tsx
@@ -1,0 +1,243 @@
+import React, { useMemo } from 'react';
+import { useSchemaEditorStore } from './store';
+import { Box, Button, Stack, Text, Breadcrumbs, Anchor, Alert, Group, NumberInput, Select, ActionIcon, Divider, Accordion } from '@mantine/core';
+import PropertyRow from './PropertyRow';
+import { TbPlus, TbInfoCircle, TbSettings } from 'react-icons/tb';
+import { getRuleValue, updateRule } from './rules/ruleHelpers';
+import { DataType } from '../../../types/schemaEditor';
+
+const DATA_TYPES = [
+  { value: 'str', label: 'String' },
+  { value: 'int', label: 'Integer' },
+  { value: 'float', label: 'Float' },
+  { value: 'bool', label: 'Boolean' },
+  { value: 'arr', label: 'Array' },
+  { value: 'object', label: 'Object' },
+  { value: 'enum', label: 'Enum' },
+  { value: 'js', label: 'Write JavaScript' },
+];
+
+const SchemaSlide = () => {
+  const schema = useSchemaEditorStore(state => state.schema);
+  const locked = useSchemaEditorStore(state => state.locked);
+  const allowedRootSchemaTypes = useSchemaEditorStore(state => state.allowedRootSchemaTypes);
+  const setSchema = useSchemaEditorStore(state => state.setSchema);
+  const path = useSchemaEditorStore(state => state.path);
+  const addProperty = useSchemaEditorStore(state => state.addProperty);
+  const removeProperty = useSchemaEditorStore(state => state.removeProperty);
+  const updateProperty = useSchemaEditorStore(state => state.updateProperty);
+  const openDrawer = useSchemaEditorStore(state => state.openDrawer);
+  const pushPath = useSchemaEditorStore(state => state.pushPath);
+  const goToPath = useSchemaEditorStore(state => state.goToPath);
+
+  const { currentTarget, currentProperties, breadcrumbItems } = useMemo(() => {
+    let current: any = schema;
+    const items = [{ title: 'Main Schema', level: 0 }];
+    
+    for (let i = 0; i < path.length; i++) {
+      const segment = path[i];
+      if (segment === 'items') {
+        items.push({ 
+          title: 'Array Items [ ]',
+          level: i + 1 
+        });
+        current = current.items || { dataType: 'str' };
+      } else {
+        if (current.properties && current.properties[segment]) {
+          items.push({ 
+            title: current.properties[segment].key || `Property ${segment}`,
+            level: i + 1 
+          });
+          current = current.properties[segment];
+        }
+      }
+    }
+    
+    return {
+      currentTarget: current,
+      currentProperties: current?.properties || [],
+      breadcrumbItems: items
+    };
+  }, [schema, path]);
+
+  const currentPathStr = useMemo(() => {
+    let str = '';
+    let curr: any = schema;
+    for (let i = 0; i < path.length; i++) {
+      const seg = path[i];
+      if (seg === 'items') {
+        str += str ? '[]' : '[]';
+        curr = curr.items || { dataType: 'str' };
+      } else {
+        const key = curr.properties[seg]?.key || '';
+        str += str ? `.${key}` : key;
+        curr = curr.properties[seg];
+      }
+    }
+    return str;
+  }, [schema, path]);
+
+  const handleConfigureProperty = (index: number) => {
+    const prop = currentProperties[index];
+    if (prop.dataType === 'object' || prop.dataType === 'arr') {
+      pushPath(index);
+    } else {
+      openDrawer([...path, index]);
+    }
+  };
+
+  const renderArrayConfig = () => {
+    const itemsSchema = currentTarget.items || { dataType: 'str' };
+
+    const handleConfigureItems = () => {
+      if (itemsSchema.dataType === 'object' || itemsSchema.dataType === 'arr') {
+        pushPath('items');
+      } else {
+        openDrawer([...path, 'items']);
+      }
+    };
+
+    return (
+      <Stack gap="md" mt="md">
+        <Group grow>
+          <NumberInput
+            label="Minimum Items"
+            placeholder="e.g. 1"
+            min={0}
+            value={getRuleValue(currentTarget.rules, 'minItems', '')}
+            onChange={(val) => updateProperty(path, { rules: updateRule(currentTarget.rules, 'minItems', val) })}
+          />
+          <NumberInput
+            label="Maximum Items"
+            placeholder="e.g. 10"
+            min={0}
+            value={getRuleValue(currentTarget.rules, 'maxItems', '')}
+            onChange={(val) => updateProperty(path, { rules: updateRule(currentTarget.rules, 'maxItems', val) })}
+          />
+        </Group>
+
+        <Divider my="sm" />
+        
+        <Text size="sm" fw={500}>Array Items Data Type</Text>
+        <Group align="center">
+          <Select
+            allowDeselect={false}
+            data={DATA_TYPES}
+            value={itemsSchema.dataType}
+            onChange={(val) => updateProperty([...path, 'items'], { dataType: val as DataType })}
+            style={{ flex: 1 }}
+            readOnly={locked}
+          />
+          <ActionIcon size="lg" variant="light" color="violet" onClick={handleConfigureItems}>
+            <TbSettings size={20} />
+          </ActionIcon>
+        </Group>
+      </Stack>
+    );
+  };
+
+  return (
+    <Box>
+      <Group mb="md">
+        <Breadcrumbs separator="→">
+          {breadcrumbItems.map((item, index) => (
+            <Anchor 
+              key={index} 
+              onClick={() => goToPath(item.level)}
+              c={index === breadcrumbItems.length - 1 ? 'dimmed' : 'violet'}
+              style={{ cursor: index === breadcrumbItems.length - 1 ? 'default' : 'pointer' }}
+            >
+              {item.title}
+            </Anchor>
+          ))}
+        </Breadcrumbs>
+      </Group>
+
+      {!locked && path.length === 0 && (!allowedRootSchemaTypes || allowedRootSchemaTypes.length > 1) && (
+        <Group mb="md" align="center">
+          <Text fw={500} size="sm">Root Schema Type:</Text>
+          <Select
+            allowDeselect={false}
+            data={DATA_TYPES.filter(d => d.value !== 'js' && (!allowedRootSchemaTypes || allowedRootSchemaTypes.includes(d.value as DataType)))}
+            value={schema.dataType}
+            onChange={(val) => setSchema({ ...schema, dataType: val as DataType })}
+            style={{ width: 150 }}
+          />
+        </Group>
+      )}
+
+      {currentTarget.dataType === 'arr' ? (
+        renderArrayConfig()
+      ) : currentTarget.dataType === 'object' ? (
+        <>
+          {!locked && (
+            <Accordion variant="separated" mb="md" styles={{ item: { border: '1px solid var(--mantine-color-violet-light-border)', backgroundColor: 'var(--mantine-color-violet-light)' }, control: { padding: '12px' } }}>
+              <Accordion.Item value="info">
+                <Accordion.Control icon={<TbInfoCircle size={16} color="var(--mantine-color-violet-filled)" />}>
+                  <Text size="sm" fw={500} c="violet">Recursive Schema Info</Text>
+                </Accordion.Control>
+                <Accordion.Panel>
+                  <Text size="sm" c="violet.9">
+                    If you need to build recursive schemas, please select the "Write JavaScript" data type for that property and provide custom validation logic. The UI editor currently doesn't natively support cyclic references.
+                  </Text>
+                </Accordion.Panel>
+              </Accordion.Item>
+            </Accordion>
+          )}
+
+          <Stack gap="xs">
+            {currentProperties.length === 0 && (
+              <Text c="dimmed" size="sm" fs="italic">No properties added yet.</Text>
+            )}
+            {currentProperties.map((prop: any, index: number) => {
+              const propPathStr = currentPathStr ? `${currentPathStr}.${prop.key}` : prop.key;
+              return (
+                <PropertyRow
+                  key={prop.id || index}
+                  index={index}
+                  property={prop}
+                  pathStr={propPathStr}
+                  onUpdate={(updates) => updateProperty([...path, index], updates)}
+                  onRemove={() => removeProperty([...path, index])}
+                  onConfigure={() => handleConfigureProperty(index)}
+                />
+              );
+            })}
+          </Stack>
+
+          {!locked && (
+            <Button
+              mt="lg"
+              leftSection={<TbPlus size={16} />}
+              variant="light"
+              color="violet"
+              onClick={() => addProperty(path)}
+            >
+              Add Property
+            </Button>
+          )}
+        </>
+      ) : (
+        <Stack align="flex-start" mt="md">
+          <Text size="sm">
+            {currentTarget.dataType === 'bool' 
+              ? "This is a Boolean root schema. There are no additional rules to configure." 
+              : "This is a primitive root schema. Click below to configure its validation rules."}
+          </Text>
+          {currentTarget.dataType !== 'bool' && (
+            <Button 
+              leftSection={<TbSettings size={16} />} 
+              color="violet" 
+              variant="light"
+              onClick={() => openDrawer(path)}
+            >
+              Configure Rules
+            </Button>
+          )}
+        </Stack>
+      )}
+    </Box>
+  );
+};
+
+export default SchemaSlide;

--- a/apps/web/src/components/editors/schemaEditor/rules/ArrayRuleEditor.tsx
+++ b/apps/web/src/components/editors/schemaEditor/rules/ArrayRuleEditor.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { SchemaProperty } from '../../../../types/schemaEditor';
+import { Stack, NumberInput, Select, Text, Divider, Alert } from '@mantine/core';
+import { getRuleValue, updateRule } from './ruleHelpers';
+import { TbInfoCircle } from 'react-icons/tb';
+
+interface Props {
+  property: SchemaProperty;
+  onUpdate: (updates: Partial<SchemaProperty>) => void;
+}
+
+const ARRAY_ITEM_TYPES = [
+  { value: 'str', label: 'String' },
+  { value: 'int', label: 'Integer' },
+  { value: 'float', label: 'Float' },
+  { value: 'bool', label: 'Boolean' },
+  { value: 'object', label: 'Object' },
+];
+
+const ArrayRuleEditor = ({ property, onUpdate }: Props) => {
+  const handleChange = (type: string, value: any) => {
+    onUpdate({ rules: updateRule(property.rules, type, value) });
+  };
+
+  const itemType = getRuleValue(property.rules, 'itemType', '');
+
+  return (
+    <Stack gap="md">
+      <Text size="sm" fw={500}>Array Validation Rules</Text>
+      
+      <Select
+        allowDeselect={false}
+        label="Items Data Type"
+        placeholder="Select type for array items"
+        data={ARRAY_ITEM_TYPES}
+        value={itemType}
+        onChange={(val) => handleChange('itemType', val)}
+      />
+
+      {itemType === 'object' && (
+        <Alert icon={<TbInfoCircle size={16} />} title="Object Arrays" color="blue" variant="light">
+          To define rules for objects inside this array, use the "Object" type directly on a parent field instead. Wait, currently array of objects requires custom JS or a different schema nesting. For now, it will validate that items are objects.
+        </Alert>
+      )}
+
+      <Divider />
+
+      <NumberInput
+        label="Minimum Items"
+        placeholder="e.g. 1"
+        min={0}
+        value={getRuleValue(property.rules, 'minItems', '')}
+        onChange={(val) => handleChange('minItems', val)}
+      />
+      <NumberInput
+        label="Maximum Items"
+        placeholder="e.g. 10"
+        min={0}
+        value={getRuleValue(property.rules, 'maxItems', '')}
+        onChange={(val) => handleChange('maxItems', val)}
+      />
+    </Stack>
+  );
+};
+
+export default ArrayRuleEditor;

--- a/apps/web/src/components/editors/schemaEditor/rules/EnumRuleEditor.tsx
+++ b/apps/web/src/components/editors/schemaEditor/rules/EnumRuleEditor.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { SchemaProperty } from '../../../../types/schemaEditor';
+import { Stack, Select, Text, TextInput, ActionIcon, Grid, Button, Divider } from '@mantine/core';
+import { getRuleValue, updateRule } from './ruleHelpers';
+import { TbTrashFilled } from 'react-icons/tb';
+
+interface Props {
+  property: SchemaProperty;
+  onUpdate: (updates: Partial<SchemaProperty>) => void;
+}
+
+const ENUM_TYPES = [
+  { value: 'string', label: 'String' },
+  { value: 'number', label: 'Number' },
+];
+
+const EnumRuleEditor = ({ property, onUpdate }: Props) => {
+  const enumType = getRuleValue(property.rules, 'enumType', 'string');
+  const enumValues = getRuleValue(property.rules, 'enumValues', []) as string[];
+
+  const handleTypeChange = (type: string) => {
+    onUpdate({ 
+      rules: updateRule(updateRule(property.rules, 'enumType', type), 'enumValues', []) 
+    });
+  };
+
+  const handleValuesChange = (values: string[]) => {
+    onUpdate({ rules: updateRule(property.rules, 'enumValues', values) });
+  };
+
+  const addValue = () => {
+    handleValuesChange([...enumValues, '']);
+  };
+
+  const updateValue = (index: number, val: string) => {
+    const newValues = [...enumValues];
+    newValues[index] = val;
+    handleValuesChange(newValues);
+  };
+
+  const removeValue = (index: number) => {
+    const newValues = enumValues.filter((_, i) => i !== index);
+    handleValuesChange(newValues);
+  };
+
+  return (
+    <Stack gap="md">
+      <Text size="sm" fw={500}>Enum Configuration</Text>
+      
+      <Select
+        allowDeselect={false}
+        label="Enum Data Type"
+        data={ENUM_TYPES}
+        value={enumType}
+        onChange={(val) => handleTypeChange(val || 'string')}
+      />
+
+      <Divider />
+
+      <Text size="sm" fw={500}>Allowed Values</Text>
+      
+      {enumValues.map((val, index) => (
+        <Grid key={index} align="center">
+          <Grid.Col span={10}>
+            <TextInput
+              placeholder={`Value ${index + 1}`}
+              value={val}
+              onChange={(e) => updateValue(index, e.currentTarget.value)}
+              type={enumType === 'number' ? 'number' : 'text'}
+            />
+          </Grid.Col>
+          <Grid.Col span={2}>
+            <ActionIcon color="red" variant="light" onClick={() => removeValue(index)}>
+              <TbTrashFilled size={16} />
+            </ActionIcon>
+          </Grid.Col>
+        </Grid>
+      ))}
+
+      <Button variant="light" color="violet" onClick={addValue}>
+        Add New Value
+      </Button>
+    </Stack>
+  );
+};
+
+export default EnumRuleEditor;

--- a/apps/web/src/components/editors/schemaEditor/rules/JSRuleEditor.tsx
+++ b/apps/web/src/components/editors/schemaEditor/rules/JSRuleEditor.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { SchemaProperty } from '../../../../types/schemaEditor';
+import { Stack, Text, Alert } from '@mantine/core';
+import { getRuleValue, updateRule } from './ruleHelpers';
+import JsEditor from '../../jsEditor';
+import { TbInfoCircle } from 'react-icons/tb';
+
+interface Props {
+  property: SchemaProperty;
+  onUpdate: (updates: Partial<SchemaProperty>) => void;
+}
+
+const JSRuleEditor = ({ property, onUpdate }: Props) => {
+  const jsCode = getRuleValue(property.rules, 'jsCode', 'return true;');
+
+  const handleChange = (val: string) => {
+    onUpdate({ rules: updateRule(property.rules, 'jsCode', val) });
+  };
+
+  return (
+    <Stack gap="md">
+      <Text size="sm" fw={500}>Custom JavaScript Validation</Text>
+      
+      <Alert icon={<TbInfoCircle size={16} />} color="violet" variant="light">
+        Write JavaScript code that evaluates this property. It should return a boolean value indicating if the validation passed.
+        You can access the field's value typically via context (e.g. `input`).
+      </Alert>
+
+      <div style={{ border: '1px solid var(--mantine-color-gray-3)', borderRadius: 4, overflow: 'hidden' }}>
+        <JsEditor
+          value={jsCode}
+          onChange={handleChange}
+          height={300}
+        />
+      </div>
+    </Stack>
+  );
+};
+
+export default JSRuleEditor;

--- a/apps/web/src/components/editors/schemaEditor/rules/NumberRuleEditor.tsx
+++ b/apps/web/src/components/editors/schemaEditor/rules/NumberRuleEditor.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { SchemaProperty } from '../../../../types/schemaEditor';
+import { Stack, NumberInput, Divider, Text } from '@mantine/core';
+import { getRuleValue, updateRule } from './ruleHelpers';
+
+interface Props {
+  property: SchemaProperty;
+  onUpdate: (updates: Partial<SchemaProperty>) => void;
+}
+
+const NumberRuleEditor = ({ property, onUpdate }: Props) => {
+  const handleChange = (type: string, value: any) => {
+    onUpdate({ rules: updateRule(property.rules, type, value) });
+  };
+
+  const isFloat = property.dataType === 'float';
+
+  return (
+    <Stack gap="md">
+      <Text size="sm" fw={500}>Number Validation Rules</Text>
+      <NumberInput
+        label="Minimum Value"
+        placeholder="e.g. 0"
+        decimalScale={isFloat ? undefined : 0}
+        value={getRuleValue(property.rules, 'min', '')}
+        onChange={(val) => handleChange('min', val)}
+      />
+      <NumberInput
+        label="Maximum Value"
+        placeholder="e.g. 100"
+        decimalScale={isFloat ? undefined : 0}
+        value={getRuleValue(property.rules, 'max', '')}
+        onChange={(val) => handleChange('max', val)}
+      />
+      <Divider />
+      <NumberInput
+        label="Exactly Equal To"
+        decimalScale={isFloat ? undefined : 0}
+        value={getRuleValue(property.rules, 'equal', '')}
+        onChange={(val) => handleChange('equal', val)}
+      />
+      <NumberInput
+        label="Not Equal To"
+        decimalScale={isFloat ? undefined : 0}
+        value={getRuleValue(property.rules, 'notEqual', '')}
+        onChange={(val) => handleChange('notEqual', val)}
+      />
+    </Stack>
+  );
+};
+
+export default NumberRuleEditor;

--- a/apps/web/src/components/editors/schemaEditor/rules/StringRuleEditor.tsx
+++ b/apps/web/src/components/editors/schemaEditor/rules/StringRuleEditor.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { SchemaProperty } from '../../../../types/schemaEditor';
+import { Stack, NumberInput, TextInput, Divider, Text } from '@mantine/core';
+import { getRuleValue, updateRule } from './ruleHelpers';
+
+interface Props {
+  property: SchemaProperty;
+  onUpdate: (updates: Partial<SchemaProperty>) => void;
+}
+
+const StringRuleEditor = ({ property, onUpdate }: Props) => {
+  const handleChange = (type: string, value: any) => {
+    onUpdate({ rules: updateRule(property.rules, type, value) });
+  };
+
+  return (
+    <Stack gap="md">
+      <Text size="sm" fw={500}>String Validation Rules</Text>
+      <NumberInput
+        label="Minimum Length"
+        placeholder="e.g. 3"
+        min={0}
+        value={getRuleValue(property.rules, 'minLength', '')}
+        onChange={(val) => handleChange('minLength', val)}
+      />
+      <NumberInput
+        label="Maximum Length"
+        placeholder="e.g. 255"
+        min={0}
+        value={getRuleValue(property.rules, 'maxLength', '')}
+        onChange={(val) => handleChange('maxLength', val)}
+      />
+      <Divider />
+      <TextInput
+        label="Regex Pattern"
+        placeholder="e.g. ^[a-z]+$"
+        value={getRuleValue(property.rules, 'regex')}
+        onChange={(e) => handleChange('regex', e.currentTarget.value)}
+      />
+      <TextInput
+        label="Starts With"
+        value={getRuleValue(property.rules, 'startsWith')}
+        onChange={(e) => handleChange('startsWith', e.currentTarget.value)}
+      />
+      <TextInput
+        label="Ends With"
+        value={getRuleValue(property.rules, 'endsWith')}
+        onChange={(e) => handleChange('endsWith', e.currentTarget.value)}
+      />
+      <TextInput
+        label="Contains"
+        placeholder="e.g. hello"
+        value={getRuleValue(property.rules, 'contains')}
+        onChange={(e) => handleChange('contains', e.currentTarget.value)}
+      />
+      <TextInput
+        label="Does Not Contain"
+        placeholder="e.g. badword"
+        value={getRuleValue(property.rules, 'notContains')}
+        onChange={(e) => handleChange('notContains', e.currentTarget.value)}
+      />
+    </Stack>
+  );
+};
+
+export default StringRuleEditor;

--- a/apps/web/src/components/editors/schemaEditor/rules/ruleHelpers.ts
+++ b/apps/web/src/components/editors/schemaEditor/rules/ruleHelpers.ts
@@ -1,0 +1,24 @@
+import { Rule } from '../../../../types/schemaEditor';
+
+export const getRuleValue = (rules: Rule[] | undefined, type: string, defaultValue: any = '') => {
+  if (!rules) return defaultValue;
+  const rule = rules.find(r => r.type === type);
+  return rule ? rule.value : defaultValue;
+};
+
+export const updateRule = (rules: Rule[] | undefined, type: string, value: any): Rule[] => {
+  const newRules = rules ? [...rules] : [];
+  const index = newRules.findIndex(r => r.type === type);
+  
+  // Remove rule if value is empty/null/undefined (but allow 0 or false)
+  if (value === '' || value === undefined || value === null) {
+    if (index >= 0) newRules.splice(index, 1);
+  } else {
+    if (index >= 0) {
+      newRules[index] = { ...newRules[index], value };
+    } else {
+      newRules.push({ type, value });
+    }
+  }
+  return newRules;
+};

--- a/apps/web/src/components/editors/schemaEditor/store.ts
+++ b/apps/web/src/components/editors/schemaEditor/store.ts
@@ -1,0 +1,137 @@
+import { createStore } from 'zustand/vanilla';
+import { useStore } from 'zustand';
+import { createContext, useContext, useRef, ReactNode } from 'react';
+import { ValidationSchema, SchemaProperty, DataType } from '../../../types/schemaEditor';
+import { produce } from 'immer';
+// No uuid needed, using Math.random for client-side IDs
+
+// Simple ID generator since uuid might not be installed
+const generateId = () => Math.random().toString(36).substring(2, 9);
+
+interface SchemaEditorState {
+  schema: ValidationSchema;
+  path: (number | 'items')[]; // Navigates through 'properties' (number index) or 'items' ('items' literal)
+  drawerOpen: boolean;
+  activePropertyPath: (number | 'items')[] | null; 
+  locked: boolean;
+  typeOverrides: Record<string, DataType[]>;
+  allowedRootSchemaTypes?: DataType[];
+  
+  // Actions
+  setSchema: (schema: ValidationSchema) => void;
+  addProperty: (currentPath: (number | 'items')[]) => void;
+  removeProperty: (targetPath: (number | 'items')[]) => void;
+  updateProperty: (targetPath: (number | 'items')[], updates: Partial<SchemaProperty>) => void;
+  
+  // UI Actions
+  pushPath: (segment: number | 'items') => void;
+  popPath: () => void;
+  goToPath: (level: number) => void;
+    openDrawer: (targetPath: (number | 'items')[]) => void;
+    closeDrawer: () => void;
+  }
+  
+  export const createSchemaStore = (initialSchema?: ValidationSchema, locked: boolean = false, typeOverrides: Record<string, DataType[]> = {}, allowedRootSchemaTypes?: DataType[]) => {
+    const defaultSchema: ValidationSchema = {
+      dataType: 'object',
+      properties: []
+    };
+  
+    return createStore<SchemaEditorState>((set) => ({
+      schema: initialSchema || defaultSchema,
+      locked,
+      typeOverrides,
+      allowedRootSchemaTypes,
+      path: [],
+      drawerOpen: false,
+      activePropertyPath: null,
+  
+      setSchema: (schema) => set({ schema }),
+  
+      addProperty: (currentPath) => set(produce((state: SchemaEditorState) => {
+        let target: any = state.schema;
+        for (const segment of currentPath) {
+          if (segment === 'items') {
+            if (!target.items) target.items = { dataType: 'str' };
+            target = target.items;
+          } else {
+            if (!target.properties) target.properties = [];
+            target = target.properties[segment];
+          }
+        }
+        
+        if (!target.properties) target.properties = [];
+        target.properties.push({
+          id: generateId(),
+          key: '',
+          dataType: 'str',
+          rules: [],
+          required: false
+        });
+      })),
+  
+      removeProperty: (targetPath) => set(produce((state: SchemaEditorState) => {
+        if (targetPath.length === 0) return;
+        const lastSegment = targetPath[targetPath.length - 1];
+        const parentPath = targetPath.slice(0, -1);
+        
+        let parent: any = state.schema;
+        for (const segment of parentPath) {
+          if (segment === 'items') parent = parent.items;
+          else parent = parent.properties[segment];
+        }
+        
+        if (lastSegment === 'items') {
+          delete parent.items;
+        } else if (parent.properties) {
+          parent.properties.splice(lastSegment as number, 1);
+        }
+      })),
+  
+      updateProperty: (targetPath, updates) => set(produce((state: SchemaEditorState) => {
+        let target: any = state.schema;
+        for (const segment of targetPath) {
+          if (segment === 'items') {
+            if (!target.items) target.items = {};
+            target = target.items;
+          } else {
+            if (!target.properties) target.properties = [];
+            target = target.properties[segment];
+          }
+        }
+        
+        Object.assign(target, updates);
+      })),
+  
+      pushPath: (segment) => set(produce((state: SchemaEditorState) => {
+        state.path.push(segment);
+      })),
+  
+      popPath: () => set(produce((state: SchemaEditorState) => {
+        state.path.pop();
+      })),
+  
+      goToPath: (level) => set(produce((state: SchemaEditorState) => {
+        state.path = state.path.slice(0, level);
+      })),
+  
+      openDrawer: (targetPath) => set({ drawerOpen: true, activePropertyPath: targetPath }),
+      closeDrawer: () => set({ drawerOpen: false, activePropertyPath: null })
+    }));
+  };
+
+export type SchemaEditorStore = ReturnType<typeof createSchemaStore>;
+
+export const SchemaEditorContext = createContext<SchemaEditorStore | null>(null);
+
+export function useSchemaEditorStore<T>(selector: (state: SchemaEditorState) => T): T {
+  const store = useContext(SchemaEditorContext);
+  if (!store) throw new Error('Missing SchemaEditorContext.Provider in the tree');
+  return useStore(store, selector);
+}
+
+export function useSchemaEditorStoreApi() {
+  const store = useContext(SchemaEditorContext);
+  if (!store) throw new Error('Missing SchemaEditorContext.Provider in the tree');
+  return store;
+}

--- a/apps/web/src/components/forms/EditRouteSettings.tsx
+++ b/apps/web/src/components/forms/EditRouteSettings.tsx
@@ -1,0 +1,300 @@
+"use client";
+import React, { useState, useEffect, useMemo, useRef } from "react";
+import { routesQueries } from "@/query/routerQuery";
+import { routesService } from "@/services/routes";
+import { Loader, Center, Box, Title, Text, Button, Group, Stack, TextInput, Select, Switch, Alert, Code, NavLink, Paper, Flex } from "@mantine/core";
+import { notifications } from "@mantine/notifications";
+import { useQueryClient } from "@tanstack/react-query";
+import { useForm } from "@mantine/form";
+import { SchemaEditor } from "../editors/schemaEditor/SchemaEditor";
+import { ValidationSchema, SchemaEditorRef, DataType } from "@/types/schemaEditor";
+import { TbInfoCircle, TbDeviceFloppy } from "react-icons/tb";
+import BackToEditorButton from "../editor/backToEditorButton";
+
+export default function EditRouteSettings({ routeId }: { routeId: string }) {
+  const { data: routeData, isLoading, error } = routesQueries.getById.useQuery(routeId);
+  const client = useQueryClient();
+  const [loading, setLoading] = useState(false);
+  const [activeTab, setActiveTab] = useState<"general" | "body" | "params" | "query">("general");
+
+  // Form for General Info
+  const generalForm = useForm({
+    mode: "uncontrolled",
+    initialValues: {
+      name: "",
+      path: "",
+      method: "GET",
+      active: false,
+    },
+    validate: {
+      name: (value) => (value.length < 2 ? "Name must have at least 2 letters" : null),
+      path: (value) => (!value.startsWith("/") ? "Path must start with /" : null),
+    },
+  });
+
+  const [bodySchema, setBodySchema] = useState<ValidationSchema | undefined>(undefined);
+  const [querySchema, setQuerySchema] = useState<ValidationSchema | undefined>(undefined);
+  const [paramsSchema, setParamsSchema] = useState<ValidationSchema | undefined>(undefined);
+  
+  const [generatedParamsSchema, setGeneratedParamsSchema] = useState<ValidationSchema | null>(null);
+
+  // Refs for SchemaEditors to trigger save internally
+  const bodySchemaRef = useRef<SchemaEditorRef>(null);
+  const querySchemaRef = useRef<SchemaEditorRef>(null);
+  const paramsSchemaRef = useRef<SchemaEditorRef>(null);
+
+  useEffect(() => {
+    if (routeData) {
+      generalForm.setValues({
+        name: routeData.name,
+        path: routeData.path,
+        method: routeData.method,
+        active: routeData.active,
+      });
+      setBodySchema(routeData.bodySchema as ValidationSchema);
+      setQuerySchema((routeData.querySchema as ValidationSchema) || { dataType: "object", properties: [] });
+      setParamsSchema(routeData.paramsSchema as ValidationSchema);
+    }
+  }, [routeData]);
+
+  // Extract variables from path to auto-generate paramsSchema
+  const pathValue = generalForm.getValues().path;
+  const pathParams = useMemo(() => {
+    return Array.from(pathValue.matchAll(/:([a-zA-Z0-9_]+)/g)).map((m) => m[1]);
+  }, [pathValue]);
+
+  const hasBody = ["POST", "PUT"].includes(generalForm.getValues().method);
+  const hasParams = pathParams.length > 0;
+
+  const paramTypeOverrides = useMemo(() => {
+    return pathParams.reduce((acc, param) => {
+      acc[param] = ["str", "int", "bool", "float"];
+      return acc;
+    }, {} as Record<string, DataType[]>);
+  }, [pathParams]);
+
+  useEffect(() => {
+    if (routeData?.paramsSchema) {
+      setParamsSchema(routeData.paramsSchema as ValidationSchema);
+    } else {
+      setGeneratedParamsSchema({
+        dataType: "object",
+        properties: pathParams.map((p) => ({
+          key: p,
+          dataType: "str",
+          required: true,
+        })),
+      });
+    }
+  }, [pathParams, routeData?.paramsSchema]);
+
+  const handleUpdate = async () => {
+    const validation = generalForm.validate();
+    if (validation.hasErrors) {
+      notifications.show({
+        title: "Validation Error",
+        message: "Please fix the errors in General Info",
+        color: "red",
+      });
+      return;
+    }
+
+    // Force save schemas before submitting
+    bodySchemaRef.current?.save();
+    querySchemaRef.current?.save();
+    paramsSchemaRef.current?.save();
+
+    try {
+      setLoading(true);
+      await routesService.update(routeId, {
+        name: generalForm.getValues().name,
+        path: generalForm.getValues().path,
+        method: generalForm.getValues().method as any,
+        active: generalForm.getValues().active,
+        bodySchema: hasBody ? bodySchema : undefined,
+        querySchema,
+        paramsSchema: hasParams ? paramsSchema : undefined,
+      });
+      notifications.show({
+        title: "Success",
+        message: "Route updated successfully",
+        color: "green",
+      });
+      routesQueries.getById.invalidate(client, routeId);
+      routesQueries.getAll.invalidate(client);
+    } catch (err: any) {
+      notifications.show({
+        title: "Error updating route",
+        message: err?.response?.data?.message || err.message || "Unknown error",
+        color: "red",
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <Center p="xl">
+        <Loader color="violet" />
+      </Center>
+    );
+  }
+
+  if (error || !routeData) {
+    return (
+      <Center p="xl">
+        <Text color="red">Failed to load route data.</Text>
+      </Center>
+    );
+  }
+
+  return (
+    <Box p="md" h="100%">
+      <Group justify="space-between" mb="lg">
+        <Title order={3}>Route Settings</Title>
+        <Button onClick={handleUpdate} loading={loading} color="violet" leftSection={<TbDeviceFloppy />}>
+          Save Changes
+        </Button>
+      </Group>
+
+      <Flex h="calc(100vh - 140px)" gap="xl">
+        <Paper 
+          withBorder 
+          w={260} 
+          p="sm" 
+          radius="md" 
+          style={{ display: 'flex', flexDirection: 'column', backgroundColor: 'var(--mantine-color-gray-0)' }}
+        >
+          <Stack justify="space-between" style={{ flex: 1 }}>
+            <Box>
+              <Text c="dimmed" size="xs" fw={700} tt="uppercase" mb="sm" px="xs">Configuration</Text>
+              
+              <NavLink
+                label="General Info"
+                active={activeTab === "general"}
+                onClick={() => setActiveTab("general")}
+                color="violet"
+                variant="light"
+                style={{ borderRadius: 8, marginBottom: 4 }}
+              />
+              {hasBody && (
+                <NavLink
+                  label="Body Validation"
+                  active={activeTab === "body"}
+                  onClick={() => setActiveTab("body")}
+                  color="violet"
+                  variant="light"
+                  style={{ borderRadius: 8, marginBottom: 4 }}
+                />
+              )}
+              {hasParams && (
+                <NavLink
+                  label="Route Params"
+                  active={activeTab === "params"}
+                  onClick={() => setActiveTab("params")}
+                  color="violet"
+                  variant="light"
+                  style={{ borderRadius: 8, marginBottom: 4 }}
+                />
+              )}
+              <NavLink
+                label="Query Params"
+                active={activeTab === "query"}
+                onClick={() => setActiveTab("query")}
+                color="violet"
+                variant="light"
+                style={{ borderRadius: 8 }}
+              />
+            </Box>
+            
+            <Box>
+              <BackToEditorButton routeId={routeId} />
+            </Box>
+          </Stack>
+        </Paper>
+
+        <Box style={{ flex: 1, overflowY: 'auto' }} pr="md">
+          {activeTab === "general" && (
+            <Stack gap="md" maw={600}>
+              <Title order={4}>Route Details</Title>
+              <TextInput
+                label="Name"
+                placeholder="e.g. Create User"
+                withAsterisk
+                {...generalForm.getInputProps("name")}
+              />
+              <TextInput
+                label="Path"
+                placeholder="e.g. /api/users"
+                withAsterisk
+                {...generalForm.getInputProps("path")}
+              />
+              <Select
+                label="Method"
+                placeholder="GET"
+                data={["GET", "POST", "PUT", "DELETE"]}
+                {...generalForm.getInputProps("method")}
+              />
+              <Switch
+                label="Active"
+                {...generalForm.getInputProps("active", { type: "checkbox" })}
+              />
+            </Stack>
+          )}
+
+          {activeTab === "body" && hasBody && (
+            <Stack gap="md">
+              <Title order={4}>Body Validation Schema</Title>
+              <Alert icon={<TbInfoCircle />} color="violet">
+                Define the payload structure expected in the HTTP request body.
+              </Alert>
+              <SchemaEditor
+                key="bodySchema"
+                ref={bodySchemaRef}
+                initialData={bodySchema || { dataType: "object", properties: [] }}
+                onSave={(data) => setBodySchema(data)}
+              />
+            </Stack>
+          )}
+
+          {activeTab === "params" && hasParams && (
+            <Stack gap="md">
+              <Title order={4}>Route Parameters Schema</Title>
+              <Alert icon={<TbInfoCircle />} color="violet">
+                The following parameters were extracted from your path:{" "}
+                <Code>{pathValue}</Code>. You can configure their validation rules
+                below.
+              </Alert>
+              <SchemaEditor
+                key="paramsSchema"
+                ref={paramsSchemaRef}
+                initialData={paramsSchema || generatedParamsSchema || { dataType: 'object', properties: [] }}
+                onSave={(data) => setParamsSchema(data)}
+                locked={true}
+                typeOverrides={paramTypeOverrides}
+              />
+            </Stack>
+          )}
+
+          {activeTab === "query" && (
+            <Stack gap="md">
+              <Title order={4}>Query Parameters Schema</Title>
+              <Alert icon={<TbInfoCircle />} color="violet">
+                Define any query string parameters this route expects (e.g.
+                ?page=1&sort=desc).
+              </Alert>
+              <SchemaEditor
+                key="querySchema"
+                ref={querySchemaRef}
+                initialData={querySchema}
+                onSave={(data) => setQuerySchema(data)}
+                allowedRootSchemaTypes={['object']}
+              />
+            </Stack>
+          )}
+        </Box>
+      </Flex>
+    </Box>
+  );
+}

--- a/apps/web/src/components/forms/RouteFormStepper.tsx
+++ b/apps/web/src/components/forms/RouteFormStepper.tsx
@@ -1,0 +1,357 @@
+import {
+	TextInput,
+	Select,
+	Switch,
+	Title,
+	Text,
+	Stack,
+	Alert,
+	Box,
+	Code,
+} from "@mantine/core";
+import { useForm } from "@mantine/form";
+import React, { useRef, useState, useMemo, useEffect } from "react";
+import {
+	OnboardingStepper,
+	OnboardingStep,
+} from "../stepper/OnboardingStepper";
+import { SchemaEditor } from "../editors/schemaEditor/SchemaEditor";
+import { SchemaPreview } from "../editors/schemaEditor/SchemaPreview";
+import {
+	ValidationSchema,
+	SchemaEditorRef,
+	DataType,
+} from "@/types/schemaEditor";
+import { TbInfoCircle } from "react-icons/tb";
+
+export type RouteFormValues = {
+	id?: string;
+	name: string;
+	path: string;
+	method: string;
+	active: boolean;
+	projectId?: string;
+	bodySchema?: ValidationSchema;
+	querySchema?: ValidationSchema;
+	paramsSchema?: ValidationSchema;
+};
+
+interface RouteFormStepperProps {
+	initialValues?: Partial<RouteFormValues>;
+	onSubmit: (values: RouteFormValues) => void;
+	onCancel?: () => void;
+	loading?: boolean;
+	readOnly?: boolean;
+}
+
+export const RouteFormStepper: React.FC<RouteFormStepperProps> = ({
+	initialValues,
+	onSubmit,
+	onCancel,
+	loading,
+	readOnly,
+}) => {
+	const [activeStep, setActiveStep] = useState(0);
+
+	// Form for General Info
+	const generalForm = useForm({
+		mode: "uncontrolled",
+		initialValues: {
+			name: initialValues?.name || "",
+			path: initialValues?.path || "",
+			method: initialValues?.method || "GET",
+			active: initialValues?.active ?? false,
+		},
+		validate: {
+			name: (value) =>
+				value.length < 2 ? "Name must have at least 2 letters" : null,
+			path: (value) =>
+				!value.startsWith("/") ? "Path must start with /" : null,
+		},
+	});
+
+	// Extract variables from path to auto-generate paramsSchema
+	const pathValue = generalForm.getValues().path;
+	const pathParams = useMemo(() => {
+		return Array.from(pathValue.matchAll(/:([a-zA-Z0-9_]+)/g)).map((m) => m[1]);
+	}, [pathValue]);
+
+	const hasBody = ["POST", "PUT"].includes(generalForm.getValues().method);
+	const hasParams = pathParams.length > 0;
+
+	// Refs for SchemaEditors to trigger save internally
+	const bodySchemaRef = useRef<SchemaEditorRef>(null);
+	const querySchemaRef = useRef<SchemaEditorRef>(null);
+	const paramsSchemaRef = useRef<SchemaEditorRef>(null);
+
+	const [bodySchema, setBodySchema] = useState<ValidationSchema | undefined>(
+		initialValues?.bodySchema,
+	);
+	const [querySchema, setQuerySchema] = useState<ValidationSchema | undefined>(
+		initialValues?.querySchema || { dataType: "object", properties: [] },
+	);
+	const [paramsSchema, setParamsSchema] = useState<
+		ValidationSchema | undefined
+	>(initialValues?.paramsSchema);
+	const [generatedParamsSchema, setGeneratedParamsSchema] =
+		useState<ValidationSchema | null>(null);
+
+	const paramTypeOverrides = useMemo(() => {
+		return pathParams.reduce(
+			(acc, param) => {
+				acc[param] = ["str", "int", "bool", "float"];
+				return acc;
+			},
+			{} as Record<string, DataType[]>,
+		);
+	}, [pathParams]);
+
+	// Initialize the params schema whenever path variables change
+	useEffect(() => {
+		if (initialValues?.paramsSchema) {
+			setParamsSchema(initialValues.paramsSchema);
+		} else {
+			setGeneratedParamsSchema({
+				dataType: "object",
+				properties: pathParams.map((p) => ({
+					key: p,
+					dataType: "str",
+					required: true,
+				})),
+			});
+		}
+	}, [pathParams, initialValues?.paramsSchema]);
+
+	const handleStepChange = (step: number) => {
+		// If going forward from a schema step, we want to save its state
+		const currentStepDef = steps[activeStep];
+		if (currentStepDef.label === "Body Validation") {
+			bodySchemaRef.current?.save();
+		} else if (currentStepDef.label === "Query Params Validation") {
+			querySchemaRef.current?.save();
+		} else if (currentStepDef.label === "Route Params Validation") {
+			paramsSchemaRef.current?.save();
+		}
+
+		if (readOnly && step !== steps.length - 1) {
+			// In readOnly mode, we can allow clicking steps if needed, but normally it's locked.
+			// We will handle it by just letting them navigate if readOnly allows.
+		}
+		setActiveStep(step);
+	};
+
+	const submitForm = () => {
+		// Before submitting from Summary step, ensure we get latest if needed, though they should be saved by step change.
+		const values: RouteFormValues = {
+			...generalForm.getValues(),
+			id: initialValues?.id,
+			projectId: initialValues?.projectId,
+			bodySchema: hasBody ? bodySchema : undefined,
+			querySchema,
+			paramsSchema: hasParams ? paramsSchema : undefined,
+		};
+		onSubmit(values);
+	};
+
+	const steps: OnboardingStep[] = [
+		{
+			label: "General Info",
+			description: "Basic route details",
+			validate: () => {
+				const validation = generalForm.validate();
+				return !validation.hasErrors;
+			},
+			content: (
+				<Stack gap="sm">
+					<Title order={5}>Route Details</Title>
+					<TextInput
+						label="Name"
+						placeholder="e.g. Create User"
+						withAsterisk
+						disabled={readOnly}
+						{...generalForm.getInputProps("name")}
+					/>
+					<TextInput
+						label="Path"
+						placeholder="e.g. /api/users"
+						withAsterisk
+						disabled={readOnly}
+						{...generalForm.getInputProps("path")}
+					/>
+					<Select
+						label="Method"
+						placeholder="GET"
+						data={["GET", "POST", "PUT", "DELETE"]}
+						disabled={readOnly}
+						{...generalForm.getInputProps("method")}
+					/>
+					<Switch
+						label="Active"
+						disabled={readOnly}
+						{...generalForm.getInputProps("active", { type: "checkbox" })}
+					/>
+				</Stack>
+			),
+		},
+	];
+
+	if (hasBody) {
+		steps.push({
+			label: "Body Validation",
+			description: "Configure HTTP Body Schema",
+			content: (
+				<Stack gap="sm">
+					<Title order={5}>Body Validation Schema</Title>
+					<Alert icon={<TbInfoCircle />} color="violet">
+						Define the payload structure expected in the HTTP request body.
+					</Alert>
+					<SchemaEditor
+						key="bodySchema"
+						ref={bodySchemaRef}
+						initialData={bodySchema || { dataType: "object", properties: [] }}
+						onSave={(data) => setBodySchema(data)}
+					/>
+				</Stack>
+			),
+		});
+	}
+
+	if (hasParams) {
+		// Generate initial params schema if missing
+		const generatedParamsSchema: ValidationSchema = paramsSchema || {
+			dataType: "object",
+			properties: pathParams.map((p) => ({
+				key: p,
+				dataType: "str",
+				required: true,
+			})),
+		};
+
+		steps.push({
+			label: "Route Params Validation",
+			description: "URL Path Parameters",
+			content: (
+				<Stack gap="sm">
+					<Title order={5}>Route Parameters Schema</Title>
+					<Alert icon={<TbInfoCircle />} color="violet">
+						The following parameters were extracted from your path:{" "}
+						<Code>{pathValue}</Code>. You can configure their validation rules
+						below.
+					</Alert>
+					<SchemaEditor
+						key="paramsSchema"
+						ref={paramsSchemaRef}
+						initialData={generatedParamsSchema}
+						onSave={(data) => setParamsSchema(data)}
+						// @ts-ignore
+						locked={true}
+						typeOverrides={paramTypeOverrides}
+					/>
+				</Stack>
+			),
+		});
+	}
+
+	steps.push({
+		label: "Query Params Validation",
+		description: "URL Query string",
+		content: (
+			<Stack gap="sm">
+				<Title order={5}>Query Parameters Schema</Title>
+				<Alert icon={<TbInfoCircle />} color="violet">
+					Define any query string parameters this route expects (e.g.
+					?page=1&sort=desc).
+				</Alert>
+				<SchemaEditor
+					key="querySchema"
+					ref={querySchemaRef}
+					initialData={querySchema}
+					onSave={(data) => setQuerySchema(data)}
+					allowedRootSchemaTypes={['object']}
+				/>
+			</Stack>
+		),
+	});
+
+	steps.push({
+		label: "Summary",
+		description: "Review and Submit",
+		content: (
+			<Stack gap="md">
+				<Title order={4}>Review Route Configuration</Title>
+
+				<Box>
+					<Text fw={600} size="md" mb="xs">
+						General Information
+					</Text>
+					<Stack gap="md">
+						<TextInput
+							label="Name"
+							readOnly
+							value={generalForm.getValues().name}
+							variant="filled"
+						/>
+						<TextInput
+							label="Path"
+							readOnly
+							value={generalForm.getValues().path}
+							variant="filled"
+						/>
+						<TextInput
+							label="Method"
+							readOnly
+							value={generalForm.getValues().method}
+							variant="filled"
+						/>
+						<Switch
+							label="Active"
+							checked={generalForm.getValues().active}
+							readOnly
+						/>
+					</Stack>
+				</Box>
+
+				{hasBody && bodySchema && (
+					<Box>
+						<Text fw={600} size="md" mb="xs">
+							Body Validation Schema
+						</Text>
+						<SchemaPreview schema={bodySchema} />
+					</Box>
+				)}
+
+				{hasParams && paramsSchema && (
+					<Box>
+						<Text fw={600} size="md" mb="xs">
+							Route Params Schema
+						</Text>
+						<SchemaPreview schema={paramsSchema} />
+					</Box>
+				)}
+
+				{querySchema &&
+					querySchema.properties &&
+					querySchema.properties.length > 0 && (
+						<Box>
+							<Text fw={600} size="md" mb="xs">
+								Query Params Schema
+							</Text>
+							<SchemaPreview schema={querySchema} />
+						</Box>
+					)}
+			</Stack>
+		),
+	});
+
+	return (
+		<OnboardingStepper
+			steps={steps}
+			activeStep={readOnly ? steps.length - 1 : activeStep}
+			onStepChange={handleStepChange}
+			onSubmit={submitForm}
+			loading={loading}
+			onCancel={onCancel}
+			readOnly={readOnly}
+		/>
+	);
+};

--- a/apps/web/src/components/panels/emptyRoutePanel.tsx
+++ b/apps/web/src/components/panels/emptyRoutePanel.tsx
@@ -1,39 +1,35 @@
 import { Button, Stack, Text } from "@mantine/core";
 import React from "react";
-import { CreateRouteForm } from "../createNewMenu";
 import FormDialog from "../dialog/formDialog";
 import { useDisclosure } from "@mantine/hooks";
 
 const EmptyRoutePanel = ({ projectId }: { projectId?: string }) => {
-  const [opened, { open, close }] = useDisclosure(false);
-  return (
-    <Stack
-      bg="gray.1"
-      bd={"2px solid gray.4"}
-      bdrs={"sm"}
-      justify="center"
-      align="center"
-      w={"100%"}
-      h={"30vh"}
-    >
-      <Text size="xl" fw={500}>
-        No Routes Found
-      </Text>
-      {projectId && (
-        <>
-          <Text c="gray.7" size="md" fw={500}>
-            Create a new route to get started
-          </Text>
-          <Button color="dark" variant="outline" onClick={open}>
-            Add New Route
-          </Button>
-          <FormDialog title="Create New Route" open={opened} onClose={close}>
-            <CreateRouteForm close={close} />
-          </FormDialog>
-        </>
-      )}
-    </Stack>
-  );
+	const [opened, { open, close }] = useDisclosure(false);
+	return (
+		<Stack
+			bg="gray.1"
+			bd={"2px solid gray.4"}
+			bdrs={"sm"}
+			justify="center"
+			align="center"
+			w={"100%"}
+			h={"30vh"}
+		>
+			<Text size="xl" fw={500}>
+				No Routes Found
+			</Text>
+			{projectId && (
+				<>
+					<Text c="gray.7" size="md" fw={500}>
+						Create a new route to get started
+					</Text>
+					<Button color="dark" variant="outline" onClick={open}>
+						Add New Route
+					</Button>
+				</>
+			)}
+		</Stack>
+	);
 };
 
 export default EmptyRoutePanel;

--- a/apps/web/src/components/routeItemMenu.tsx
+++ b/apps/web/src/components/routeItemMenu.tsx
@@ -9,10 +9,7 @@ import { showErrorNotification } from "@/lib/errorNotifier";
 import { routesQueries } from "@/query/routerQuery";
 import { useQueryClient } from "@tanstack/react-query";
 import { notifications } from "@mantine/notifications";
-import FormDialog from "./dialog/formDialog";
-import RouteForm from "./forms/routeForm";
-import QueryLoader from "./query/queryLoader";
-import QueryError from "./query/queryError";
+import { useRouter } from "next/navigation";
 
 type Proptypes = {
   id: string;
@@ -20,12 +17,11 @@ type Proptypes = {
 
 const RouteItemMenu = (props: Proptypes) => {
   const [opened, { open, close }] = useDisclosure(false);
-  const [editOpened, { open: openEdit, close: closeEdit }] =
-    useDisclosure(false);
   const client = useQueryClient();
+  const router = useRouter();
 
   function onEditClicked() {
-    openEdit();
+    router.push(`/editor/${props.id}/settings`);
   }
   function onDuplicateClicked() {}
   function onDownloadJsonClicked() {}
@@ -74,68 +70,8 @@ const RouteItemMenu = (props: Proptypes) => {
           Are you sure want to delete?
         </ConfirmDialog>
       </Menu>
-      <FormDialog open={editOpened} onClose={closeEdit} title="Edit Route">
-        <RouteEditForm id={props.id} close={closeEdit} />
-      </FormDialog>
     </>
   );
 };
-
-function RouteEditForm({ id, close }: { id: string; close: () => void }) {
-  const [saving, setSaving] = useState(false);
-  const { data, isLoading, isError, error } =
-    routesQueries.getById.useQuery(id);
-  const client = useQueryClient();
-
-  if (isLoading) {
-    return <QueryLoader />;
-  }
-  if (isError) {
-    return (
-      <QueryError
-        error={error!}
-        refetcher={() => {
-          routesQueries.getById.invalidate(client, id);
-        }}
-      />
-    );
-  }
-
-  async function onUpdate(data: any) {
-    try {
-      setSaving(true);
-      await routesService.update(id, data);
-      routesQueries.invalidateAll(client);
-      close();
-    } catch (error: any) {
-      showErrorNotification(error);
-    } finally {
-      setSaving(false);
-    }
-  }
-
-  return (
-    <RouteForm
-      values={data}
-      onSubmit={onUpdate}
-      zodSchema={routesService.updateRequestSchema}
-      actionSection={
-        <Group mt={"xs"} gap={"xs"} justify="end">
-          <Button
-            loading={saving}
-            type="submit"
-            variant="outline"
-            color="violet"
-          >
-            Update
-          </Button>
-          <Button onClick={close} variant="subtle" color="dark">
-            Cancel
-          </Button>
-        </Group>
-      }
-    />
-  );
-}
 
 export default RouteItemMenu;

--- a/apps/web/src/components/stepper/OnboardingStepper.tsx
+++ b/apps/web/src/components/stepper/OnboardingStepper.tsx
@@ -1,0 +1,121 @@
+import React from "react";
+import { Stepper, Button, Group, Paper, Box } from "@mantine/core";
+
+export interface OnboardingStep {
+  label: string;
+  description?: string;
+  content: React.ReactNode;
+  /** Return true if the step is valid and we can proceed to next step */
+  validate?: () => boolean | Promise<boolean>;
+  /** Optional icon for the step */
+  icon?: React.ReactNode;
+}
+
+interface OnboardingStepperProps {
+  steps: OnboardingStep[];
+  activeStep: number;
+  onStepChange: (step: number) => void;
+  onSubmit: () => void;
+  readOnly?: boolean;
+  loading?: boolean;
+  onCancel?: () => void;
+}
+
+export const OnboardingStepper: React.FC<OnboardingStepperProps> = ({
+  steps,
+  activeStep,
+  onStepChange,
+  onSubmit,
+  readOnly,
+  loading,
+  onCancel,
+}) => {
+  const handleNext = async () => {
+    const currentStepDef = steps[activeStep];
+    if (currentStepDef.validate) {
+      const isValid = await currentStepDef.validate();
+      if (!isValid) return;
+    }
+    
+    if (activeStep === steps.length - 1) {
+      onSubmit();
+    } else {
+      onStepChange(activeStep + 1);
+    }
+  };
+
+  const handlePrev = () => {
+    onStepChange(activeStep - 1);
+  };
+
+  const isSummaryStep = activeStep === steps.length - 1;
+
+  if (readOnly) {
+    // In read-only mode, we usually just want to display the summary or the specific step's content without navigation.
+    return (
+      <Paper p="xl" radius="md">
+        <Box mb="xl">{steps[activeStep].content}</Box>
+      </Paper>
+    );
+  }
+
+  return (
+    <Box>
+      <Stepper
+        active={activeStep}
+        onStepClick={onStepChange}
+        color="violet"
+        allowNextStepsSelect={false}
+      >
+        {steps.map((step, index) => (
+          <Stepper.Step
+            key={index}
+            label={step.label}
+            description={step.description}
+            icon={step.icon}
+          />
+        ))}
+      </Stepper>
+
+      <Paper p="md" radius="md" mt="md" style={{ flex: 1, paddingBottom: 80 }}>
+        <Box style={{ minHeight: "300px" }}>
+          {steps[activeStep].content}
+        </Box>
+      </Paper>
+
+      <Group 
+        justify="space-between" 
+        p="md" 
+        style={{ 
+          position: "sticky", 
+          bottom: 0, 
+          backgroundColor: "var(--mantine-color-body)", 
+          borderTop: "1px solid var(--mantine-color-gray-2)",
+          zIndex: 10 
+        }}
+      >
+        <Group>
+          {onCancel && (
+            <Button variant="subtle" color="dark" onClick={onCancel}>
+              Cancel
+            </Button>
+          )}
+          <Button
+            variant="default"
+            onClick={handlePrev}
+            disabled={activeStep === 0}
+          >
+            Back
+          </Button>
+        </Group>
+        <Button
+          onClick={handleNext}
+          color="violet"
+          loading={loading}
+        >
+          {isSummaryStep ? "Submit" : "Next step"}
+        </Button>
+      </Group>
+    </Box>
+  );
+};

--- a/apps/web/src/store/layout.ts
+++ b/apps/web/src/store/layout.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+interface LayoutState {
+  sidebarOpened: boolean;
+  setSidebarOpened: (opened: boolean) => void;
+  toggleSidebar: () => void;
+}
+
+export const useLayoutStore = create<LayoutState>((set) => ({
+  sidebarOpened: true,
+  setSidebarOpened: (opened) => set({ sidebarOpened: opened }),
+  toggleSidebar: () => set((state) => ({ sidebarOpened: !state.sidebarOpened })),
+}));

--- a/apps/web/src/types/schemaEditor.ts
+++ b/apps/web/src/types/schemaEditor.ts
@@ -1,0 +1,40 @@
+export type DataType = "str" | "int" | "float" | "bool" | "object" | "arr" | "js" | "enum";
+
+export type ChainType = "or" | "and";
+
+export interface Rule {
+  type: string;
+  value?: any;
+  message?: string;
+  [key: string]: any;
+}
+
+export interface SchemaProperty {
+  id?: string; // Client-side only ID for React keys
+  key: string;
+  dataType: DataType;
+  rules?: Rule[];
+  required?: boolean;
+  properties?: SchemaProperty[]; // For 'object' type
+  items?: SchemaProperty; // For 'arr' type
+  chain?: SchemaChain[]; // For complex nested logic
+  js?: string; // For custom JS validation
+}
+
+export interface SchemaChain {
+  chainType: ChainType;
+  properties?: SchemaProperty[];
+  // If a chain can have its own data type (unlikely, usually it's just a grouping of properties)
+}
+
+export interface ValidationSchema {
+  dataType: DataType;
+  properties?: SchemaProperty[];
+  chain?: SchemaChain[];
+  rules?: Rule[]; // Root level rules
+  js?: string; // For root level custom JS validation
+}
+
+export interface SchemaEditorRef {
+  save: () => void;
+}

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -78,6 +78,7 @@ export default defineConfig({
 					items: [
 						{ text: "Overview", link: "/getting-started/" },
 						{ text: "Guide", link: "/getting-started/basics" },
+						{ text: "Routing & Validation", link: "/getting-started/routing" },
 						{ text: "Contributing", link: "/getting-started/contributing" },
 						{ text: "Local Testing", link: "/getting-started/local-testing" },
 					],

--- a/docs/getting-started/routing.md
+++ b/docs/getting-started/routing.md
@@ -1,0 +1,145 @@
+---
+title: Routing & Request Validation
+description: How Fluxify maps incoming requests to your API workflows, validates request data, and returns errors to clients.
+---
+
+# Routing & Request Validation
+
+When someone calls your API, Fluxify automatically figures out which workflow to run, checks the request data against your defined rules, and only then starts executing your logic. This page explains how that works and what your callers can expect to receive.
+
+---
+
+## How Requests Are Matched
+
+Every route you create in Fluxify has an HTTP method (like `GET` or `POST`) and a URL path (like `/users/:id`). When a request comes in, Fluxify matches it to the right workflow instantly.
+
+- If a match is found, the workflow runs.
+- If nothing matches, the caller gets a `404` response.
+
+Path parameters like `:id` or `:slug` are captured automatically and made available inside your workflow.
+
+::: tip Hot Reloading
+Routes update in real time. When you create or change a route in the dashboard, the change takes effect immediately — no server restart needed.
+:::
+
+---
+
+## What Happens Before Your Workflow Runs
+
+Before Fluxify executes a single block in your workflow, it runs through a quick validation pipeline:
+
+1. **Match the route** — find the right workflow for this request.
+2. **Parse the request body** — read the JSON data sent by the caller.
+3. **Validate the body** — check it against your Body Schema (if set).
+4. **Validate query parameters** — check URL query strings against your Query Schema (if set).
+5. **Validate path parameters** — check URL path values against your Params Schema (if set).
+6. **Run your workflow** — only if everything above passed.
+
+If any validation step fails, the workflow never runs and the caller immediately gets a clear error response.
+
+---
+
+## Request Validation
+
+Each route optionally has three schemas you can configure in the Schema Editor:
+
+| Schema | What It Validates |
+| :--- | :--- |
+| **Body Schema** | The JSON data in the request body (`POST`, `PUT`) |
+| **Query Schema** | URL query parameters (e.g. `?page=2&limit=10`) |
+| **Params Schema** | URL path values (e.g. the `42` in `/users/42`) |
+
+You only need to configure the ones that matter for your route — unused schemas are simply skipped.
+
+### Available Data Types
+
+| Type | What It Accepts |
+| :--- | :--- |
+| `String` | Any text, with optional rules like minimum length, maximum length, or a required format |
+| `Integer` | A whole number, with optional min/max |
+| `Float` | A decimal number, with optional min/max |
+| `Boolean` | `true` or `false` |
+| `Array` | A list of items, with optional min/max item count |
+| `Object` | A structured set of named fields (can be nested) |
+| `Enum` | One specific value from a predefined list |
+| `Use JavaScript` | Custom validation logic you write yourself |
+
+### Marking Fields as Required
+
+Each field in your schema can be marked as **required** or optional. Required fields must be present — if they're missing, the request is rejected with an error.
+
+### Custom JavaScript Validation
+
+For rules that can't be expressed with the built-in types, you can switch a field to **Use JavaScript** and write your own logic. Your code receives the field's value and should either return `true` (validation passes) or throw a `ValidationError` with a custom message.
+
+```javascript
+// Example: reject discount codes that don't start with "SALE"
+if (!input.startsWith("SALE")) {
+  throw new ValidationError({
+    code: "INVALID_CODE",
+    message: "Discount codes must start with SALE"
+  });
+}
+return true;
+```
+
+Whatever you pass to `ValidationError` is returned directly to the caller — giving you full control over your error messages.
+
+---
+
+## Validation Error Response
+
+When a request fails validation, the caller receives a `400 Bad Request` with a JSON body that clearly describes what went wrong.
+
+```json
+{
+  "message": "Body validation failed",
+  "errors": [
+    {
+      "path": "address.zipCode",
+      "property": "zipCode",
+      "errors": ["String must contain at least 5 character(s)"]
+    },
+    {
+      "path": "age",
+      "property": "age",
+      "errors": ["Expected number, received string"]
+    }
+  ]
+}
+```
+
+| Field | Description |
+| :--- | :--- |
+| `message` | Which part of the request failed: body, query, or path parameters |
+| `errors[].path` | The full path to the failing field using dot notation (e.g. `address.zipCode`) |
+| `errors[].property` | Just the field name that failed (e.g. `zipCode`) |
+| `errors[].errors` | One or more error messages for that field |
+
+When a custom JavaScript validator throws a `ValidationError`, its payload appears verbatim in `errors[].errors` — exactly as you wrote it.
+
+---
+
+## Error Responses at a Glance
+
+Here's every possible outcome and what the caller receives:
+
+| Situation | Status | Response |
+| :--- | :--- | :--- |
+| Route doesn't exist | `404` | `{ "message": "Route not found" }` |
+| Validation failed | `400` | `{ "message": "...", "errors": [...] }` |
+| Workflow error | `500` | `{ "error": "description" }` |
+| Unexpected crash | `500` | `{ "message": "Internal server error" }` |
+| Success | `200` | Whatever your Response block returns |
+
+::: info Custom Status Codes
+Your workflow can return any HTTP status code you choose using the **Response** block — the defaults above only apply when no status is explicitly set.
+:::
+
+---
+
+## Next Steps
+
+- 🧩 [Explore the Blocks Reference](../blocks/index.md) — build the workflow logic that runs after validation
+- ✍️ [Scripting Guide](../scripting/index.md) — learn more about writing custom JavaScript
+- ⚙️ [App Config](../concepts/app-config.md) — manage secrets your validators can reference

--- a/packages/adapters/db/mongoDbAdapter.test.ts
+++ b/packages/adapters/db/mongoDbAdapter.test.ts
@@ -15,7 +15,7 @@ import { fakerEN as faker } from "@faker-js/faker";
 import { docker, pullImage } from "./testHelpers";
 
 const containerName = "fluxify-mongo-adapter-test";
-const exposedPort = 27017;
+const exposedPort = Math.floor(Math.random() * (65000 - 20000 + 1)) + 20000;
 
 let container: Docker.Container | null = null;
 let db: any;

--- a/packages/adapters/db/mySqlAdapter.test.ts
+++ b/packages/adapters/db/mySqlAdapter.test.ts
@@ -15,7 +15,7 @@ import { faker } from "@faker-js/faker";
 import { docker, pullImage } from "./testHelpers";
 
 const containerName = "fluxify-mysql-adapter-test";
-const exposedPort = 33006;
+const exposedPort = Math.floor(Math.random() * (65000 - 20000 + 1)) + 20000;
 
 let container: Docker.Container | null = null;
 let db: any;

--- a/packages/adapters/db/postgresAdapter.test.ts
+++ b/packages/adapters/db/postgresAdapter.test.ts
@@ -15,7 +15,7 @@ import { faker } from "@faker-js/faker";
 import { docker, pullImage } from "./testHelpers";
 
 const containerName = "fluxify-pg-adapter-test";
-const exposedPort = 54320;
+const exposedPort = Math.floor(Math.random() * (65000 - 20000 + 1)) + 20000;
 
 let container: Docker.Container | null = null;
 let db: any;

--- a/packages/lib/routing/parser.ts
+++ b/packages/lib/routing/parser.ts
@@ -4,6 +4,9 @@ export type HttpRoute = {
   projectName: string;
   path: string;
   method: "GET" | "POST" | "PUT" | "DELETE";
+  bodySchema?: any;
+  querySchema?: any;
+  paramsSchema?: any;
 };
 
 export type RouteTree = {
@@ -13,6 +16,9 @@ export type RouteTree = {
   id?: string;
   projectId?: string;
   projectName?: string;
+  bodySchema?: any;
+  querySchema?: any;
+  paramsSchema?: any;
 };
 
 export class HttpRouteParser {
@@ -60,6 +66,9 @@ export class HttpRouteParser {
         id: route.routeId,
         projectId: route.projectId,
         projectName: route.projectName,
+        bodySchema: route.bodySchema,
+        querySchema: route.querySchema,
+        paramsSchema: route.paramsSchema,
       };
     }
   }
@@ -71,6 +80,9 @@ export class HttpRouteParser {
     routeParams?: Record<string, string>;
     projectId: string;
     projectName: string;
+    bodySchema?: any;
+    querySchema?: any;
+    paramsSchema?: any;
   } | null {
     const parts = path.split("/").filter((p) => p.trim() != "");
     let current = this.routesTree;
@@ -102,6 +114,9 @@ export class HttpRouteParser {
         routeParams: params,
         projectId: current["<ID>"].projectId!,
         projectName: current["<ID>"].projectName!,
+        bodySchema: current["<ID>"].bodySchema,
+        querySchema: current["<ID>"].querySchema,
+        paramsSchema: current["<ID>"].paramsSchema,
       };
     }
     return null;


### PR DESCRIPTION
## Summary

Closes #65

This PR implements end-to-end request validation for API routes. Users can now define validation schemas for their route's request body, query parameters, and path parameters directly in the route settings. Invalid requests are rejected before any workflow logic runs.

---

## What Changed

### 🎨 Schema Editor UI (pps/web)
- **New SchemaEditor component** — a full visual editor for building typed validation schemas. Supports all data types: String, Integer, Float, Boolean, Array, Object, Enum, and custom JavaScript.
- **Per-type rule configuration** — drawers for configuring rules like minLength, max, egex, minItems, enum values, etc.
- **Custom JS validator support** — write inline JS that receives the field value; throw ValidationError with a custom payload for rich error messages.
- **Schema preview tab** — rendered read-only view of the defined schema.
- **Locked mode** — a locked prop makes the editor read-only (keys, types, add/remove all frozen). Supports 	ypeOverrides to selectively allow type changes on specific property paths, and llowedRootSchemaTypes to restrict root type choices.
- **Multi-step route creation wizard** — RouteFormStepper + OnboardingStepper replacing the old inline route creation form.
- **EditRouteSettings form** — dedicated settings page section for editing body, query, and params schemas per route.

### ⚙️ Validation Engine (pps/server)
- **schemaParser.ts** — builds a live Zod schema from the stored JSON schema definition. Supports coercion mode for query/path params (since HTTP transmits those as raw strings).
- **alidationSchemaZod.ts** — Zod schema used to validate the schema definition itself before storing in the DB.
- **ValidationError class** — thrown from custom JS validators; its payload passes through verbatim to the API response.
- **Comprehensive unit tests** — covers primitives, nested objects, arrays, enums, custom JS validators, ValidationError interception, and boundary/edge cases.

### 🔀 Request Router (pps/server + packages/lib)
- **Pre-execution validation pipeline** — handleRequest now validates body (strict), query params (coerced), and path params (coerced) before starting block execution.
- **Structured 400 errors** — validation failures return { message, errors: [{ path, property, errors[] }] }.
- **HttpRouteParser updated** — odySchema, querySchema, and paramsSchema are now loaded from the DB and carried through the in-memory route tree, making schema lookups zero-cost at request time.
- **outesLoader updated** — fetches schema columns alongside route identity.

### 🗄️ Database
- **New DB migration** (