### PR TITLE
fix(editor): resolve routing issue #86

### DIFF
--- a/apps/web/src/app/[projectId]/editor/[routeId]/page.tsx
+++ b/apps/web/src/app/[projectId]/editor/[routeId]/page.tsx
@@ -8,14 +8,16 @@ import { redirect } from "next/navigation";
 import React from "react";
 import { EditorStoreProvider } from "@/store/editor";
 import EditorProvidersWrapper from "@/components/editor/editorProvidersWrapper";
-
-const Page = async () => {
+const Page = async (props: { params: Promise<{ projectId: string; routeId: string }>; searchParams: Promise<{ [key: string]: string | string[] | undefined }> }) => {
+	const params = await props.params;
+	const searchParams = await props.searchParams;
 	const headersList = await headers();
 	const session = await authClient.getSession({
 		fetchOptions: { headers: headersList },
 	});
 	if (!session.data?.user) {
-		return redirect("/login");
+		const nextUrl = encodeURIComponent(`/${params.projectId}/editor/${params.routeId}`);
+		return redirect(`/login?next=${nextUrl}`);
 	}
 	const hasAccess = canAccess((session.data as any).acl, "viewer");
 	if (!hasAccess) {

--- a/apps/web/src/app/[projectId]/editor/[routeId]/settings/page.tsx
+++ b/apps/web/src/app/[projectId]/editor/[routeId]/settings/page.tsx
@@ -7,8 +7,10 @@ import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import React from "react";
 
-const Page = async ({ params }: { params: Promise<{ id: string }> }) => {
-  const routeId = (await params).id;
+const Page = async ({ params }: { params: Promise<{ projectId: string; routeId: string }> }) => {
+  const resolvedParams = await params;
+  const routeId = resolvedParams.routeId;
+  const projectId = resolvedParams.projectId;
 
   const headersList = await headers();
   const session = await authClient.getSession({
@@ -23,7 +25,7 @@ const Page = async ({ params }: { params: Promise<{ id: string }> }) => {
   }
   return (
     <Stack p={"xs"} h="100%">
-      <EditRouteSettings routeId={routeId} />
+      <EditRouteSettings routeId={routeId} projectId={projectId} />
     </Stack>
   );
 };

--- a/apps/web/src/app/[projectId]/layout.tsx
+++ b/apps/web/src/app/[projectId]/layout.tsx
@@ -88,7 +88,7 @@ const NewProjectLayout = ({ children }: { children: React.ReactNode }) => {
 		},
 	];
 
-	if (path.endsWith("/openapi") || path.includes("/custom-blocks/edit")) {
+	if (path.endsWith("/openapi") || path.includes("/custom-blocks/edit") || path.includes("/editor/")) {
 		return <>{children}</>;
 	}
 

--- a/apps/web/src/components/editor/backToEditorButton.tsx
+++ b/apps/web/src/components/editor/backToEditorButton.tsx
@@ -6,6 +6,7 @@ import { TbArrowNarrowLeft } from "react-icons/tb";
 
 type Props = {
   routeId: string;
+  projectId: string;
 };
 
 const BackToEditorButton = (props: Props) => {
@@ -15,7 +16,7 @@ const BackToEditorButton = (props: Props) => {
     if (window.history.length > 1) {
       router.back();
     } else {
-      router.push(`/editor/${props.routeId}`);
+      router.push(`/${props.projectId}/editor/${props.routeId}`);
     }
   }
 

--- a/apps/web/src/components/editor/blocks/settingsDialog/customBlockSettingsPanel.tsx
+++ b/apps/web/src/components/editor/blocks/settingsDialog/customBlockSettingsPanel.tsx
@@ -40,7 +40,7 @@ export const CustomBlockSettingsPanel = ({
 				<Text size="lg" fw={500}>
 					Parameters
 				</Text>
-				{customBlock.sourceType === "inhouse" && (
+				{customBlock.sourceType === "user-defined" && (
 					<Button
 						component="a"
 						href={`/_/admin/ui/${projectId}/custom-blocks/edit/${customBlock.id}`}

--- a/apps/web/src/components/editor/editorProvidersWrapper.tsx
+++ b/apps/web/src/components/editor/editorProvidersWrapper.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import React, { useMemo } from "react";
+import React, { useEffect, useMemo } from "react";
 import { CanvasStoreProvider } from "@/store/canvas";
 import { BlockDataStoreProvider } from "@/store/blockDataStore";
 import { FlowEditorFeatures, FlowEditorProvider } from "./flowEditor/flowEditorContext";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { routesQueries } from "@/query/routerQuery";
 import QueryLoader from "../query/queryLoader";
 import QueryError from "../query/queryError";
@@ -21,18 +21,38 @@ const defaultFeatures: FlowEditorFeatures = {
 };
 
 const EditorProvidersWrapper = ({ children }: { children: React.ReactNode }) => {
-	const { id } = useParams<{ id: string }>();
+	const { routeId } = useParams<{ routeId: string }>();
+	const router = useRouter();
 	const { useQuery } = routesQueries.getCanvasItems;
-	const { data: itemsData, isLoading: itemsLoading, isError: itemsError, error: itemsErrorData, refetch: refetchItems } = useQuery(id);
-	const { data: routeData, isLoading: routeLoading } = routesQueries.getById.useQuery(id);
+	const { data: itemsData, isLoading: itemsLoading, isError: itemsError, error: itemsErrorData, refetch: refetchItems } = useQuery(routeId);
+	const { data: routeData, isLoading: routeLoading, isError: routeError, error: routeErrorData } = routesQueries.getById.useQuery(routeId);
 	const { acl, userData } = useAuthStore();
+
+	useEffect(() => {
+		if (routeError || itemsError) {
+			const err = (routeErrorData || itemsErrorData) as any;
+			const status = err?.response?.status || err?.status;
+			if (status === 404) {
+				const errorData = err?.response?.data || err?.data;
+				if (errorData?.projectId) {
+					router.replace(`/${errorData.projectId}/routes`);
+				} else {
+					router.replace("/");
+				}
+			}
+		}
+	}, [routeError, itemsError, routeErrorData, itemsErrorData, router]);
 
 	if (itemsLoading || routeLoading) {
 		return <QueryLoader type="spinner" />;
 	}
 
 	if (itemsError) {
-		return <QueryError error={itemsErrorData} refetcher={refetchItems} />;
+		const err = itemsErrorData as any;
+		const status = err?.response?.status || err?.status;
+		if (status !== 404) {
+			return <QueryError error={itemsErrorData} refetcher={refetchItems} />;
+		}
 	}
 
 	if (!itemsData || !routeData) {
@@ -61,7 +81,7 @@ const EditorProvidersWrapper = ({ children }: { children: React.ReactNode }) => 
 		<FlowEditorProvider
 			value={{
 				readonly: false,
-				entityId: id,
+				entityId: routeId,
 				entityType: "route",
 				projectId: projectId as string,
 				features: defaultFeatures,

--- a/apps/web/src/components/editor/panels/testingPanel.tsx
+++ b/apps/web/src/components/editor/panels/testingPanel.tsx
@@ -36,7 +36,7 @@ export type TestSuite = {
 };
 
 const TestingPanel = () => {
-  const { id } = useParams<{ id: string }>();
+  const { routeId } = useParams<{ routeId: string }>();
   const queryClient = useQueryClient();
   const {
     data: route,
@@ -44,9 +44,9 @@ const TestingPanel = () => {
     isError,
     error,
     refetch,
-  } = routesQueries.getById.useQuery(id);
+  } = routesQueries.getById.useQuery(routeId);
 
-  const { data: testSuitesList } = testSuitesQueries.getAll.useQuery(id);
+  const { data: testSuitesList } = testSuitesQueries.getAll.useQuery(routeId);
   const testSuites = (testSuitesList || []) as any[];
 
   const [activeView, setActiveView] = useState<"playground" | string>(
@@ -81,7 +81,7 @@ const TestingPanel = () => {
       route_id: route?.id,
       assertions: [],
     });
-    testSuitesQueries.getAll.invalidate(queryClient, id);
+    testSuitesQueries.getAll.invalidate(queryClient, routeId);
     setActiveView(res.id);
     setNewSuite({ name: "", description: "" });
     setIsAddDialogOpen(false);

--- a/apps/web/src/components/editor/saveEditorButton.tsx
+++ b/apps/web/src/components/editor/saveEditorButton.tsx
@@ -10,7 +10,7 @@ const SaveEditorButton = () => {
 	const { entityId, entityType, readonly } = useFlowEditorContext();
 	const changeTracker = useEditorChangeTrackerStore();
 	const disableButton = changeTracker.tracker.size === 0;
-	const { id: routeId } = useParams<{ id: string }>();
+	const { routeId } = useParams<{ routeId: string }>();
 	const { onSave } = useCanvasSave(entityId ?? "", entityType ?? "route");
 
 	async function onSaveClicked() {

--- a/apps/web/src/components/editor/topbar.tsx
+++ b/apps/web/src/components/editor/topbar.tsx
@@ -11,8 +11,8 @@ import RequireRole from "../auth/requireRole";
 import { routesQueries } from "@/query/routerQuery";
 
 const Topbar = () => {
-  const { id } = useParams();
-  const { data: route } = routesQueries.getById.useQuery(id!.toString());
+  const { routeId } = useParams();
+  const { data: route } = routesQueries.getById.useQuery(routeId!.toString());
   const projectId = route?.projectId;
   return (
     <Paper style={{ zIndex: 10 }} shadow="sm" p={"sm"} pos={"relative"}>
@@ -44,7 +44,7 @@ const Topbar = () => {
             <RequireRole projectId={projectId || ""} requiredRole="creator">
               <ActiveToggle
                 showToggleNotifications
-                routeId={id?.toString() ?? ""}
+                routeId={routeId?.toString() ?? ""}
               />
               <SaveEditorButton />
               <VersionHistoryButton />

--- a/apps/web/src/components/editor/updateRouteNameField.tsx
+++ b/apps/web/src/components/editor/updateRouteNameField.tsx
@@ -26,9 +26,9 @@ import Link from "next/link";
 import HttpMethodText from "../httpMethodText";
 
 const UpdateRouteNameField = () => {
-	const { id } = useParams();
+	const { routeId } = useParams();
 	const { useQuery } = routesQueries.getById;
-	const { data, isLoading } = useQuery(id?.toString() || "");
+	const { data, isLoading } = useQuery(routeId?.toString() || "");
 	const [name, setName] = React.useState(data?.name || "");
 	const queryClient = useQueryClient();
 	const [updateLoading, setUpdateLoading] = useState(false);
@@ -157,7 +157,7 @@ const UpdateRouteNameField = () => {
 								<Menu.Item
 									key={route.id}
 									component={Link}
-									href={`/editor/${route.id}`}
+									href={`/${projectId}/editor/${route.id}`}
 								>
 									<Group wrap="nowrap" gap="xs">
 										<HttpMethodText method={route.method as any} small />

--- a/apps/web/src/components/forms/EditRouteSettings.tsx
+++ b/apps/web/src/components/forms/EditRouteSettings.tsx
@@ -11,7 +11,7 @@ import { ValidationSchema, SchemaEditorRef, DataType } from "@/types/schemaEdito
 import { TbInfoCircle, TbDeviceFloppy } from "react-icons/tb";
 import BackToEditorButton from "../editor/backToEditorButton";
 
-export default function EditRouteSettings({ routeId }: { routeId: string }) {
+export default function EditRouteSettings({ routeId, projectId }: { routeId: string; projectId: string }) {
   const { data: routeData, isLoading, error } = routesQueries.getById.useQuery(routeId);
   const client = useQueryClient();
   const [loading, setLoading] = useState(false);
@@ -209,7 +209,7 @@ export default function EditRouteSettings({ routeId }: { routeId: string }) {
             </Box>
             
             <Box>
-              <BackToEditorButton routeId={routeId} />
+              <BackToEditorButton routeId={routeId} projectId={projectId} />
             </Box>
           </Stack>
         </Paper>

--- a/apps/web/src/components/routeItem.tsx
+++ b/apps/web/src/components/routeItem.tsx
@@ -75,7 +75,7 @@ const RouteItem = (props: Proptypes) => {
   }
 
   function onItemClick() {
-    router.push(`/editor/${props.id}`);
+    router.push(`/${props.projectId}/editor/${props.id}`);
   }
 
   const projectName = props.projectName;
@@ -132,7 +132,7 @@ const RouteItem = (props: Proptypes) => {
                 onChange={toggleActive}
                 checked={active}
               />
-              <RouteItemMenu id={props.id} />
+              <RouteItemMenu id={props.id} projectId={props.projectId} />
             </RequireRole>
           </Group>
         </Grid.Col>

--- a/apps/web/src/components/routeItemMenu.tsx
+++ b/apps/web/src/components/routeItemMenu.tsx
@@ -13,6 +13,7 @@ import { useRouter } from "next/navigation";
 
 type Proptypes = {
   id: string;
+  projectId: string;
 };
 
 const RouteItemMenu = (props: Proptypes) => {
@@ -21,7 +22,7 @@ const RouteItemMenu = (props: Proptypes) => {
   const router = useRouter();
 
   function onEditClicked() {
-    router.push(`/editor/${props.id}/settings`);
+    router.push(`/${props.projectId}/editor/${props.id}/settings`);
   }
   function onDuplicateClicked() {}
   function onDownloadJsonClicked() {}

--- a/apps/web/src/query/routerQuery.ts
+++ b/apps/web/src/query/routerQuery.ts
@@ -27,6 +27,7 @@ export const routesQueries = {
           return await routesService.getByID(id);
         },
         refetchOnWindowFocus: false,
+        retry: false,
         enabled: !!id,
       });
     },
@@ -45,6 +46,7 @@ export const routesQueries = {
           return await routesService.getCanvasItems(id);
         },
         refetchOnWindowFocus: false,
+        retry: false,
         staleTime: Infinity,
       });
     },


### PR DESCRIPTION
Moves the editor route to properly support route IDs and updates components to use routeId instead of id to prevent query errors and overlapping layouts.