### PR TITLE
feat: implement canvas context menu, custom block refactoring, and keyboard accessibility

### DIFF
--- a/apps/server/src/api/v1/custom-blocks/create/dto.ts
+++ b/apps/server/src/api/v1/custom-blocks/create/dto.ts
@@ -45,8 +45,6 @@ export const requestBodySchema = z.object({
   iconUrl: z.string().max(68266).optional(),
   projectId: z.string(),
   inputParams: z.array(inputParamSchema).optional(),
-  sourceType: z.enum(["plugin", "inhouse"]).optional(),
-  source: z.string().optional(),
 });
 
 export const responseSchema = z.object({

--- a/apps/server/src/api/v1/custom-blocks/create/service.ts
+++ b/apps/server/src/api/v1/custom-blocks/create/service.ts
@@ -21,7 +21,7 @@ export default async function handleRequest(
 				`project with id ${data.projectId} does not exist`,
 			);
 		}
-		data.name = `${data.sourceType || "inhouse"}.${data.source || "project"}.${data.name}`;
+		data.name = `user_defined.project.${data.name}`;
 		const existingBlock = await checkCustomBlockExist(
 			data.projectId,
 			data.name,

--- a/apps/web/src/app/[projectId]/custom-blocks/create/CustomBlockForm.tsx
+++ b/apps/web/src/app/[projectId]/custom-blocks/create/CustomBlockForm.tsx
@@ -23,32 +23,7 @@ import { APP_ROUTES } from "@/constants/routes";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { notifications } from "@mantine/notifications";
 import InputParamsEditor from "./InputParamsEditor";
-import {
-  TbBrandPython,
-  TbBrandJavascript,
-  TbDatabase,
-  TbCloud,
-  TbMail,
-  TbMessage,
-  TbApi,
-  TbWebhook,
-  TbLock,
-  TbKey,
-  TbSearch,
-} from "react-icons/tb";
-
-const premadeIcons = [
-  { value: "python", icon: <TbBrandPython size={24} /> },
-  { value: "javascript", icon: <TbBrandJavascript size={24} /> },
-  { value: "database", icon: <TbDatabase size={24} /> },
-  { value: "cloud", icon: <TbCloud size={24} /> },
-  { value: "mail", icon: <TbMail size={24} /> },
-  { value: "message", icon: <TbMessage size={24} /> },
-  { value: "api", icon: <TbApi size={24} /> },
-  { value: "webhook", icon: <TbWebhook size={24} /> },
-  { value: "lock", icon: <TbLock size={24} /> },
-  { value: "key", icon: <TbKey size={24} /> },
-];
+import CustomBlockIconSelector from "@/components/forms/CustomBlockIconSelector";
 
 export default function CustomBlockForm({
   initialValues,
@@ -62,7 +37,7 @@ export default function CustomBlockForm({
   const { projectId } = useParams();
   const router = useRouter();
   const queryClient = useQueryClient();
-  const [iconSearch, setIconSearch] = React.useState("");
+
 
   const form = useForm({
     initialValues: initialValues || {
@@ -72,8 +47,6 @@ export default function CustomBlockForm({
       icon: "premade-list" as "premade-list" | "custom",
       iconUrl: "",
       inputParams: [],
-      sourceType: "inhouse" as const,
-      source: "",
     },
     validate: {
       name: (val) =>
@@ -163,90 +136,7 @@ export default function CustomBlockForm({
             <Text fw={600} size="lg">
               Icon
             </Text>
-            <Tabs
-              value={form.values.icon}
-              onChange={(value) =>
-                form.setFieldValue("icon", value as "premade-list" | "custom")
-              }
-              color="violet"
-            >
-              <Tabs.List>
-                <Tabs.Tab value="premade-list">Premade</Tabs.Tab>
-                <Tabs.Tab value="custom">Custom (Base64/URL)</Tabs.Tab>
-              </Tabs.List>
-
-              <Tabs.Panel value="premade-list" pt="md">
-                <Stack gap="md">
-                  <TextInput
-                    placeholder="Search icons..."
-                    leftSection={<TbSearch size={16} />}
-                    value={iconSearch}
-                    onChange={(e) => setIconSearch(e.currentTarget.value)}
-                  />
-                  <ScrollArea h={200}>
-                    <SimpleGrid cols={5} spacing="md">
-                      {premadeIcons
-                        .filter((pi) =>
-                          pi.value.toLowerCase().includes(iconSearch.toLowerCase())
-                        )
-                        .map((pi) => (
-                          <Paper
-                            key={pi.value}
-                            withBorder
-                            p="sm"
-                            style={{
-                              cursor: "pointer",
-                              borderColor:
-                                form.values.iconUrl === pi.value
-                                  ? "var(--mantine-color-violet-filled)"
-                                  : "var(--mantine-color-gray-3)",
-                              backgroundColor:
-                                form.values.iconUrl === pi.value
-                                  ? "var(--mantine-color-violet-light)"
-                                  : "transparent",
-                            }}
-                            onClick={() => form.setFieldValue("iconUrl", pi.value)}
-                          >
-                            <Center>{pi.icon}</Center>
-                          </Paper>
-                        ))}
-                    </SimpleGrid>
-                  </ScrollArea>
-                </Stack>
-              </Tabs.Panel>
-
-              <Tabs.Panel value="custom" pt="md">
-                <Group align="flex-start" wrap="nowrap">
-                  <Paper
-                    withBorder
-                    w={100}
-                    h={100}
-                    style={{ overflow: "hidden", display: 'flex', alignItems: 'center', justifyContent: 'center', backgroundColor: '#f8f9fa', flexShrink: 0 }}
-                  >
-                    {form.values.iconUrl ? (
-                      <Image
-                        src={form.values.iconUrl}
-                        w={100}
-                        h={100}
-                        fit="contain"
-                        alt="Icon preview"
-                      />
-                    ) : (
-                      <Text size="xs" c="dimmed">
-                        100x100
-                      </Text>
-                    )}
-                  </Paper>
-                  <Textarea
-                    label="Icon URL or Base64"
-                    placeholder="data:image/svg+xml;base64,..."
-                    flex={1}
-                    rows={4}
-                    {...form.getInputProps("iconUrl")}
-                  />
-                </Group>
-              </Tabs.Panel>
-            </Tabs>
+            <CustomBlockIconSelector form={form} />
           </Stack>
         </Paper>
 

--- a/apps/web/src/components/editor/flowEditor/blockCanvas.tsx
+++ b/apps/web/src/components/editor/flowEditor/blockCanvas.tsx
@@ -279,9 +279,7 @@ const BlockCanvas = () => {
 
 				<BlockSettingsDialog />
 				<BlockSearchDrawer />
-				{contextMenuPosition && (
-					<CanvasContextMenu position={contextMenuPosition} onClose={() => setContextMenuPosition(null)} />
-				)}
+				<CanvasContextMenu position={contextMenuPosition} onClose={() => setContextMenuPosition(null)} />
 			</BlockCanvasContext.Provider>
 		</Box>
 	);

--- a/apps/web/src/components/editor/flowEditor/blockCanvas.tsx
+++ b/apps/web/src/components/editor/flowEditor/blockCanvas.tsx
@@ -1,12 +1,12 @@
 "use client";
 import { Box } from "@mantine/core";
-import { Background, Panel, ReactFlow } from "@xyflow/react";
+import { Background, Panel, ReactFlow, Node, useReactFlow } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { blocksList } from "../blocks/blocksList";
 import { BaseBlockType } from "@/types/block";
 import CustomBlockNode from "../blocks/customBlockNode";
 import { customBlocksQueries } from "@/query/customBlocksQuery";
-import { useMemo } from "react";
+import { useMemo, useState, useCallback } from "react";
 import {
 	useCanvasActionsStore,
 	useCanvasBlocksStore,
@@ -30,6 +30,7 @@ import {
 } from "@/store/blockDataStore";
 import { useEditorChangeTrackerStore } from "@/store/editor";
 import { useFlowEditorContext } from "./flowEditorContext";
+import CanvasContextMenu from "./contextMenu/canvasContextMenu";
 
 const BlockCanvas = () => {
 	const { readonly, entityId, entityType, features, projectId } = useFlowEditorContext();
@@ -84,6 +85,52 @@ const BlockCanvas = () => {
 	}, [customBlocks, blocks]);
 
 	useCanvasSnapshot();
+	const { getNodes, getEdges } = useReactFlow();
+
+	const copySelection = useCallback(async () => {
+		const selectedBlocks = getNodes().filter(n => n.selected);
+		const selectedEdges = getEdges().filter(e => e.selected);
+
+		if (selectedBlocks.length === 0 && selectedEdges.length === 0) return;
+
+		const blocks = selectedBlocks.map(node => ({
+			id: node.id,
+			position: node.position,
+			type: node.type!,
+			data: blockDataStore[node.id],
+		}));
+
+		const edges = selectedEdges.map(edge => ({
+			id: edge.id,
+			source: edge.source,
+			target: edge.target,
+			sourceHandle: edge.sourceHandle!,
+			targetHandle: edge.targetHandle!,
+			type: edge.type!,
+		}));
+
+		await navigator.clipboard.writeText(
+			JSON.stringify({ source: "FLUXIFY/COPY_PASTE", data: { blocks, edges } })
+		);
+	}, [getNodes, getEdges, blockDataStore]);
+
+	const [contextMenuPosition, setContextMenuPosition] = useState<{ x: number; y: number } | null>(null);
+
+	const onPaneContextMenu = useCallback(
+		(event: React.MouseEvent | MouseEvent) => {
+			event.preventDefault();
+			setContextMenuPosition({ x: event.clientX, y: event.clientY });
+		},
+		[setContextMenuPosition],
+	);
+
+	const onNodeContextMenu = useCallback(
+		(event: React.MouseEvent | MouseEvent, node: Node) => {
+			event.preventDefault();
+			setContextMenuPosition({ x: event.clientX, y: event.clientY });
+		},
+		[setContextMenuPosition],
+	);
 
 	function doAction(_type: "undo" | "redo") {
 		actionsStore.disable();
@@ -176,6 +223,8 @@ const BlockCanvas = () => {
 					deleteBulk: deleteBulkWithHistory,
 					onSave,
 					duplicateSelection,
+					copySelection,
+					pasteSelection,
 				}}
 			>
 				<Box style={{ position: "absolute", zIndex: 10, right: 0 }} p="lg">
@@ -183,6 +232,8 @@ const BlockCanvas = () => {
 				</Box>
 
 				<ReactFlow
+					onPaneContextMenu={onPaneContextMenu}
+					onNodeContextMenu={onNodeContextMenu}
 					deleteKeyCode=""
 					onEdgesChange={(changes) => {
 						changes.forEach((c) => {
@@ -223,6 +274,7 @@ const BlockCanvas = () => {
 
 				<BlockSettingsDialog />
 				<BlockSearchDrawer />
+				<CanvasContextMenu position={contextMenuPosition} onClose={() => setContextMenuPosition(null)} />
 			</BlockCanvasContext.Provider>
 		</Box>
 	);

--- a/apps/web/src/components/editor/flowEditor/blockCanvas.tsx
+++ b/apps/web/src/components/editor/flowEditor/blockCanvas.tsx
@@ -234,6 +234,9 @@ const BlockCanvas = () => {
 				<ReactFlow
 					onPaneContextMenu={onPaneContextMenu}
 					onNodeContextMenu={onNodeContextMenu}
+					onSelectionContextMenu={onPaneContextMenu}
+					onPaneClick={() => setContextMenuPosition(null)}
+					onNodeClick={() => setContextMenuPosition(null)}
 					deleteKeyCode=""
 					onEdgesChange={(changes) => {
 						changes.forEach((c) => {
@@ -274,7 +277,9 @@ const BlockCanvas = () => {
 
 				<BlockSettingsDialog />
 				<BlockSearchDrawer />
-				<CanvasContextMenu position={contextMenuPosition} onClose={() => setContextMenuPosition(null)} />
+				{contextMenuPosition && (
+					<CanvasContextMenu position={contextMenuPosition} onClose={() => setContextMenuPosition(null)} />
+				)}
 			</BlockCanvasContext.Provider>
 		</Box>
 	);

--- a/apps/web/src/components/editor/flowEditor/blockCanvas.tsx
+++ b/apps/web/src/components/editor/flowEditor/blockCanvas.tsx
@@ -89,9 +89,11 @@ const BlockCanvas = () => {
 
 	const copySelection = useCallback(async () => {
 		const selectedBlocks = getNodes().filter(n => n.selected);
-		const selectedEdges = getEdges().filter(e => e.selected);
+		
+		if (selectedBlocks.length === 0) return;
 
-		if (selectedBlocks.length === 0 && selectedEdges.length === 0) return;
+		const selectedBlockIds = selectedBlocks.map(n => n.id);
+		const edgesToCopy = getEdges().filter(e => selectedBlockIds.includes(e.source) && selectedBlockIds.includes(e.target));
 
 		const blocks = selectedBlocks.map(node => ({
 			id: node.id,
@@ -100,7 +102,7 @@ const BlockCanvas = () => {
 			data: blockDataStore[node.id],
 		}));
 
-		const edges = selectedEdges.map(edge => ({
+		const edges = edgesToCopy.map(edge => ({
 			id: edge.id,
 			source: edge.source,
 			target: edge.target,

--- a/apps/web/src/components/editor/flowEditor/blockSearchList.tsx
+++ b/apps/web/src/components/editor/flowEditor/blockSearchList.tsx
@@ -9,7 +9,7 @@ import { BlockTypes } from "@/types/block";
 import { customBlocksQueries } from "@/query/customBlocksQuery";
 import { useFlowEditorContext } from "./flowEditorContext";
 import { getCustomBlockIcon } from "../blocks/customBlockNode";
-import { TbCodeVariable } from "react-icons/tb";
+import { TbCodeVariable, TbPlugConnected } from "react-icons/tb";
 
 const BlockSearchList = () => {
   const { projectId } = useFlowEditorContext();
@@ -35,14 +35,15 @@ const BlockSearchList = () => {
 
     if (customBlocks) {
       customBlocks.forEach((cb) => {
-        let cat = cb.sourceType === "inhouse" ? "User Defined" : cb.source || "Plugin";
+        const isUserDefined = cb.name?.startsWith("user_defined.") || cb.sourceType === "inhouse";
+        let cat = isUserDefined ? "User Defined Blocks" : "Plugin Blocks";
         if (!categories.find((c) => c.category === cat) && !newCategoriesMap[cat]) {
           newCategoriesMap[cat] = true;
           categories.push({
             id: crypto.randomUUID(),
             category: cat as any,
-            description: `Blocks from ${cat}`,
-            icon: <TbCodeVariable size={20} />,
+            description: isUserDefined ? "Your custom built blocks" : "Blocks from plugins",
+            icon: isUserDefined ? <TbCodeVariable size={20} /> : <TbPlugConnected size={20} />,
           });
         }
       });
@@ -54,7 +55,8 @@ const BlockSearchList = () => {
     const blocks = [...blocksForSearch];
     if (customBlocks) {
       customBlocks.forEach((cb) => {
-        let cat = cb.sourceType === "inhouse" ? "User Defined" : cb.source || "Plugin";
+        const isUserDefined = cb.name?.startsWith("user_defined.") || cb.sourceType === "inhouse";
+        let cat = isUserDefined ? "User Defined Blocks" : "Plugin Blocks";
         blocks.push({
           id: cb.id,
           title: cb.label || cb.name,

--- a/apps/web/src/components/editor/flowEditor/canvasKeyboardAccessibility.tsx
+++ b/apps/web/src/components/editor/flowEditor/canvasKeyboardAccessibility.tsx
@@ -19,7 +19,7 @@ const CanvasKeyboardAccessibility = () => {
 	const [selectedEdges, setSelectedEdges] = useState<string[]>([]);
 	const { open: openSearchbar } = useEditorSearchbarStore();
 	const { open } = useEditorBlockSettingsStore();
-	const { deleteBulk, undo, redo, duplicateSelection } =
+	const { deleteBulk, undo, redo, duplicateSelection, copySelection } =
 		useContext(BlockCanvasContext);
 	const onChange = useCallback(
 		({ nodes, edges }: { nodes: Node[]; edges: Edge[] }) => {
@@ -47,13 +47,7 @@ const CanvasKeyboardAccessibility = () => {
 		duplicateSelection,
 	]); // duplicate selection
 	useHotkeys("ctrl+z", undo, { preventDefault: true }, [undo]); // undo
-	useHotkeys("ctrl+c", onCopySelection, { preventDefault: true }, [
-		selectedBlocks,
-		selectedEdges,
-		blockData,
-		getNodes,
-		getEdges,
-	]); // copy selection
+	useHotkeys("ctrl+c", copySelection, { preventDefault: true }, [copySelection]); // copy selection
 	useHotkeys("ctrl+y, ctrl+shift+z", redo, { preventDefault: true }, [redo]); // redo
 	useHotkeys("delete, backspace", onDeleteClicked, { preventDefault: true }, [
 		selectedBlocks,
@@ -69,51 +63,6 @@ const CanvasKeyboardAccessibility = () => {
 		onSave();
 	}
 
-	async function onCopySelection() {
-		if (selectedBlocks.length === 0 && selectedEdges.length === 0) {
-			return;
-		}
-		// {blocks: [{id, position, type, data}], edges: [{id, source, target, sourceHandle, targetHandle, type}]}
-		const blocks: {
-			id: string;
-			position: { x: number; y: number };
-			type: string;
-			data: any;
-		}[] = [];
-		const edges: {
-			id: string;
-			source: string;
-			target: string;
-			sourceHandle: string;
-			targetHandle: string;
-			type: string;
-		}[] = [];
-		getNodes().forEach((node) => {
-			if (selectedBlocks.includes(node.id)) {
-				blocks.push({
-					id: node.id,
-					position: node.position,
-					type: node.type!,
-					data: blockData[node.id],
-				});
-			}
-		});
-		getEdges().forEach((edge) => {
-			if (selectedEdges.includes(edge.id)) {
-				edges.push({
-					id: edge.id,
-					source: edge.source,
-					target: edge.target,
-					sourceHandle: edge.sourceHandle!,
-					targetHandle: edge.targetHandle!,
-					type: edge.type!,
-				});
-			}
-		});
-		await navigator.clipboard.writeText(
-			JSON.stringify({ source: "FLUXIFY/COPY_PASTE", data: { blocks, edges } }),
-		);
-	}
 
 	function onDuplicateSelection() {
 		if (selectedBlocks.length === 0) return;

--- a/apps/web/src/components/editor/flowEditor/canvasKeyboardAccessibility.tsx
+++ b/apps/web/src/components/editor/flowEditor/canvasKeyboardAccessibility.tsx
@@ -19,7 +19,7 @@ const CanvasKeyboardAccessibility = () => {
 	const [selectedEdges, setSelectedEdges] = useState<string[]>([]);
 	const { open: openSearchbar } = useEditorSearchbarStore();
 	const { open } = useEditorBlockSettingsStore();
-	const { deleteBulk, undo, redo, duplicateSelection, copySelection } =
+	const { deleteBulk, undo, redo, duplicateSelection, copySelection, pasteSelection } =
 		useContext(BlockCanvasContext);
 	const onChange = useCallback(
 		({ nodes, edges }: { nodes: Node[]; edges: Edge[] }) => {
@@ -48,6 +48,7 @@ const CanvasKeyboardAccessibility = () => {
 	]); // duplicate selection
 	useHotkeys("ctrl+z", undo, { preventDefault: true }, [undo]); // undo
 	useHotkeys("ctrl+c", copySelection, { preventDefault: true }, [copySelection]); // copy selection
+	useHotkeys("ctrl+v", pasteSelection, { preventDefault: true }, [pasteSelection]); // paste selection
 	useHotkeys("ctrl+y, ctrl+shift+z", redo, { preventDefault: true }, [redo]); // redo
 	useHotkeys("delete, backspace", onDeleteClicked, { preventDefault: true }, [
 		selectedBlocks,

--- a/apps/web/src/components/editor/flowEditor/contextMenu/canvasContextMenu.tsx
+++ b/apps/web/src/components/editor/flowEditor/contextMenu/canvasContextMenu.tsx
@@ -26,8 +26,8 @@ export default function CanvasContextMenu({ position, onClose }: Props) {
   const { open: openSearchbar } = useEditorSearchbarStore();
   const { getNodes, getEdges } = useReactFlow();
 
-  const [selectedBlocks, setSelectedBlocks] = useState<string[]>([]);
-  const [selectedEdges, setSelectedEdges] = useState<string[]>([]);
+  const [selectedBlocks, setSelectedBlocks] = useState<string[]>(() => getNodes().filter(n => n.selected).map(n => n.id));
+  const [selectedEdges, setSelectedEdges] = useState<string[]>(() => getEdges().filter(e => e.selected).map(e => e.id));
   const [refactorModalOpened, setRefactorModalOpened] = useState(false);
 
   const onChange = useCallback(({ nodes, edges }: { nodes: Node[]; edges: Edge[] }) => {
@@ -48,7 +48,16 @@ export default function CanvasContextMenu({ position, onClose }: Props) {
 
   return (
     <>
-      <Menu opened={!!position && !refactorModalOpened} onClose={onClose} shadow="md" width={220}>
+      <Menu 
+        opened={!!position && !refactorModalOpened} 
+        onClose={onClose} 
+        shadow="md" 
+        width={220}
+        styles={{
+          item: { padding: "4px 10px", minHeight: 32 },
+          itemLabel: { fontSize: 13 },
+        }}
+      >
         <Menu.Target>
           <Box
             style={{

--- a/apps/web/src/components/editor/flowEditor/contextMenu/canvasContextMenu.tsx
+++ b/apps/web/src/components/editor/flowEditor/contextMenu/canvasContextMenu.tsx
@@ -72,9 +72,9 @@ export default function CanvasContextMenu({ position, onClose }: Props) {
         </Menu.Target>
 
         <Menu.Dropdown>
-          <Menu.Item fz="sm"
+          <Menu.Item fz={13} style={{ minHeight: 28, padding: "4px 8px" }}
             leftSection={<TbPlus size={14} />}
-            rightSection={<Kbd ml="md" size="xs">⇧ + A</Kbd>}
+            rightSection={<Kbd ml="md" size="xs" p="2px 4px">⇧ + A</Kbd>}
             onClick={() => {
               onClose();
               setTimeout(() => openSearchbar(), 0);
@@ -85,9 +85,9 @@ export default function CanvasContextMenu({ position, onClose }: Props) {
           
           <Menu.Divider />
           
-          <Menu.Item fz="sm"
+          <Menu.Item fz={13} style={{ minHeight: 28, padding: "4px 8px" }}
             leftSection={<TbArrowBackUp size={14} />}
-            rightSection={<Kbd ml="md" size="xs">Ctrl + Z</Kbd>}
+            rightSection={<Kbd ml="md" size="xs" p="2px 4px">Ctrl + Z</Kbd>}
             onClick={() => {
               undo();
               onClose();
@@ -95,9 +95,9 @@ export default function CanvasContextMenu({ position, onClose }: Props) {
           >
             Undo
           </Menu.Item>
-          <Menu.Item fz="sm"
+          <Menu.Item fz={13} style={{ minHeight: 28, padding: "4px 8px" }}
             leftSection={<TbArrowForwardUp size={14} />}
-            rightSection={<Kbd ml="md" size="xs">Ctrl + Y</Kbd>}
+            rightSection={<Kbd ml="md" size="xs" p="2px 4px">Ctrl + Y</Kbd>}
             onClick={() => {
               redo();
               onClose();
@@ -107,9 +107,9 @@ export default function CanvasContextMenu({ position, onClose }: Props) {
           </Menu.Item>
 
           <Menu.Divider />
-          <Menu.Item fz="sm"
+          <Menu.Item fz={13} style={{ minHeight: 28, padding: "4px 8px" }}
             leftSection={<TbCopy size={14} />}
-            rightSection={<Kbd ml="md" size="xs">Ctrl + C</Kbd>}
+            rightSection={<Kbd ml="md" size="xs" p="2px 4px">Ctrl + C</Kbd>}
             disabled={!hasSelection}
             onClick={() => {
               copySelection();
@@ -118,9 +118,9 @@ export default function CanvasContextMenu({ position, onClose }: Props) {
           >
             Copy
           </Menu.Item>
-          <Menu.Item fz="sm"
+          <Menu.Item fz={13} style={{ minHeight: 28, padding: "4px 8px" }}
             leftSection={<TbClipboardText size={14} />}
-            rightSection={<Kbd ml="md" size="xs">Ctrl + V</Kbd>}
+            rightSection={<Kbd ml="md" size="xs" p="2px 4px">Ctrl + V</Kbd>}
             onClick={() => {
               pasteSelection();
               onClose();
@@ -128,9 +128,9 @@ export default function CanvasContextMenu({ position, onClose }: Props) {
           >
             Paste
           </Menu.Item>
-          <Menu.Item fz="sm"
+          <Menu.Item fz={13} style={{ minHeight: 28, padding: "4px 8px" }}
             leftSection={<TbDuplicate size={14} />}
-            rightSection={<Kbd ml="md" size="xs">⇧ + D</Kbd>}
+            rightSection={<Kbd ml="md" size="xs" p="2px 4px">⇧ + D</Kbd>}
             disabled={!hasSelection}
             onClick={() => {
               duplicateSelection(selectedBlocks);
@@ -142,7 +142,7 @@ export default function CanvasContextMenu({ position, onClose }: Props) {
 
           <Menu.Divider />
 
-          <Menu.Item fz="sm"
+          <Menu.Item fz={13} style={{ minHeight: 28, padding: "4px 8px" }}
             leftSection={<TbTransform size={14} />}
             disabled={!canRefactor}
             onClick={() => setRefactorModalOpened(true)}
@@ -152,9 +152,9 @@ export default function CanvasContextMenu({ position, onClose }: Props) {
 
           <Menu.Divider />
 
-          <Menu.Item fz="sm"
+          <Menu.Item fz={13} style={{ minHeight: 28, padding: "4px 8px" }}
             leftSection={<TbDeviceFloppy size={14} />}
-            rightSection={<Kbd ml="md" size="xs">Ctrl + S</Kbd>}
+            rightSection={<Kbd ml="md" size="xs" p="2px 4px">Ctrl + S</Kbd>}
             onClick={() => {
               onSave();
               onClose();

--- a/apps/web/src/components/editor/flowEditor/contextMenu/canvasContextMenu.tsx
+++ b/apps/web/src/components/editor/flowEditor/contextMenu/canvasContextMenu.tsx
@@ -65,8 +65,8 @@ export default function CanvasContextMenu({ position, onClose }: Props) {
             leftSection={<TbPlus size={16} />}
             rightSection={<Kbd ml="md">⇧ + A</Kbd>}
             onClick={() => {
-              openSearchbar();
               onClose();
+              setTimeout(() => openSearchbar(), 0);
             }}
           >
             Add new

--- a/apps/web/src/components/editor/flowEditor/contextMenu/canvasContextMenu.tsx
+++ b/apps/web/src/components/editor/flowEditor/contextMenu/canvasContextMenu.tsx
@@ -1,0 +1,147 @@
+import React, { useContext, useState, useCallback } from "react";
+import { Menu, Kbd, Group, Text, Box } from "@mantine/core";
+import { BlockCanvasContext } from "@/context/blockCanvas";
+import { useReactFlow, useOnSelectionChange, Node, Edge } from "@xyflow/react";
+import { useEditorSearchbarStore } from "@/store/editor";
+import { useBlockDataStore } from "@/store/blockDataStore";
+import { 
+  TbCopy, 
+  TbClipboardText, 
+  TbDeviceFloppy, 
+  TbPlus, 
+  TbCopy as TbDuplicate,
+  TbTransform 
+} from "react-icons/tb";
+import RefactorToCustomBlockModal from "./refactorToCustomBlockModal";
+
+interface Props {
+  position: { x: number; y: number } | null;
+  onClose: () => void;
+}
+
+export default function CanvasContextMenu({ position, onClose }: Props) {
+  const { duplicateSelection, pasteSelection, onSave, copySelection } = useContext(BlockCanvasContext);
+  const { open: openSearchbar } = useEditorSearchbarStore();
+  const { getNodes, getEdges } = useReactFlow();
+
+  const [selectedBlocks, setSelectedBlocks] = useState<string[]>([]);
+  const [selectedEdges, setSelectedEdges] = useState<string[]>([]);
+  const [refactorModalOpened, setRefactorModalOpened] = useState(false);
+
+  const onChange = useCallback(({ nodes, edges }: { nodes: Node[]; edges: Edge[] }) => {
+    setSelectedBlocks(nodes.map((node) => node.id));
+    setSelectedEdges(edges.map((edge) => edge.id));
+  }, []);
+
+  useOnSelectionChange({ onChange });
+
+  const hasSelection = selectedBlocks.length > 0;
+  
+  // Refactoring is only possible if > 1 block is selected, and none of them are entrypoint/error_handler/response
+  const canRefactor = selectedBlocks.length > 1 && !getNodes().some(
+    (node) => 
+      selectedBlocks.includes(node.id) && 
+      (node.type === "entrypoint" || node.type === "error_handler" || node.type === "response")
+  );
+
+  return (
+    <>
+      <Menu opened={!!position && !refactorModalOpened} onClose={onClose} shadow="md">
+        <Menu.Target>
+          <Box
+            style={{
+              position: "fixed",
+              top: position?.y || 0,
+              left: position?.x || 0,
+              width: 1,
+              height: 1,
+              pointerEvents: "none",
+            }}
+          />
+        </Menu.Target>
+
+        <Menu.Dropdown>
+          <Menu.Item
+            leftSection={<TbPlus size={16} />}
+            rightSection={<Kbd ml="md">⇧ + A</Kbd>}
+            onClick={() => {
+              openSearchbar();
+              onClose();
+            }}
+          >
+            Add new
+          </Menu.Item>
+          
+          <Menu.Divider />
+          
+          <Menu.Item
+            leftSection={<TbCopy size={16} />}
+            rightSection={<Kbd ml="md">Ctrl + C</Kbd>}
+            disabled={!hasSelection}
+            onClick={() => {
+              copySelection();
+              onClose();
+            }}
+          >
+            Copy
+          </Menu.Item>
+          <Menu.Item
+            leftSection={<TbClipboardText size={16} />}
+            rightSection={<Kbd ml="md">Ctrl + V</Kbd>}
+            onClick={() => {
+              pasteSelection();
+              onClose();
+            }}
+          >
+            Paste
+          </Menu.Item>
+          <Menu.Item
+            leftSection={<TbDuplicate size={16} />}
+            rightSection={<Kbd ml="md">⇧ + D</Kbd>}
+            disabled={!hasSelection}
+            onClick={() => {
+              duplicateSelection(selectedBlocks);
+              onClose();
+            }}
+          >
+            Duplicate
+          </Menu.Item>
+
+          <Menu.Divider />
+
+          <Menu.Item
+            leftSection={<TbTransform size={16} />}
+            disabled={!canRefactor}
+            onClick={() => setRefactorModalOpened(true)}
+          >
+            Refactor to custom block
+          </Menu.Item>
+
+          <Menu.Divider />
+
+          <Menu.Item
+            leftSection={<TbDeviceFloppy size={16} />}
+            rightSection={<Kbd ml="md">Ctrl + S</Kbd>}
+            onClick={() => {
+              onSave();
+              onClose();
+            }}
+          >
+            Save
+          </Menu.Item>
+        </Menu.Dropdown>
+      </Menu>
+
+      {refactorModalOpened && (
+        <RefactorToCustomBlockModal
+          opened={refactorModalOpened}
+          onClose={() => {
+            setRefactorModalOpened(false);
+            onClose();
+          }}
+          selectedBlocks={selectedBlocks}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/web/src/components/editor/flowEditor/contextMenu/canvasContextMenu.tsx
+++ b/apps/web/src/components/editor/flowEditor/contextMenu/canvasContextMenu.tsx
@@ -46,6 +46,14 @@ export default function CanvasContextMenu({ position, onClose }: Props) {
       (node.type === "entrypoint" || node.type === "error_handler" || node.type === "response")
   );
 
+  const [lastPosition, setLastPosition] = useState(position);
+
+  React.useEffect(() => {
+    if (position) {
+      setLastPosition(position);
+    }
+  }, [position]);
+
   return (
     <>
       <Menu 
@@ -62,8 +70,8 @@ export default function CanvasContextMenu({ position, onClose }: Props) {
           <Box
             style={{
               position: "fixed",
-              top: position?.y || 0,
-              left: position?.x || 0,
+              top: lastPosition?.y || 0,
+              left: lastPosition?.x || 0,
               width: 1,
               height: 1,
               pointerEvents: "none",

--- a/apps/web/src/components/editor/flowEditor/contextMenu/canvasContextMenu.tsx
+++ b/apps/web/src/components/editor/flowEditor/contextMenu/canvasContextMenu.tsx
@@ -10,7 +10,9 @@ import {
   TbDeviceFloppy, 
   TbPlus, 
   TbCopy as TbDuplicate,
-  TbTransform 
+  TbTransform,
+  TbArrowBackUp,
+  TbArrowForwardUp
 } from "react-icons/tb";
 import RefactorToCustomBlockModal from "./refactorToCustomBlockModal";
 
@@ -20,7 +22,7 @@ interface Props {
 }
 
 export default function CanvasContextMenu({ position, onClose }: Props) {
-  const { duplicateSelection, pasteSelection, onSave, copySelection } = useContext(BlockCanvasContext);
+  const { duplicateSelection, pasteSelection, onSave, copySelection, undo, redo } = useContext(BlockCanvasContext);
   const { open: openSearchbar } = useEditorSearchbarStore();
   const { getNodes, getEdges } = useReactFlow();
 
@@ -74,6 +76,28 @@ export default function CanvasContextMenu({ position, onClose }: Props) {
           
           <Menu.Divider />
           
+          <Menu.Item
+            leftSection={<TbArrowBackUp size={16} />}
+            rightSection={<Kbd ml="md">Ctrl + Z</Kbd>}
+            onClick={() => {
+              undo();
+              onClose();
+            }}
+          >
+            Undo
+          </Menu.Item>
+          <Menu.Item
+            leftSection={<TbArrowForwardUp size={16} />}
+            rightSection={<Kbd ml="md">Ctrl + Y</Kbd>}
+            onClick={() => {
+              redo();
+              onClose();
+            }}
+          >
+            Redo
+          </Menu.Item>
+
+          <Menu.Divider />
           <Menu.Item
             leftSection={<TbCopy size={16} />}
             rightSection={<Kbd ml="md">Ctrl + C</Kbd>}

--- a/apps/web/src/components/editor/flowEditor/contextMenu/canvasContextMenu.tsx
+++ b/apps/web/src/components/editor/flowEditor/contextMenu/canvasContextMenu.tsx
@@ -48,7 +48,7 @@ export default function CanvasContextMenu({ position, onClose }: Props) {
 
   return (
     <>
-      <Menu opened={!!position && !refactorModalOpened} onClose={onClose} shadow="md">
+      <Menu opened={!!position && !refactorModalOpened} onClose={onClose} shadow="md" width={220}>
         <Menu.Target>
           <Box
             style={{
@@ -63,9 +63,9 @@ export default function CanvasContextMenu({ position, onClose }: Props) {
         </Menu.Target>
 
         <Menu.Dropdown>
-          <Menu.Item
-            leftSection={<TbPlus size={16} />}
-            rightSection={<Kbd ml="md">⇧ + A</Kbd>}
+          <Menu.Item fz="sm"
+            leftSection={<TbPlus size={14} />}
+            rightSection={<Kbd ml="md" size="xs">⇧ + A</Kbd>}
             onClick={() => {
               onClose();
               setTimeout(() => openSearchbar(), 0);
@@ -76,9 +76,9 @@ export default function CanvasContextMenu({ position, onClose }: Props) {
           
           <Menu.Divider />
           
-          <Menu.Item
-            leftSection={<TbArrowBackUp size={16} />}
-            rightSection={<Kbd ml="md">Ctrl + Z</Kbd>}
+          <Menu.Item fz="sm"
+            leftSection={<TbArrowBackUp size={14} />}
+            rightSection={<Kbd ml="md" size="xs">Ctrl + Z</Kbd>}
             onClick={() => {
               undo();
               onClose();
@@ -86,9 +86,9 @@ export default function CanvasContextMenu({ position, onClose }: Props) {
           >
             Undo
           </Menu.Item>
-          <Menu.Item
-            leftSection={<TbArrowForwardUp size={16} />}
-            rightSection={<Kbd ml="md">Ctrl + Y</Kbd>}
+          <Menu.Item fz="sm"
+            leftSection={<TbArrowForwardUp size={14} />}
+            rightSection={<Kbd ml="md" size="xs">Ctrl + Y</Kbd>}
             onClick={() => {
               redo();
               onClose();
@@ -98,9 +98,9 @@ export default function CanvasContextMenu({ position, onClose }: Props) {
           </Menu.Item>
 
           <Menu.Divider />
-          <Menu.Item
-            leftSection={<TbCopy size={16} />}
-            rightSection={<Kbd ml="md">Ctrl + C</Kbd>}
+          <Menu.Item fz="sm"
+            leftSection={<TbCopy size={14} />}
+            rightSection={<Kbd ml="md" size="xs">Ctrl + C</Kbd>}
             disabled={!hasSelection}
             onClick={() => {
               copySelection();
@@ -109,9 +109,9 @@ export default function CanvasContextMenu({ position, onClose }: Props) {
           >
             Copy
           </Menu.Item>
-          <Menu.Item
-            leftSection={<TbClipboardText size={16} />}
-            rightSection={<Kbd ml="md">Ctrl + V</Kbd>}
+          <Menu.Item fz="sm"
+            leftSection={<TbClipboardText size={14} />}
+            rightSection={<Kbd ml="md" size="xs">Ctrl + V</Kbd>}
             onClick={() => {
               pasteSelection();
               onClose();
@@ -119,9 +119,9 @@ export default function CanvasContextMenu({ position, onClose }: Props) {
           >
             Paste
           </Menu.Item>
-          <Menu.Item
-            leftSection={<TbDuplicate size={16} />}
-            rightSection={<Kbd ml="md">⇧ + D</Kbd>}
+          <Menu.Item fz="sm"
+            leftSection={<TbDuplicate size={14} />}
+            rightSection={<Kbd ml="md" size="xs">⇧ + D</Kbd>}
             disabled={!hasSelection}
             onClick={() => {
               duplicateSelection(selectedBlocks);
@@ -133,8 +133,8 @@ export default function CanvasContextMenu({ position, onClose }: Props) {
 
           <Menu.Divider />
 
-          <Menu.Item
-            leftSection={<TbTransform size={16} />}
+          <Menu.Item fz="sm"
+            leftSection={<TbTransform size={14} />}
             disabled={!canRefactor}
             onClick={() => setRefactorModalOpened(true)}
           >
@@ -143,9 +143,9 @@ export default function CanvasContextMenu({ position, onClose }: Props) {
 
           <Menu.Divider />
 
-          <Menu.Item
-            leftSection={<TbDeviceFloppy size={16} />}
-            rightSection={<Kbd ml="md">Ctrl + S</Kbd>}
+          <Menu.Item fz="sm"
+            leftSection={<TbDeviceFloppy size={14} />}
+            rightSection={<Kbd ml="md" size="xs">Ctrl + S</Kbd>}
             onClick={() => {
               onSave();
               onClose();

--- a/apps/web/src/components/editor/flowEditor/contextMenu/refactorToCustomBlockModal.tsx
+++ b/apps/web/src/components/editor/flowEditor/contextMenu/refactorToCustomBlockModal.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState } from "react";
-import { Modal, Button, TextInput, Textarea, Stack, Group, Select } from "@mantine/core";
+import { Modal, Button, TextInput, Stack, Group, Text } from "@mantine/core";
 import { useForm } from "@mantine/form";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { customBlocksService } from "@/services/customBlocks";
@@ -9,6 +9,7 @@ import { useReactFlow } from "@xyflow/react";
 import { useBlockDataStore } from "@/store/blockDataStore";
 import { BlockCanvasContext } from "@/context/blockCanvas";
 import { notifications } from "@mantine/notifications";
+import CustomBlockIconSelector from "@/components/forms/CustomBlockIconSelector";
 
 interface Props {
   opened: boolean;
@@ -28,7 +29,7 @@ export default function RefactorToCustomBlockModal({ opened, onClose, selectedBl
       name: "",
       label: "",
       description: "",
-      icon: "api",
+      icon: "premade-list" as "premade-list" | "custom",
       iconUrl: "",
     },
     validate: {
@@ -158,6 +159,7 @@ export default function RefactorToCustomBlockModal({ opened, onClose, selectedBl
       closeOnClickOutside={!mutation.isPending}
       closeOnEscape={!mutation.isPending}
       withCloseButton={!mutation.isPending}
+      size="xl"
     >
       <form onSubmit={form.onSubmit((values) => mutation.mutate(values))}>
         <Stack gap="md">
@@ -176,42 +178,25 @@ export default function RefactorToCustomBlockModal({ opened, onClose, selectedBl
             disabled={mutation.isPending}
             {...form.getInputProps("label")}
           />
-          <Textarea
-            label="Description"
-            placeholder="What does this block do?"
-            disabled={mutation.isPending}
-            {...form.getInputProps("description")}
-          />
-          <Select
-            label="Icon"
-            placeholder="Select an icon"
-            required
-            disabled={mutation.isPending}
-            data={[
-              { value: "python", label: "Python" },
-              { value: "javascript", label: "JavaScript" },
-              { value: "database", label: "Database" },
-              { value: "cloud", label: "Cloud" },
-              { value: "mail", label: "Mail" },
-              { value: "message", label: "Message" },
-              { value: "api", label: "API" },
-              { value: "webhook", label: "Webhook" },
-              { value: "lock", label: "Lock" },
-              { value: "key", label: "Key" },
-              { value: "custom", label: "Custom (Use URL)" },
-            ]}
-            {...form.getInputProps("icon")}
-          />
-          {form.values.icon === "custom" && (
-            <TextInput
-              label="Icon URL"
-              required
-              disabled={mutation.isPending}
-              {...form.getInputProps("iconUrl")}
-            />
-          )}
-          <Group justify="flex-end" mt="md">
-            <Button variant="subtle" onClick={onClose} disabled={mutation.isPending}>
+          <Text fw={500} size="sm">Icon</Text>
+          <CustomBlockIconSelector form={form} />
+          <Group 
+            justify="flex-end" 
+            mt="md"
+            mx="-md"
+            mb="-md"
+            px="md"
+            pb="md"
+            pt="md"
+            style={{
+              position: "sticky",
+              bottom: "-16px",
+              backgroundColor: "var(--mantine-color-body)",
+              zIndex: 10,
+              borderTop: "1px solid var(--mantine-color-default-border)",
+            }}
+          >
+            <Button variant="subtle" color="dark" onClick={onClose} disabled={mutation.isPending}>
               Cancel
             </Button>
             <Button type="submit" loading={mutation.isPending} color="violet">

--- a/apps/web/src/components/editor/flowEditor/contextMenu/refactorToCustomBlockModal.tsx
+++ b/apps/web/src/components/editor/flowEditor/contextMenu/refactorToCustomBlockModal.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState } from "react";
-import { Modal, Button, TextInput, Textarea, Stack, Group } from "@mantine/core";
+import { Modal, Button, TextInput, Textarea, Stack, Group, Select } from "@mantine/core";
 import { useForm } from "@mantine/form";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { customBlocksService } from "@/services/customBlocks";
@@ -28,6 +28,8 @@ export default function RefactorToCustomBlockModal({ opened, onClose, selectedBl
       name: "",
       label: "",
       description: "",
+      icon: "api",
+      iconUrl: "",
     },
     validate: {
       name: (val) =>
@@ -37,6 +39,8 @@ export default function RefactorToCustomBlockModal({ opened, onClose, selectedBl
             : "Lowercase letters, numbers, dots, and underscores only"
           : "Name is required",
       label: (val) => (val.length > 0 ? null : "Label is required"),
+      iconUrl: (val, values) =>
+        values.icon === "custom" && !val ? "Icon URL is required" : null,
     },
   });
 
@@ -44,10 +48,12 @@ export default function RefactorToCustomBlockModal({ opened, onClose, selectedBl
     mutationFn: async (values: typeof form.values) => {
       // 1. Create the custom block
       const createPayload = {
-        ...values,
+        name: values.name,
+        label: values.label,
+        description: values.description,
+        icon: values.icon === "custom" ? ("custom" as const) : ("premade-list" as const),
+        iconUrl: values.icon === "custom" ? values.iconUrl : values.icon,
         projectId: projectId!,
-        icon: "custom" as const,
-        iconUrl: "",
         inputParams: [],
       };
       const createdBlock = await customBlocksService.create(createPayload);
@@ -176,11 +182,39 @@ export default function RefactorToCustomBlockModal({ opened, onClose, selectedBl
             disabled={mutation.isPending}
             {...form.getInputProps("description")}
           />
+          <Select
+            label="Icon"
+            placeholder="Select an icon"
+            required
+            disabled={mutation.isPending}
+            data={[
+              { value: "python", label: "Python" },
+              { value: "javascript", label: "JavaScript" },
+              { value: "database", label: "Database" },
+              { value: "cloud", label: "Cloud" },
+              { value: "mail", label: "Mail" },
+              { value: "message", label: "Message" },
+              { value: "api", label: "API" },
+              { value: "webhook", label: "Webhook" },
+              { value: "lock", label: "Lock" },
+              { value: "key", label: "Key" },
+              { value: "custom", label: "Custom (Use URL)" },
+            ]}
+            {...form.getInputProps("icon")}
+          />
+          {form.values.icon === "custom" && (
+            <TextInput
+              label="Icon URL"
+              required
+              disabled={mutation.isPending}
+              {...form.getInputProps("iconUrl")}
+            />
+          )}
           <Group justify="flex-end" mt="md">
             <Button variant="subtle" onClick={onClose} disabled={mutation.isPending}>
               Cancel
             </Button>
-            <Button type="submit" loading={mutation.isPending}>
+            <Button type="submit" loading={mutation.isPending} color="violet">
               Create
             </Button>
           </Group>

--- a/apps/web/src/components/editor/flowEditor/contextMenu/refactorToCustomBlockModal.tsx
+++ b/apps/web/src/components/editor/flowEditor/contextMenu/refactorToCustomBlockModal.tsx
@@ -1,0 +1,191 @@
+import React, { useContext, useState } from "react";
+import { Modal, Button, TextInput, Textarea, Stack, Group } from "@mantine/core";
+import { useForm } from "@mantine/form";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { customBlocksService } from "@/services/customBlocks";
+import { customBlocksQueries } from "@/query/customBlocksQuery";
+import { useFlowEditorContext } from "../flowEditorContext";
+import { useReactFlow } from "@xyflow/react";
+import { useBlockDataStore } from "@/store/blockDataStore";
+import { BlockCanvasContext } from "@/context/blockCanvas";
+import { notifications } from "@mantine/notifications";
+
+interface Props {
+  opened: boolean;
+  onClose: () => void;
+  selectedBlocks: string[];
+}
+
+export default function RefactorToCustomBlockModal({ opened, onClose, selectedBlocks }: Props) {
+  const { projectId } = useFlowEditorContext();
+  const queryClient = useQueryClient();
+  const { getNodes, getEdges } = useReactFlow();
+  const blockDataStore = useBlockDataStore();
+  const { deleteBulk, addBlock } = useContext(BlockCanvasContext);
+
+  const form = useForm({
+    initialValues: {
+      name: "",
+      label: "",
+      description: "",
+    },
+    validate: {
+      name: (val) =>
+        val.length > 0
+          ? /^[a-z0-9_.]+$/.test(val)
+            ? null
+            : "Lowercase letters, numbers, dots, and underscores only"
+          : "Name is required",
+      label: (val) => (val.length > 0 ? null : "Label is required"),
+    },
+  });
+
+  const mutation = useMutation({
+    mutationFn: async (values: typeof form.values) => {
+      // 1. Create the custom block
+      const createPayload = {
+        ...values,
+        projectId: projectId!,
+        icon: "custom" as const,
+        iconUrl: "",
+        inputParams: [],
+      };
+      const createdBlock = await customBlocksService.create(createPayload);
+      const newBlockId = createdBlock.id;
+
+      // 2. Prepare canvas payload for the new custom block
+      const allNodes = getNodes();
+      const allEdges = getEdges();
+
+      const nodesToMove = allNodes.filter((n) => selectedBlocks.includes(n.id));
+      const edgesToMove = allEdges.filter(
+        (e) => selectedBlocks.includes(e.source) && selectedBlocks.includes(e.target)
+      );
+
+      const blockActionsToPerform = nodesToMove.map((b) => ({ id: b.id, action: "upsert" as const }));
+      const edgeActionsToPerform = edgesToMove.map((e) => ({ id: e.id, action: "upsert" as const }));
+
+      const blocksToSave = nodesToMove.map((b) => ({
+        id: b.id,
+        type: b.type!,
+        position: b.position,
+        data: blockDataStore[b.id],
+      }));
+
+      const savePayload = {
+        actionsToPerform: {
+          blocks: blockActionsToPerform,
+          edges: edgeActionsToPerform,
+        },
+        changes: {
+          blocks: blocksToSave,
+          edges: edgesToMove.map((edge) => ({
+            id: edge.id,
+            fromHandle: edge.sourceHandle,
+            toHandle: edge.targetHandle,
+            from: edge.source,
+            to: edge.target,
+          })),
+        },
+      };
+
+      // 3. Save to new custom block canvas
+      await customBlocksService.saveCanvasItems(newBlockId, savePayload);
+      
+      return { createdBlock, nodesToMove, edgesToMove };
+    },
+    onSuccess: ({ createdBlock, nodesToMove, edgesToMove }, variables) => {
+      // 4. Invalidate queries to update custom blocks list
+      customBlocksQueries.getAll.invalidate(queryClient, projectId!);
+
+      // 5. Replace selected blocks in the current canvas with the new custom block
+      // Calculate center of selected blocks
+      let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+      nodesToMove.forEach(n => {
+        if (n.position.x < minX) minX = n.position.x;
+        if (n.position.y < minY) minY = n.position.y;
+        if (n.position.x > maxX) maxX = n.position.x;
+        if (n.position.y > maxY) maxY = n.position.y;
+      });
+      const centerX = (minX + maxX) / 2;
+      const centerY = (minY + maxY) / 2;
+
+      deleteBulk(selectedBlocks, "block");
+      
+      // Some edges might have been connected to the outside, deleting them too
+      // `deleteBulk` on blocks might automatically remove edges, but let's be safe.
+      const allEdges = getEdges();
+      const edgesConnectedToDeletedBlocks = allEdges.filter(
+        (e) => selectedBlocks.includes(e.source) || selectedBlocks.includes(e.target)
+      ).map(e => e.id);
+      if (edgesConnectedToDeletedBlocks.length > 0) {
+        deleteBulk(edgesConnectedToDeletedBlocks, "edge");
+      }
+
+      addBlock({
+        id: crypto.randomUUID(),
+        type: variables.name,
+        position: { x: centerX, y: centerY },
+      } as any);
+
+      notifications.show({
+        title: "Success",
+        message: "Successfully refactored to custom block",
+        color: "green",
+      });
+      onClose();
+    },
+    onError: (error: any) => {
+      notifications.show({
+        title: "Error",
+        message: error.message || "Failed to refactor",
+        color: "red",
+      });
+    },
+  });
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={() => !mutation.isPending && onClose()}
+      title="Refactor to Custom Block"
+      closeOnClickOutside={!mutation.isPending}
+      closeOnEscape={!mutation.isPending}
+      withCloseButton={!mutation.isPending}
+    >
+      <form onSubmit={form.onSubmit((values) => mutation.mutate(values))}>
+        <Stack gap="md">
+          <TextInput
+            label="Name"
+            description="Lowercase letters, numbers, dots, and underscores only. Cannot be changed later."
+            placeholder="e.g. process_data"
+            required
+            disabled={mutation.isPending}
+            {...form.getInputProps("name")}
+          />
+          <TextInput
+            label="Label"
+            placeholder="e.g. Process Data"
+            required
+            disabled={mutation.isPending}
+            {...form.getInputProps("label")}
+          />
+          <Textarea
+            label="Description"
+            placeholder="What does this block do?"
+            disabled={mutation.isPending}
+            {...form.getInputProps("description")}
+          />
+          <Group justify="flex-end" mt="md">
+            <Button variant="subtle" onClick={onClose} disabled={mutation.isPending}>
+              Cancel
+            </Button>
+            <Button type="submit" loading={mutation.isPending}>
+              Create
+            </Button>
+          </Group>
+        </Stack>
+      </form>
+    </Modal>
+  );
+}

--- a/apps/web/src/components/forms/CustomBlockIconSelector.tsx
+++ b/apps/web/src/components/forms/CustomBlockIconSelector.tsx
@@ -1,0 +1,143 @@
+import React from "react";
+import {
+  Tabs,
+  Image,
+  Text,
+  Center,
+  SimpleGrid,
+  ScrollArea,
+  Paper,
+  TextInput,
+  Stack,
+  Group,
+  Textarea,
+} from "@mantine/core";
+import {
+  TbBrandPython,
+  TbBrandJavascript,
+  TbDatabase,
+  TbCloud,
+  TbMail,
+  TbMessage,
+  TbApi,
+  TbWebhook,
+  TbLock,
+  TbKey,
+  TbSearch,
+} from "react-icons/tb";
+import { UseFormReturnType } from "@mantine/form";
+
+export const premadeIcons = [
+  { value: "python", icon: <TbBrandPython size={24} /> },
+  { value: "javascript", icon: <TbBrandJavascript size={24} /> },
+  { value: "database", icon: <TbDatabase size={24} /> },
+  { value: "cloud", icon: <TbCloud size={24} /> },
+  { value: "mail", icon: <TbMail size={24} /> },
+  { value: "message", icon: <TbMessage size={24} /> },
+  { value: "api", icon: <TbApi size={24} /> },
+  { value: "webhook", icon: <TbWebhook size={24} /> },
+  { value: "lock", icon: <TbLock size={24} /> },
+  { value: "key", icon: <TbKey size={24} /> },
+];
+
+export default function CustomBlockIconSelector({
+  form,
+}: {
+  form: UseFormReturnType<any>;
+}) {
+  const [iconSearch, setIconSearch] = React.useState("");
+
+  return (
+    <Tabs
+      value={form.values.icon}
+      onChange={(value) =>
+        form.setFieldValue("icon", value as "premade-list" | "custom")
+      }
+      color="violet"
+    >
+      <Tabs.List>
+        <Tabs.Tab value="premade-list">Premade</Tabs.Tab>
+        <Tabs.Tab value="custom">Custom (Base64/URL)</Tabs.Tab>
+      </Tabs.List>
+
+      <Tabs.Panel value="premade-list" pt="md">
+        <Stack gap="md">
+          <TextInput
+            placeholder="Search icons..."
+            leftSection={<TbSearch size={16} />}
+            value={iconSearch}
+            onChange={(e) => setIconSearch(e.currentTarget.value)}
+          />
+          <ScrollArea h={200}>
+            <SimpleGrid cols={5} spacing="md">
+              {premadeIcons
+                .filter((pi) =>
+                  pi.value.toLowerCase().includes(iconSearch.toLowerCase())
+                )
+                .map((pi) => (
+                  <Paper
+                    key={pi.value}
+                    withBorder
+                    p="sm"
+                    style={{
+                      cursor: "pointer",
+                      borderColor:
+                        form.values.iconUrl === pi.value
+                          ? "var(--mantine-color-violet-filled)"
+                          : "var(--mantine-color-gray-3)",
+                      backgroundColor:
+                        form.values.iconUrl === pi.value
+                          ? "var(--mantine-color-violet-light)"
+                          : "transparent",
+                    }}
+                    onClick={() => form.setFieldValue("iconUrl", pi.value)}
+                  >
+                    <Center>{pi.icon}</Center>
+                  </Paper>
+                ))}
+            </SimpleGrid>
+          </ScrollArea>
+        </Stack>
+      </Tabs.Panel>
+
+      <Tabs.Panel value="custom" pt="md">
+        <Group align="center" wrap="nowrap">
+          <Paper
+            withBorder
+            w={100}
+            h={100}
+            style={{
+              overflow: "hidden",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              backgroundColor: "#f8f9fa",
+              flexShrink: 0,
+            }}
+          >
+            {form.values.iconUrl ? (
+              <Image
+                src={form.values.iconUrl}
+                w={100}
+                h={100}
+                fit="contain"
+                alt="Icon preview"
+              />
+            ) : (
+              <Text size="xs" c="dimmed">
+                100x100
+              </Text>
+            )}
+          </Paper>
+          <Textarea
+            label="Icon URL or Base64"
+            placeholder="data:image/svg+xml;base64,..."
+            flex={1}
+            rows={4}
+            {...form.getInputProps("iconUrl")}
+          />
+        </Group>
+      </Tabs.Panel>
+    </Tabs>
+  );
+}

--- a/apps/web/src/context/blockCanvas.tsx
+++ b/apps/web/src/context/blockCanvas.tsx
@@ -13,4 +13,6 @@ export const BlockCanvasContext = createContext<{
   deleteBulk: (ids: string[], type: "block" | "edge") => void;
   onSave: () => Promise<void>;
   duplicateSelection: (blockIds: string[]) => void;
+  copySelection: () => Promise<void>;
+  pasteSelection: (clipboardData?: any) => void;
 }>({} as any);

--- a/apps/web/src/hooks/useBlockHistory.ts
+++ b/apps/web/src/hooks/useBlockHistory.ts
@@ -175,7 +175,7 @@ export function useBlockHistory() {
 			createNewBlock(newId, position, block.type, block.data);
 		});
 
-		clipboardData.edges.forEach((edge: any) => {
+		clipboardData.data.edges?.forEach((edge: any) => {
 			if (
 				!oldIdToNewIdMap.has(edge.source) ||
 				!oldIdToNewIdMap.has(edge.target)

--- a/apps/web/src/hooks/useBlockHistory.ts
+++ b/apps/web/src/hooks/useBlockHistory.ts
@@ -150,16 +150,22 @@ export function useBlockHistory() {
 		updateBlockData(id, data);
 	}
 
-	function pasteSelection(clipboardData: any) {
-		const oldIdToNewIdMap = new Map<string, string>();
-		const newBlockIds: string[] = [];
+	async function pasteSelection() {
+		try {
+			const text = await navigator.clipboard.readText();
+			const clipboardData = JSON.parse(text);
+			if (clipboardData.source !== "FLUXIFY/COPY_PASTE" || !clipboardData.data) return;
 
-		clipboardData.blocks.forEach((block: any) => {
-			const isUnduplitable =
-				block.type === BlockTypes.entrypoint ||
-				block.type === BlockTypes.errorHandler;
+			const oldIdToNewIdMap = new Map<string, string>();
+			const newBlockIds: string[] = [];
 
-			if (isUnduplitable) return;
+			clipboardData.data.blocks.forEach((block: any) => {
+				const isUnduplitable =
+					block.type === BlockTypes.entrypoint ||
+					block.type === BlockTypes.errorHandler ||
+					block.type === BlockTypes.response;
+
+				if (isUnduplitable) return;
 
 			const newId = generateID();
 			oldIdToNewIdMap.set(block.id, newId);
@@ -201,6 +207,9 @@ export function useBlockHistory() {
 
 		setBlocksSelection(newBlockIds, true);
 		setEdgesSelection(newBlockIds, true);
+		} catch (error) {
+			console.error("Failed to paste from clipboard", error);
+		}
 	}
 
 	return {


### PR DESCRIPTION
This PR implements multiple enhancements for the canvas editor and custom block creation, addressing the requirements of #76.

### Key Features
- **Context Menu Improvements**: Added a persistent context menu on the canvas to support actions like Undo, Redo, Copy, Paste, Duplicate, and Refactoring.
- **Refactor to Custom Block**: Added the ability to select multiple nodes and refactor them directly into a new, reusable Custom Block. Integrated a reusable icon selector component.
- **Keyboard Shortcuts**: Added robust keyboard accessibility (`Ctrl+C`, `Ctrl+V`, `Ctrl+Z`, `Ctrl+Y`) that syncs directly with context menu actions.
- **Copy/Paste Enhancements**: Logic rewritten to correctly retain connected edges and accurately map IDs when pasting or duplicating blocks.
- **Custom Block API & Sidebar Integration**: 
  - Backend inherently enforces the `user_defined` source schema for custom created blocks.
  - Custom blocks are correctly grouped in the search sidebar under `"User Defined Blocks"` (code icon) vs `"Plugin Blocks"` (socket icon).

Resolves #76.
