### PR TITLE
fix(ai-gateway): load project-level AI settings and keys for harness runs

### DIFF
--- a/apps/ai-gateway/src/harness/models/projectConfig.ts
+++ b/apps/ai-gateway/src/harness/models/projectConfig.ts
@@ -1,0 +1,42 @@
+import { aiIntegrationsCache, aiVariantSchema, getProjectSetting } from "@fluxify/server";
+import type { AgentFactoryOptions, AgentProvider } from "./factory";
+
+/** Maps a stored AI integration variant to the harness agent provider. */
+const VARIANT_TO_PROVIDER: Record<string, AgentProvider> = {
+	[aiVariantSchema.enum.Anthropic]: "anthropic",
+	[aiVariantSchema.enum.Gemini]: "google",
+	[aiVariantSchema.enum.OpenAI]: "openai",
+	[aiVariantSchema.enum.Mistral]: "mistral",
+	[aiVariantSchema.enum["OpenAI Compatible"]]: "openai",
+};
+
+/**
+ * Resolves the harness agent config from the user-configured AI integration for
+ * a project. Keys never leave the server config — nothing is read from env or
+ * hardcoded. Throws if the project has no AI integration set.
+ */
+export async function resolveAgentOptionsFromProjectId(
+	projectId: string,
+): Promise<AgentFactoryOptions> {
+	const integrationId = await getProjectSetting(
+		projectId,
+		"settings.ai.agentConnectionId",
+	);
+	const integration = aiIntegrationsCache[integrationId];
+
+	if (!integration) {
+		throw new Error("No AI integration configured for this project");
+	}
+
+	const provider = VARIANT_TO_PROVIDER[integration.variant];
+	if (!provider) {
+		throw new Error(`Unsupported AI variant for harness: ${integration.variant}`);
+	}
+
+	return {
+		provider,
+		modelName: integration.model,
+		apiKey: integration.apiKey,
+		baseUrl: integration.baseUrl,
+	};
+}

--- a/apps/ai-gateway/src/harness/worker.ts
+++ b/apps/ai-gateway/src/harness/worker.ts
@@ -2,23 +2,11 @@ import { Worker } from "bullmq";
 import { logger } from "@fluxify/common";
 import { REDIS_HOST, REDIS_PASS, REDIS_PORT, REDIS_USER } from "../lib/env";
 import { HARNESS_QUEUE_NAME, type HarnessJobData } from "./queue";
-import { AgentFactory, type AgentProvider } from "./models/factory";
+import { AgentFactory } from "./models/factory";
+import { resolveAgentOptionsFromProjectId } from "./models/projectConfig";
 import { FluxifyHarness, type HarnessRunContext } from "./index";
 
 let worker: Worker<HarnessJobData> | null = null;
-
-/** Builds the LLM agent factory from env (defaults mirror demo.ts). */
-function createAgentFactory(): AgentFactory {
-	return new AgentFactory({
-		provider: (process.env.HARNESS_LLM_PROVIDER as AgentProvider) || "mistral",
-		modelName: process.env.HARNESS_LLM_MODEL || "mistral-medium-3-5",
-		apiKey:
-			process.env.HARNESS_LLM_API_KEY ||
-			process.env.MISTRAL_API_KEY ||
-			"cBTsofirRdO6gJpPH2n0TRcIiZgJI4Ih",
-		maxToolIterations: 20,
-	});
-}
 
 /**
  * Starts the BullMQ worker that consumes harness jobs and drives a run through
@@ -31,7 +19,17 @@ export function initializeHarnessWorker() {
 		HARNESS_QUEUE_NAME,
 		async (job) => {
 			const data = job.data;
-			const harness = new FluxifyHarness(createAgentFactory());
+
+			const projectId = data.metadata?.projectId;
+			if (!projectId) {
+				throw new Error("Harness job missing projectId; cannot resolve AI config");
+			}
+
+			// AI provider/keys come from the user's configured integration, never env.
+			const agentOptions = await resolveAgentOptionsFromProjectId(projectId);
+			const harness = new FluxifyHarness(
+				new AgentFactory({ ...agentOptions, maxToolIterations: 20 }),
+			);
 			const ctx: HarnessRunContext = {
 				conversationId: data.conversationId,
 				runId: data.runId,


### PR DESCRIPTION
### Summary

Resolves #106.

#### Why
Previously, the AI gateway worker initialized harness runs using hardcoded/environment variable LLM configurations, ignoring the project-specific AI connection and settings stored in the database.

#### What Changed
- Added \esolveAgentOptionsFromProjectId\ in \pps/ai-gateway/src/harness/models/projectConfig.ts\ to dynamically resolve AI provider, model, API key, and base URL from the project's configured AI integration (\settings.ai.agentConnectionId\).
- Updated \initializeHarnessWorker\ in \pps/ai-gateway/src/harness/worker.ts\ to fetch project AI settings using \projectId\ before starting the harness run.