### PR TITLE
fix: prevent unnecessary refetching of Integration & Custom blocks

### DIFF
--- a/apps/web/src/components/editors/integrationSelector.tsx
+++ b/apps/web/src/components/editors/integrationSelector.tsx
@@ -74,7 +74,7 @@ const IntegrationSelector = (props: Props) => {
     }
   }, [selectedIntegration]);
 
-  if (isLoading || isRefetching) {
+  if (isLoading) {
     return <QueryLoader skeletonsCols={1} skeletonsRows={1} />;
   }
 

--- a/apps/web/src/query/customBlocksQuery.ts
+++ b/apps/web/src/query/customBlocksQuery.ts
@@ -13,6 +13,7 @@ export const customBlocksQueries = {
           return await customBlocksService.getAll(query);
         },
         refetchOnWindowFocus: false,
+        staleTime: 5 * 60 * 1000,
       });
     },
     invalidate(client: QueryClient, projectId: string) {

--- a/apps/web/src/query/integrationsQuery.ts
+++ b/apps/web/src/query/integrationsQuery.ts
@@ -16,6 +16,7 @@ export const integrationsQuery = {
 				queryKey: ["integrations", projectId, group, tags],
 				queryFn: () => integrationService.getAll(projectId, group, tags),
 				refetchOnWindowFocus: false,
+				staleTime: 5 * 60 * 1000,
 				enabled: !!projectId,
 			});
 		},


### PR DESCRIPTION
Fixes #95. Added staleTime to queries and removed isRefetching check from IntegrationSelector to prevent UI unmount during background refetches.