### PR TITLE
docs: improve getting started page and fix HR styling

### DIFF
--- a/.agents/workflows/git-pr-sync.md
+++ b/.agents/workflows/git-pr-sync.md
@@ -24,8 +24,8 @@ Trigger this workflow when a user requests to push their code, open a PR, merge 
    - Push to the user's origin fork: `git push -u origin <branch-name>`
 
 3. **Create the Pull Request**
-   - Create a PR against the upstream repository (e.g., `Fluxify-rest/Fluxify`).
-   - Run: `gh pr create --repo <upstream-repo> --head <username>:<branch-name> --title "<Title>" --body "<Body>"`
+   - Create a PR against the upstream repository `Fluxify-rest/Fluxify`
+   - Run: `gh pr create --repo Fluxify-rest/Fluxify --head <username>:<branch-name> --title "<Title>" --body "<Body>"`
 
 4. **Enable Auto-Merge / Wait for Checks**
    - Enable auto-merge so the PR merges immediately upon CI passing (if applicable):
@@ -40,7 +40,7 @@ Trigger this workflow when a user requests to push their code, open a PR, merge 
    - Switch back to main locally: `git checkout main`
    - Pull the updated changes from the remote fork: `git pull origin main`
 
-7. **Clean Up Local Environment**
+7. **Clean Up Local Environment but ask before deleting the branch**
    - Delete the temporary local feature branch: `git branch -D <branch-name>`
 
 You are now successfully synced with the upstream `main` branch, and the temporary feature branches have been securely disposed of!

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,0 +1,4 @@
+import DefaultTheme from "vitepress/theme";
+import "./custom.css";
+
+export default DefaultTheme;

--- a/docs/blocks/js-runner.md
+++ b/docs/blocks/js-runner.md
@@ -7,16 +7,11 @@ description: Execute custom JavaScript code within a sandboxed V8 environment wi
 
 The **JS Runner** block lets you write arbitrary JavaScript code inside your workflow. It is the most flexible block available — use it for custom business logic, data transformation, conditional branching preparation, or anything that standard blocks don't cover.
 
----
-
 ## Inputs
 
 | Field | Description |
 | :--- | :--- |
 | **Value** | The JavaScript code to execute. Supports full ES6+ syntax and `async/await`. |
-
----
-
 ## How It Works
 
 1. The block receives the output of the previous block as its `params` argument.
@@ -27,9 +22,6 @@ The **JS Runner** block lets you write arbitrary JavaScript code inside your wor
 6. If an exception is thrown, the block returns `successful: false` and stops the chain (unless the next block is an Error Handler).
 
 > The JS Runner always sets `continueIfFail: true` on success, meaning the workflow will proceed even if `output` is `null` or `undefined`.
-
----
-
 ## Available Globals
 
 Inside your JS Runner code, all of the following are available without any import or prefix:
@@ -55,9 +47,6 @@ Inside your JS Runner code, all of the following are available without any impor
 | `zod` | Zod schema validation library. |
 
 For the complete API reference with type signatures and examples, see the [Scripting Context](../scripting/context.md) page.
-
----
-
 ## Examples
 
 ### Basic Transformation
@@ -142,9 +131,6 @@ requestingUser = getRouteParam("userId");
 return { status: "processing" };
 // Next blocks can read: processedAt, requestingUser
 ```
-
----
-
 ## Error Handling
 
 If your code throws an unhandled exception, the JS Runner returns:
@@ -169,9 +155,6 @@ try {
   return { error: "Service temporarily unavailable" };
 }
 ```
-
----
-
 ## Sandbox Constraints
 
 | Constraint | Detail |

--- a/docs/concepts/context.md
+++ b/docs/concepts/context.md
@@ -8,9 +8,6 @@ description: Understanding the shared environment that carries request data and 
 The **Execution Context** is a per-request object created when an HTTP request triggers a workflow. It is passed to every block that runs and holds all the data and tools needed to process that request — from the incoming URL and headers to the scripting VM, logger, and global variables.
 
 Think of it as the workflow's environment for a single request run.
-
----
-
 ## What the Context Contains
 
 Every block in a workflow has access to:
@@ -26,9 +23,6 @@ Every block in a workflow has access to:
 - **Timeout control** — the context enforces a maximum execution time for the entire workflow.
 
 For the complete scripting API (all available globals, functions, and examples), see the [Scripting Context](../scripting/context.md) reference.
-
----
-
 ## Global Variables
 
 A key feature of the context is its **global variable store**. Any variable set in one block is immediately readable by all subsequent blocks in the same workflow run.
@@ -37,9 +31,6 @@ A key feature of the context is its **global variable store**. Any variable set 
 - **Read** in any later block or `js:` expression: `myVariable`
 
 Variables live only for the duration of a single request. They are not shared between different users or different requests.
-
----
-
 ## The `input` Variable
 
 Every block receives the output of the **previous block** as `input`. This is separate from the global variable store — `input` only holds what the immediately preceding block returned.
@@ -48,9 +39,6 @@ Every block receives the output of the **previous block** as `input`. This is se
 // Previous block returned { "user": { "name": "Alice" } }
 return input.user.name; // → "Alice"
 ```
-
----
-
 ## Lifetime & Isolation
 
 | Property | Behavior |
@@ -59,9 +47,6 @@ return input.user.name; // → "Alice"
 | **Isolation** | Concurrent requests each get their own context with no shared state. |
 | **Timeout** | Workflows have a maximum execution time of **4 seconds**. Exceeding it returns a timeout error. |
 | **Cleanup** | The context is discarded after the response is sent. |
-
----
-
 ## Related Pages
 
 - [Scripting Context](../scripting/context.md) — Full API reference for all globals available in scripts.

--- a/docs/concepts/execution-engine.md
+++ b/docs/concepts/execution-engine.md
@@ -6,9 +6,6 @@ description: The core system that runs your workflows block by block, manages th
 # Execution Engine
 
 The **Execution Engine** is the runtime core of Fluxify. Every time an HTTP request is matched to a workflow, the engine takes over — it walks the block graph, passes data between steps, manages failures, and enforces time limits.
-
----
-
 ## How the Engine Runs a Workflow
 
 When a request arrives, the server assembles an [Execution Context](./context.md) and then calls the engine's `start()` method with the ID of the first block to run (the **Entrypoint**).
@@ -39,9 +36,6 @@ Incoming Request
 4. **Error handling**: If a block fails and does not set `continueIfFail: true`, the engine routes to the configured **Error Handler** block. If the error handler has no continuation, execution stops.
 5. **Timeout enforcement**: Before each iteration, the engine checks if `performance.now()` has exceeded `stopper.timeoutEnd`. If so, execution stops and a timeout error is returned.
 6. **Final result**: The last `BlockOutput` is returned to the request router, which serializes it into an HTTP response.
-
----
-
 ## The Context & The Engine
 
 The `Engine` receives the [Execution Context](./context.md) in its `EngineOptions`. It does not read request data directly — all request awareness comes from the context:
@@ -55,9 +49,6 @@ export type EngineOptions = {
 ```
 
 The engine only directly uses `context.stopper` to track timeouts. Every block receives the full context via its constructor, giving it access to the VM, helpers, logger, DB, and HTTP client.
-
----
-
 ## Timeout System
 
 Workflows are subject to a **4-second execution timeout** by default (controlled by `RESPONSE_TIMEOUT = 4000` ms).
@@ -71,9 +62,6 @@ Workflows are subject to a **4-second execution timeout** by default (controlled
 | **`ExecutionTimeoutError`** | Blocks can also throw this error explicitly; the engine catches it and terminates cleanly. |
 
 > **Tip**: Long-running tasks (like DB queries or external HTTP calls) count toward the timeout. Design workflows to be efficient and avoid unnecessary sequential round-trips.
-
----
-
 ## Error Handling
 
 Every workflow must have an **Error Handler** block configured. The engine uses its ID (`errorHandlerId`) to route failures.
@@ -85,9 +73,6 @@ Every workflow must have an **Error Handler** block configured. The engine uses 
 4. If the error block has no `next`, the last failure result is returned.
 
 **`continueIfFail` flag**: A block can signal that even on failure the engine should proceed to `next`. This is used by blocks like **JS Runner** (which always sets `continueIfFail: true` on success).
-
----
-
 ## Block Output Contract
 
 Every block must return a `BlockOutput` object:
@@ -101,9 +86,6 @@ interface BlockOutput {
   continueIfFail: boolean; // If true, engine moves to `next` even on failure
 }
 ```
-
----
-
 ## Relationship to the Context
 
 The engine is intentionally thin — it knows nothing about HTTP, databases, or scripting. All of that lives in the **Context** that surrounds it:
@@ -119,9 +101,6 @@ The engine is intentionally thin — it knows nothing about HTTP, databases, or 
 | Timeout | `context.stopper` (read by Engine) |
 
 See [Execution Context](./context.md) for the full context reference.
-
----
-
 ## Performance
 
 The engine is designed to be lightweight:

--- a/docs/deployments/index.md
+++ b/docs/deployments/index.md
@@ -9,9 +9,6 @@ Fluxify is designed to be self-hosted. This guide covers everything you need to 
 
 > [!NOTE]
 > This guide covers the **standalone Docker** deployment — the simplest way to self-host Fluxify. Production-grade topologies (Kubernetes, cloud-managed services) will be documented here as they mature.
-
----
-
 ## Architecture Overview
 
 The topology below reflects the standalone Docker deployment. External clients talk to port `8080` only — Caddy routes requests internally.
@@ -44,18 +41,12 @@ In addition to the container, the following **external services** are required a
 
 - **PostgreSQL** — primary datastore for workflows, users, and project configuration
 - **Redis** — used for caching, BullMQ job queues, and pub/sub
-
----
-
 ## Requirements
 
 - **Docker** (Docker Engine 20+ or Docker Desktop)
 - A **PostgreSQL** instance (version 14+ recommended)
 - A **Redis** instance (version 6+ recommended)
 - A domain name or IP address reachable from your users (for production)
-
----
-
 ## Setup Guide
 
 ### Step 1: Pull the Image
@@ -132,9 +123,6 @@ After the container starts, the server will:
 3. Start the Caddy proxy and all internal services.
 
 Access the dashboard at `http://your-host:8080` (or your configured domain). Log in with the `SEED_USER_EMAIL` and `SEED_USER_PASSWORD` from your `.env`.
-
----
-
 ## Upgrading
 
 To upgrade to the latest version of Fluxify:
@@ -158,9 +146,6 @@ docker run -d \
 
 > [!NOTE]
 > Database migrations are applied automatically on startup. Always read the release notes before upgrading to check for breaking changes.
-
----
-
 ## Troubleshooting
 
 **Container exits immediately**
@@ -185,9 +170,6 @@ docker run -d \
 
 > [!TIP]
 > Help us build out this section. If you encountered and solved an issue not listed here, please open a PR to add it to the docs!
-
----
-
 ## Environment Variables
 
 Copy `env.example` to `.env` and configure the variables below. All values are described with their purpose and defaults.

--- a/docs/getting-started/basics.md
+++ b/docs/getting-started/basics.md
@@ -6,9 +6,6 @@ description: The fundamental concepts you need to understand to build with Fluxi
 # Basics & Core Concepts
 
 Fluxify is built around a small set of composable concepts. Understanding these will allow you to model any backend logic visually — from simple CRUD endpoints to AI-powered workflows with complex branching logic.
-
----
-
 ## 1. Workflows (API Endpoints)
 
 A **Workflow** is the fundamental unit of logic in Fluxify. Each workflow represents a single API endpoint — it has a defined HTTP method and path (e.g., `POST /users`), and defines exactly what happens when that endpoint is called.
@@ -19,9 +16,6 @@ Every workflow:
 - Ends when a **Response** block sends a reply, or when the execution engine reaches a block with no outgoing connection.
 
 Workflows are displayed visually as a directed graph (a canvas of blocks and connecting arrows) inside the Fluxify editor.
-
----
-
 ## 2. Blocks
 
 **Blocks** are the individual units of logic that make up a workflow. Each block performs a single, well-defined action. Blocks are the building "lego pieces" of Fluxify — you compose them to express arbitrarily complex backend behaviour.
@@ -45,9 +39,6 @@ Block inputs support **dynamic expressions**: prefix a value with `js:` to evalu
 | **Logging** | Console Log, Cloud Logs | Observability and debugging |
 
 Browse the full [Blocks Reference](../blocks/index.md) for detailed documentation on every block.
-
----
-
 ## 3. Edges (Connections)
 
 **Edges** are the arrows connecting blocks on the canvas. They define the **order of execution** — the directed path the engine follows through the workflow.
@@ -57,9 +48,6 @@ Key behaviours:
 - If Block A is connected to Block B, Block B runs immediately after Block A finishes successfully.
 - Some blocks produce **multiple output ports**. For example, the **If Condition** block has a `True` and a `False` output — the engine follows the matching branch based on the evaluated condition.
 - A block with no outgoing edge ends the workflow at that point.
-
----
-
 ## 4. Execution Context & Variables
 
 Every time a request hits a workflow, the engine creates a fresh **Execution Context** — an isolated per-request environment that holds everything the workflow needs:
@@ -95,9 +83,6 @@ return input.name; // → "Alice"
 ```
 
 For a complete reference, see the [Execution Context](../concepts/context.md) and [Scripting Context](../scripting/context.md) documentation.
-
----
-
 ## 5. Integrations
 
 **Integrations** are the connections between Fluxify and external systems. They are configured once in the project settings and then referenced by blocks using a connection ID.
@@ -115,9 +100,6 @@ Fluxify uses an **Adapter Pattern** internally — blocks interact with a generi
 Configure integrations in the **Integrations** section of the project dashboard, then reference them in your blocks by their connection ID.
 
 See the [Integrations Reference](../integrations/index.md) for setup guides.
-
----
-
 ## 6. App Config (Secrets)
 
 The **App Config** is a secure key-value store for project-level secrets and configuration values — things like API keys, database passwords, or external service URLs that you don't want to hardcode in your workflows.
@@ -129,9 +111,6 @@ cfg:OPENAI_API_KEY
 ```
 
 This keeps sensitive values out of your workflow definitions and centralises credential management.
-
----
-
 ## Next Steps
 
 Now that you understand the core concepts, you're ready to:

--- a/docs/getting-started/contributing.md
+++ b/docs/getting-started/contributing.md
@@ -9,9 +9,6 @@ Thank you for your interest in contributing! Fluxify is an open-source project i
 
 > [!NOTE]
 > Because Fluxify is in alpha, the architecture and APIs may change. If you're planning a large contribution, we recommend opening an issue first to discuss the approach.
-
----
-
 ## Ways to Contribute
 
 You don't have to write code to contribute. Here are all the ways you can help:
@@ -25,9 +22,6 @@ You don't have to write code to contribute. Here are all the ways you can help:
 | 🔧 **Core Features** | Improve the execution engine, API, or frontend |
 | 🧪 **Tests** | Add or improve unit and integration tests |
 | 🎨 **UI/UX** | Improve the visual workflow builder or settings UI |
-
----
-
 ## Getting Started
 
 ### 1. Fork & Clone
@@ -56,9 +50,6 @@ cp env.example .env
 ```
 
 See [Local Testing](./local-testing.md) for a full setup guide including starting the required databases.
-
----
-
 ## Development Workflow
 
 ### Create a Branch
@@ -109,9 +100,6 @@ Ensure your code meets the project's quality standards:
 ```bash
 bun run lint
 ```
-
----
-
 ## Submitting a Pull Request
 
 1. **Push** your branch to your fork:
@@ -122,9 +110,6 @@ bun run lint
 3. Fill in the PR template — describe **what** changed and **why**.
 4. Link any related Issues in the PR description (e.g., `Closes #42`).
 5. Wait for a maintainer review. Be responsive to feedback — PRs with no activity may be closed after a period of time.
-
----
-
 ## Contribution Guidelines
 
 ### Code Style
@@ -149,9 +134,6 @@ Since Fluxify is in alpha:
 - Some APIs and internal interfaces may change between PRs.
 - Not all features are fully documented — improving docs is always a great first contribution.
 - Feature ideas and architectural feedback are especially valuable right now. Open a [Discussion](https://github.com/fluxify-rest/Fluxify/discussions) to share your thoughts.
-
----
-
 ## Reporting Bugs
 
 When opening a bug report, please include:
@@ -160,9 +142,6 @@ When opening a bug report, please include:
 2. **What actually happened** (error messages, screenshots if relevant).
 3. **Steps to reproduce** the issue.
 4. **Environment details**: OS, Docker version, Bun version, browser (if a UI issue).
-
----
-
 ## Feature Requests & Ideas
 
 Fluxify is in alpha and actively shaping its roadmap. If you have:
@@ -172,9 +151,6 @@ Fluxify is in alpha and actively shaping its roadmap. If you have:
 - Feedback on the developer experience
 
 ...please open a [GitHub Discussion](https://github.com/fluxify-rest/Fluxify/discussions) or an Issue tagged `enhancement`. Every idea helps the project improve.
-
----
-
 ## Community
 
 - 💬 [GitHub Discussions](https://github.com/fluxify-rest/Fluxify/discussions) — Q&A, ideas, and general chat

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -9,9 +9,6 @@ description: A complete introduction to Fluxify — what it is, how it works, an
 
 > [!NOTE]
 > Fluxify is currently in **alpha**. The platform is under active development and some features are still stabilizing. Feedback, bug reports, and contributions are very welcome.
-
----
-
 ## What is Fluxify?
 
 Fluxify is a visual backend platform. Instead of writing route handlers, middleware, and data-access layers manually, you build **workflows** — directed graphs of **Blocks** connected by **Edges** — that define exactly what happens when an HTTP request arrives.
@@ -26,9 +23,6 @@ A typical workflow might:
 6. Return a JSON response with a **Response** block
 
 All of this is configured visually in the browser — no server framework knowledge required.
-
----
-
 ## Core Capabilities
 
 | Capability | Description |
@@ -41,9 +35,6 @@ All of this is configured visually in the browser — no server framework knowle
 | 📡 **Observability** | Structured logging with support for Loki and OpenTelemetry Logs; built-in console logging for local development |
 | 🔒 **Security** | Per-project App Config for secrets management, encrypted credentials, and sandbox isolation for scripts |
 | 🚀 **Flexible Deployment** | Ship as a standalone Docker container (via `fluxify-kit`), or scale with Kubernetes for high availability |
-
----
-
 ## How It Works
 
 Every API endpoint in Fluxify is powered by a **workflow**. The platform runs a lightweight execution engine that:
@@ -56,9 +47,6 @@ Every API endpoint in Fluxify is powered by a **workflow**. The platform runs a 
 6. **Returns** the final block's output as the HTTP response.
 
 For a deep dive, see the [Execution Engine](../concepts/execution-engine.md) documentation.
-
----
-
 ## In This Section
 
 | Page | Description |
@@ -67,9 +55,6 @@ For a deep dive, see the [Execution Engine](../concepts/execution-engine.md) doc
 | [Local Testing](./local-testing.md) | Set up a full Fluxify stack locally for development and testing |
 | [Self-Hosting](../deployments/index.md) | Deploy Fluxify on your own infrastructure with Docker |
 | [Contributing](./contributing.md) | Learn how to contribute code, docs, or ideas to the project |
-
----
-
 ## Quick Links
 
 - 📖 [Blocks Reference](../blocks/index.md) — Browse all available blocks

--- a/docs/getting-started/local-testing.md
+++ b/docs/getting-started/local-testing.md
@@ -6,9 +6,6 @@ description: How to run the full Fluxify stack locally for development and testi
 # Local Testing Guide
 
 This guide walks you through setting up a complete Fluxify development environment on your local machine. By the end, you will have the frontend, backend API, worker, and all supporting services running locally.
-
----
-
 ## Prerequisites
 
 Before you begin, ensure you have the following installed:
@@ -21,18 +18,12 @@ Before you begin, ensure you have the following installed:
 
 > [!TIP]
 > Fluxify uses **Bun** (not npm or yarn) as its runtime. Make sure `bun --version` works in your terminal before proceeding.
-
----
-
 ## Step 1: Clone the Repository
 
 ```bash
 git clone https://github.com/fluxify-rest/Fluxify.git
 cd Fluxify
 ```
-
----
-
 ## Step 2: Install Dependencies
 
 ```bash
@@ -40,9 +31,6 @@ bun install
 ```
 
 This installs all workspace dependencies across the monorepo (`apps/`, `packages/`).
-
----
-
 ## Step 3: Configure Your Environment
 
 Copy the example environment file:
@@ -81,9 +69,6 @@ HOSTNAME=localhost
 > The `SEED_USER_EMAIL` and `SEED_USER_PASSWORD` values define the initial admin account. You must set these before the first run — you will use them to log into the dashboard.
 
 See [Self-Hosting](./self-hosting.md) for the complete `.env` schema and description of every variable.
-
----
-
 ## Step 4: Start Databases with Docker
 
 The project includes a `docker-compose` configuration that starts PostgreSQL and Redis:
@@ -99,9 +84,6 @@ docker compose ps
 ```
 
 You should see both `postgres` and `redis` containers in a healthy state.
-
----
-
 ## Step 5: Start the Application
 
 Run all services (frontend, backend API, worker) in development mode with a single command:
@@ -120,9 +102,6 @@ This starts:
 
 > [!NOTE]
 > On first startup, the server will automatically run database migrations and seed the initial admin user defined in your `.env` file.
-
----
-
 ## Step 6: Access the Dashboard
 
 Open your browser and navigate to:
@@ -132,9 +111,6 @@ http://localhost:3000
 ```
 
 Log in with the `SEED_USER_EMAIL` and `SEED_USER_PASSWORD` you set in `.env`.
-
----
-
 ## Running the Docs Locally
 
 If you want to contribute to or preview the documentation:
@@ -144,9 +120,6 @@ bun run docs:dev
 ```
 
 The docs site will be available at `http://localhost:5173` (or the next available port).
-
----
-
 ## Useful Commands
 
 | Command | Description |
@@ -158,9 +131,6 @@ The docs site will be available at `http://localhost:5173` (or the next availabl
 | `bun run docs:dev` | Start the documentation site in dev mode |
 | `docker compose up -d` | Start PostgreSQL and Redis in the background |
 | `docker compose down` | Stop and remove the database containers |
-
----
-
 ## Troubleshooting
 
 **Cannot connect to PostgreSQL**

--- a/docs/getting-started/routing.md
+++ b/docs/getting-started/routing.md
@@ -6,9 +6,6 @@ description: How Fluxify maps incoming requests to your API workflows, validates
 # Routing & Request Validation
 
 When someone calls your API, Fluxify automatically figures out which workflow to run, checks the request data against your defined rules, and only then starts executing your logic. This page explains how that works and what your callers can expect to receive.
-
----
-
 ## How Requests Are Matched
 
 Every route you create in Fluxify has an HTTP method (like `GET` or `POST`) and a URL path (like `/users/:id`). When a request comes in, Fluxify matches it to the right workflow instantly.
@@ -21,9 +18,6 @@ Path parameters like `:id` or `:slug` are captured automatically and made availa
 ::: tip Hot Reloading
 Routes update in real time. When you create or change a route in the dashboard, the change takes effect immediately — no server restart needed.
 :::
-
----
-
 ## What Happens Before Your Workflow Runs
 
 Before Fluxify executes a single block in your workflow, it runs through a quick validation pipeline:
@@ -36,9 +30,6 @@ Before Fluxify executes a single block in your workflow, it runs through a quick
 6. **Run your workflow** — only if everything above passed.
 
 If any validation step fails, the workflow never runs and the caller immediately gets a clear error response.
-
----
-
 ## Request Validation
 
 Each route optionally has three schemas you can configure in the Schema Editor:
@@ -84,9 +75,6 @@ return true;
 ```
 
 Whatever you pass to `ValidationError` is returned directly to the caller — giving you full control over your error messages.
-
----
-
 ## Validation Error Response
 
 When a request fails validation, the caller receives a `400 Bad Request` with a JSON body that clearly describes what went wrong.
@@ -117,9 +105,6 @@ When a request fails validation, the caller receives a `400 Bad Request` with a 
 | `errors[].errors` | One or more error messages for that field |
 
 When a custom JavaScript validator throws a `ValidationError`, its payload appears verbatim in `errors[].errors` — exactly as you wrote it.
-
----
-
 ## Error Responses at a Glance
 
 Here's every possible outcome and what the caller receives:
@@ -135,9 +120,6 @@ Here's every possible outcome and what the caller receives:
 ::: info Custom Status Codes
 Your workflow can return any HTTP status code you choose using the **Response** block — the defaults above only apply when no status is explicitly set.
 :::
-
----
-
 ## Next Steps
 
 - 🧩 [Explore the Blocks Reference](../blocks/index.md) — build the workflow logic that runs after validation

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
----
+
 layout: home
 
 hero:
@@ -40,4 +40,3 @@ features:
   - icon: 🚀
     title: Flexible Deployments
     details: Deploy as a standalone Docker container, in Kubernetes for high availability, or as a serverless function.
----

--- a/docs/scripting/context.md
+++ b/docs/scripting/context.md
@@ -10,9 +10,6 @@ Every time your JavaScript code runs — whether inside a **JS Runner** block, a
 This page is the complete reference for everything available in that environment.
 
 > **How it works**: When the execution engine prepares to run a script, it takes the `vars` object from the [Execution Context](../concepts/context.md), injects all its properties as top-level globals into the V8 sandbox, and runs your code. This means every function listed below is callable directly by name, with no prefix.
-
----
-
 ## The `input` Variable
 
 The single most important variable in any script:
@@ -29,9 +26,6 @@ return input.user.name; // → "Alice"
 ```
 
 > `input` is populated per-execution by the engine, not from `vars`. It is not persistent — each block receives only the output of its direct predecessor.
-
----
-
 ## Global Variables (Runtime State)
 
 Beyond built-in helpers, `vars` functions as a mutable key-value store for the duration of the workflow run. Any variable you assign in a script becomes a global accessible by all subsequent blocks.
@@ -52,9 +46,6 @@ return currentUser.name; // → "Alice"
 You can also use **Set Variable** blocks to write globals without writing code.
 
 > **Caution**: Variable names must not shadow built-in globals. Avoid names like `input`, `logger`, `jwt`, `libs`, `getHeader`, etc.
-
----
-
 ## HTTP Request Helpers
 
 Read data from the incoming HTTP request that triggered this workflow. All functions return `""` (empty string) if the requested value is not present.
@@ -80,9 +71,6 @@ const authHeader = getHeader("Authorization"); // "Bearer eyJ..."
 const body = getRequestBody();
 return body.amount * 1.1; // → 55
 ```
-
----
-
 ## HTTP Response Helpers
 
 Shape the response that will be sent back to the caller when the workflow completes.
@@ -120,9 +108,6 @@ setCookie("session_token", {
   samesite: "Strict"
 });
 ```
-
----
-
 ## Logger
 
 The `logger` object writes structured log entries to the configured output. The destination depends on project settings: **console** (default / local dev) or a **cloud observability provider** (Loki, OpenTelemetry Logs, etc.). See [Logging](../concepts/logging.md).
@@ -141,9 +126,6 @@ if (!result.success) {
   logger.logError("Order failed", result.error);
 }
 ```
-
----
-
 ## App Config
 
 `getConfig(key)` reads values from the project's **App Config** — a secure store for secrets, API keys, and environment-specific settings.
@@ -158,9 +140,6 @@ const maxRetries = getConfig("MAX_RETRY_COUNT"); // may return a number
 ```
 
 > Never hardcode secrets in scripts. Always use `getConfig()`.
-
----
-
 ## HTTP Client
 
 `httpClient` is an Axios-backed client for making **outgoing** HTTP requests from within a script. It is distinct from the workflow-level **HTTP Request** block and is available for direct use in JS Runner code.
@@ -182,9 +161,6 @@ const response = await httpClient.get("https://api.example.com/data", {
 });
 return response.data;
 ```
-
----
-
 ## JWT Utilities
 
 A built-in JWT helper is available globally as `jwt`:
@@ -209,9 +185,6 @@ if (!success) {
 }
 return payload.userId;
 ```
-
----
-
 ## Built-in Libraries (`libs`)
 
 Three third-party libraries are bundled and available as top-level globals inside scripts. No import statement is needed.
@@ -252,9 +225,6 @@ if (!result.success) {
 }
 return result.data;
 ```
-
----
-
 ## Database Helper (DB Native Block Only)
 
 `dbQuery` is **exclusively available** inside the **DB Native** block. It is injected into the VM context only when that specific block executes.
@@ -270,9 +240,6 @@ return users;
 ```
 
 Attempting to call `dbQuery` in a regular JS Runner block will result in a `ReferenceError`.
-
----
-
 ## Sandbox Constraints
 
 The scripting environment is a secure **V8 sandbox** (via Node.js `vm` module). The following constraints apply:
@@ -285,9 +252,6 @@ The scripting environment is a secure **V8 sandbox** (via Node.js `vm` module). 
 | **No cross-request state** | Variables exist only for the duration of a single workflow run. |
 | **Async supported** | `async/await` is fully supported. The VM waits for promise resolution. |
 | **ES6+ syntax** | Modern JavaScript (arrow functions, destructuring, spread, etc.) is supported. |
-
----
-
 ## Quick Reference
 
 ```typescript
@@ -328,9 +292,6 @@ zod                            // Zod schema validation
 // ─── DB Native block only ─────────────────────────────────────
 dbQuery("SELECT ...")
 ```
-
----
-
 ## Technical Notes for LLMs and Developers
 
 - **Injection mechanism**: All properties of the `ContextVarsType` object are spread as globals into the V8 `vm.createContext()` sandbox via `JsVM`. This is why helpers are available without a prefix.

--- a/docs/scripting/how-it-works.md
+++ b/docs/scripting/how-it-works.md
@@ -6,9 +6,6 @@ description: The execution model of Fluxify scripts.
 # How Scripting Works
 
 Fluxify executes your custom JavaScript code using an isolated, sandboxed Virtual Machine (VM) wrapper defined in `@fluxify/lib` (`JsVM`). This allows scripts to run server-side in a secure runtime sandbox that separates user execution from the host application process.
-
----
-
 ## The Execution Flow
 
 When a workflow runs a script (or evaluates a `js:` input), it follows these four steps:
@@ -17,9 +14,6 @@ When a workflow runs a script (or evaluates a `js:` input), it follows these fou
 2. **Context Injection**: The engine prepares the global environment by injecting helpers, third-party libraries, and the current workflow's variables (`vars`) as top-level globals in the sandboxed scope.
 3. **Sandboxed Evaluation**: The script is executed inside a fresh VM context. If the script is written in a block, it is wrapped in an immediately-invoked function expression (IIFE) to isolate variable declarations.
 4. **Result Resolution**: The output value is captured and returned. If the script returns a Promise (e.g., using `async`/`await` or calling async functions like `httpClient`), the VM suspends execution and waits for the Promise to resolve before passing the result to the next block.
-
----
-
 ## Synchronous vs. Asynchronous Execution
 
 Both synchronous logic and modern asynchronous JavaScript (`async/await`) are fully supported.
@@ -41,9 +35,6 @@ const userId = getQueryParam("userId");
 const response = await httpClient.get(`https://api.example.com/users/${userId}`);
 return response.data;
 ```
-
----
-
 ## Sandbox Limits and Timeouts
 
 To maintain platform stability and protect server resources, script execution is constrained by a strict **4-second (4000ms) execution limit**:

--- a/docs/scripting/index.md
+++ b/docs/scripting/index.md
@@ -8,9 +8,6 @@ description: Extend Fluxify functionalities with custom JavaScript.
 While Fluxify provides a robust set of built-in blocks, there are times when your workflows require custom logic. Fluxify's scripting features allow you to write standard JavaScript code to manipulate data, execute complex calculations, handle advanced routing or request parsing, and implement custom condition flows.
 
 All user scripts are executed on the server in a secure, isolated sandbox environment (Virtual Machine). This ensures safety and stability while running high-performance computations.
-
----
-
 ## Where Scripting Can Be Used
 
 Scripting in Fluxify is divided into two main categories: **dedicated script blocks** and **dynamic inputs/conditions**.
@@ -22,9 +19,6 @@ Scripting in Fluxify is divided into two main categories: **dedicated script blo
 ### 2. Dynamic Input Fields & Expressions
 - **Dynamic Field Inputs (`js:`)**: Many fields inside block editors allow you to write inline JavaScript code by prefixing the value with `js:`. The execution engine evaluates this expression at runtime and uses the result as the block's input.
 - **Condition Chains**: Use Javascript expressions within conditional gates (like the **If** block or routing conditions) to evaluate complex truth/falsity assertions.
-
----
-
 ## Writing Scripts: The `return` Requirement
 
 Every script you write in Fluxify is implicitly wrapped and executed inside an **Immediately Invoked Function Expression (IIFE)**. 
@@ -49,9 +43,6 @@ const rawAmount = input.total;
 const taxRate = 0.08;
 const total = rawAmount * (1 + taxRate);
 ```
-
----
-
 ## Core Execution Concepts
 
 To write effective scripts, you should be familiar with the following three concepts:

--- a/docs/scripting/key-considerations.md
+++ b/docs/scripting/key-considerations.md
@@ -8,9 +8,6 @@ description: Important limits, pitfalls, and behaviors that can cause 500 errors
 Because Fluxify runs your custom scripts on the server, writing improper code can cause workflow execution failures, return `500 Internal Server Error` statuses to clients, or degrade server-wide performance. 
 
 Pay close attention to the following constraints and pitfalls when scripting.
-
----
-
 ## 1. Global Variable Mutation (Context Corruption)
 
 Every block in a workflow execution shares the **same mutable context object**. Any global helper variables (like `setHeader`, `logger`, `jwt`, `libs`, `getConfig`, etc.) are injected as properties into this context.
@@ -31,9 +28,6 @@ Every block in a workflow execution shares the **same mutable context object**. 
   // ❌ BAD: Destroys the built-in logger reference for subsequent blocks
   logger = null; 
   ```
-
----
-
 ## 2. Missing `return` Statements
 
 All user scripts are implicitly wrapped in an Immediately Invoked Function Expression (IIFE).
@@ -49,9 +43,6 @@ All user scripts are implicitly wrapped in an Immediately Invoked Function Expre
   // Always return something
   return { success: true };
   ```
-
----
-
 ## 3. Unresolved Async Promises (Resource Leaks)
 
 Fluxify supports `async/await` and races asynchronous promises against a 4-second timeout.
@@ -64,9 +55,6 @@ Fluxify supports `async/await` and races asynchronous promises against a 4-secon
 ### Best Practice
 - Always specify timeouts on external fetches or operations (e.g., using Axios timeouts in `httpClient`).
 - Ensure all promises resolve or reject under all circumstances.
-
----
-
 ## 4. Unhandled Runtime Exceptions
 
 Executing operations on unverified inputs (like calling a method on `null` or `undefined`) throws runtime exceptions.
@@ -94,9 +82,6 @@ If an unhandled exception is thrown inside a script:
   return input.user.email;
   ```
 - Always configure an **Error Handler Block** in your workflow to catch script failures and return client-friendly JSON responses instead of 500 errors.
-
----
-
 ## 5. Memory Exhaustion
 
 Scripts run in-process on the server. If a script allocates massive structures (e.g. loading a 100MB database result, or infinite loops appending to a string), it can exhaust process memory. This will cause the garbage collector to consume 100% CPU or trigger an Out-Of-Memory (OOM) crash of the entire server instance, knocking out all API routes.

--- a/docs/scripting/npm-packages.md
+++ b/docs/scripting/npm-packages.md
@@ -23,9 +23,6 @@ const schema = zod.object({ name: zod.string() });
 ```
 
 These libraries are injected via the `libs` property of the [Execution Context](../concepts/context.md) and exposed as globals by the VM.
-
----
-
 ## Arbitrary NPM Packages — Not Supported
 
 The scripting environment does **not** support importing arbitrary NPM packages using `require()` or ES module `import` syntax. This is intentional:
@@ -35,9 +32,6 @@ The scripting environment does **not** support importing arbitrary NPM packages 
 - **Predictability**: A curated set of globals ensures consistent behavior across deployments.
 
 Calling `require("lodash")` or `import ... from "..."` inside a script will result in a `ReferenceError`.
-
----
-
 ## Recommended Alternatives
 
 | Need | Recommended approach |
@@ -49,9 +43,6 @@ Calling `require("lodash")` or `import ... from "..."` inside a script will resu
 | Complex collection operations | Use the **Array Operations** block |
 | External API calls | Use `httpClient` global or the **HTTP Request** block |
 | Secrets / config | Use `getConfig("KEY")` global |
-
----
-
 ## For Platform Developers
 
 If you are contributing to the Fluxify codebase itself (not scripting workflows), the full set of internal npm dependencies is managed by the monorepo. See the [Contributing Guide](/getting-started/contributing) for information about workspace packages, the `@fluxify/lib` package, and how `JsVM` injects the `libs` object.


### PR DESCRIPTION
Closes #82

## What
- Renamed ## 1. Workflows (API Endpoints) → ## 1. Routes (HTTP Endpoints) in asics.md to use correct terminology
- Added ## Running Fluxify section to getting-started/index.md with Docker container quick-start and link to the Self-Hosting guide
- Reordered sections in getting-started/index.md for a more intuitive user journey: What is Fluxify → Running Fluxify → How It Works → Core Capabilities → In This Section → Quick Links
- Added .vitepress/theme/custom.css and 	heme/index.ts to fix double HR line — uses .vp-doc hr selector with correct specificity to render a single divider line