### PR TITLE
feat(server): dynamic SSO layer + instance-settings admin management

### DIFF
--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -15,6 +15,9 @@ REDIS_PASS=
 #====================== PORT CONFIG & URLS ======================
 SERVER_PORT=5500
 SERVER_URL=http://localhost:8080
+# Comma-separated origins allowed for CORS + Better Auth (web + API). Prod DNS behind the proxy.
+# Dev localhost:* is always allowed. e.g. https://app.example.com,https://api.example.com
+TRUSTED_ORIGINS=http://localhost:8080
 
 #====================== SECURITY & AUTH ======================
 ENABLE_ADMIN=true

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -34,6 +34,7 @@
 		"typescript": "^6.0.3"
 	},
 	"dependencies": {
+		"@better-auth/sso": "^1.6.24",
 		"@fluxify/adapters": "workspace:*",
 		"@fluxify/blocks": "workspace:*",
 		"@fluxify/common": "workspace:*",

--- a/apps/server/src/api/auth/create-user/service.ts
+++ b/apps/server/src/api/auth/create-user/service.ts
@@ -1,15 +1,54 @@
 import { requestBodySchema, responseSchema } from "./dto";
 import { z } from "zod";
 import { auth } from "../../../lib/auth";
+import { db } from "../../../db";
+import { user } from "../../../db/auth-schema";
+import { generateID } from "@fluxify/lib";
+import { getSetting } from "../../../loaders/instanceSettingsLoader";
+import { ValidationError } from "../../../errors/validationError";
 
 export default async function handleRequest(
   data: z.infer<typeof requestBodySchema>
 ): Promise<z.infer<typeof responseSchema>> {
+  const mode = getSetting("auth_config")?.mode ?? "traditional";
+
+  if (mode === "sso_only") {
+    // Auth is offloaded to the IdP: create a pre-provisioned user row only,
+    // no credential account. Enforce the IdP domain (no cross-domain accounts).
+    const sso = getSetting("sso_config");
+    if (!sso) {
+      throw new ValidationError([
+        { field: "email", message: "SSO is not configured" },
+      ]);
+    }
+    const domain = data.email.split("@")[1]?.toLowerCase();
+    if (domain !== sso.domain.toLowerCase()) {
+      throw new ValidationError([
+        { field: "email", message: `Email must be on the ${sso.domain} domain` },
+      ]);
+    }
+    const id = generateID();
+    await db.insert(user).values({
+      id,
+      email: data.email,
+      name: data.fullname || "",
+      emailVerified: true,
+      isSystemAdmin: data.isSystemAdmin,
+    });
+    return { id };
+  }
+
+  // traditional: email + password required
+  if (!data.password) {
+    throw new ValidationError([
+      { field: "password", message: "Password is required" },
+    ]);
+  }
   const result = await auth.api.createUser({
     body: {
       email: data.email,
       name: data.fullname || "",
-      password: data.password!,
+      password: data.password,
       data: {
         isSystemAdmin: data.isSystemAdmin,
       },

--- a/apps/server/src/api/register.ts
+++ b/apps/server/src/api/register.ts
@@ -2,9 +2,13 @@ import v1Register from "./v1/register";
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { HonoServer } from "../types";
+import { getPublicSettings } from "../loaders/instanceSettingsLoader";
 
 export function mapVersionedAdminRoutes(app: HonoServer) {
   const router = app.basePath("/_/admin/api");
+  // Public, unauthenticated feature flags. Secrets are stripped by each key's
+  // publicSchema, so is_public rows never leak IdP credentials.
+  router.get("/public-settings", (c) => c.json(getPublicSettings()));
   router.get("/openapi/ui", (c) => {
     try {
       const htmlContent = loadHtmlContent();

--- a/apps/server/src/api/v1/instance-settings/dto.ts
+++ b/apps/server/src/api/v1/instance-settings/dto.ts
@@ -1,0 +1,14 @@
+import z from "zod";
+import { instanceSettingCategorySchema } from "../../../lib/instance-settings/schemas";
+
+export const instanceSettingItemSchema = z.object({
+	id: z.string(),
+	key: z.string(),
+	category: instanceSettingCategorySchema,
+	value: z.record(z.string(), z.unknown()),
+	isPublic: z.boolean(),
+	createdAt: z.date().or(z.string()),
+	updatedAt: z.date().or(z.string()),
+});
+
+export type InstanceSettingItem = z.infer<typeof instanceSettingItemSchema>;

--- a/apps/server/src/api/v1/instance-settings/get-all/dto.ts
+++ b/apps/server/src/api/v1/instance-settings/get-all/dto.ts
@@ -1,0 +1,4 @@
+import z from "zod";
+import { instanceSettingItemSchema } from "../dto";
+
+export const responseSchema = z.array(instanceSettingItemSchema);

--- a/apps/server/src/api/v1/instance-settings/get-all/repository.ts
+++ b/apps/server/src/api/v1/instance-settings/get-all/repository.ts
@@ -1,0 +1,6 @@
+import { db } from "../../../../db";
+import { instanceSettingsEntity } from "../../../../db/schema";
+
+export async function getAllInstanceSettings() {
+	return await db.select().from(instanceSettingsEntity);
+}

--- a/apps/server/src/api/v1/instance-settings/get-all/route.ts
+++ b/apps/server/src/api/v1/instance-settings/get-all/route.ts
@@ -1,0 +1,62 @@
+import {
+	describeRoute,
+	DescribeRouteOptions,
+	resolver,
+} from "hono-openapi";
+import { responseSchema } from "./dto";
+import handleRequest from "./service";
+import { errorSchema } from "../../../../errors/customError";
+import { HonoServer } from "../../../../types";
+import { requireSystemAdmin } from "../../../auth/middleware";
+
+const openapiRouteOptions: DescribeRouteOptions = {
+	description: "Get all instance settings",
+	operationId: "get-all-instance-settings",
+	tags: ["Instance Settings"],
+	responses: {
+		200: {
+			description: "Successful",
+			content: {
+				"application/json": {
+					schema: resolver(responseSchema),
+				},
+			},
+		},
+		401: {
+			description: "Unauthorized",
+			content: {
+				"application/json": {
+					schema: resolver(errorSchema),
+				},
+			},
+		},
+		403: {
+			description: "Forbidden",
+			content: {
+				"application/json": {
+					schema: resolver(errorSchema),
+				},
+			},
+		},
+		500: {
+			description: "Internal Server Error",
+			content: {
+				"application/json": {
+					schema: resolver(errorSchema),
+				},
+			},
+		},
+	},
+};
+
+export default function (app: HonoServer) {
+	app.get(
+		"/",
+		describeRoute(openapiRouteOptions),
+		requireSystemAdmin,
+		async (c) => {
+			const result = await handleRequest();
+			return c.json(result);
+		},
+	);
+}

--- a/apps/server/src/api/v1/instance-settings/get-all/service.ts
+++ b/apps/server/src/api/v1/instance-settings/get-all/service.ts
@@ -1,0 +1,7 @@
+import { redactSecrets } from "../../../../lib/instance-settings/schemas";
+import { getAllInstanceSettings } from "./repository";
+
+export default async function handleRequest() {
+	const rows = await getAllInstanceSettings();
+	return rows.map((row) => ({ ...row, value: redactSecrets(row.value) }));
+}

--- a/apps/server/src/api/v1/instance-settings/get-all/tests/get-all.test.ts
+++ b/apps/server/src/api/v1/instance-settings/get-all/tests/get-all.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, mock, beforeEach } from "bun:test";
+import handleRequest from "../service";
+import * as repository from "../repository";
+
+mock.module("../repository", () => ({
+	getAllInstanceSettings: mock(),
+}));
+
+describe("get-all instance settings service", () => {
+	beforeEach(() => {
+		(repository.getAllInstanceSettings as any).mockClear();
+	});
+
+	it("should return list of all instance settings from repository", async () => {
+		const mockSettings = [
+			{
+				id: "setting-1",
+				key: "sso_config",
+				category: "auth",
+				value: { enabled: true, provider: "oidc", issuer: "https://auth.example.com", domain: "example.com" },
+				isPublic: true,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			},
+		];
+		(repository.getAllInstanceSettings as any).mockResolvedValue(mockSettings);
+
+		const result = await handleRequest();
+
+		expect(repository.getAllInstanceSettings).toHaveBeenCalledTimes(1);
+		expect(result).toEqual(mockSettings);
+	});
+});

--- a/apps/server/src/api/v1/instance-settings/get-by-category/dto.ts
+++ b/apps/server/src/api/v1/instance-settings/get-by-category/dto.ts
@@ -1,0 +1,9 @@
+import z from "zod";
+import { instanceSettingItemSchema } from "../dto";
+import { instanceSettingCategorySchema } from "../../../../lib/instance-settings/schemas";
+
+export const requestRouteSchema = z.object({
+	category: instanceSettingCategorySchema,
+});
+
+export const responseSchema = z.array(instanceSettingItemSchema);

--- a/apps/server/src/api/v1/instance-settings/get-by-category/repository.ts
+++ b/apps/server/src/api/v1/instance-settings/get-by-category/repository.ts
@@ -1,0 +1,10 @@
+import { eq } from "drizzle-orm";
+import { db } from "../../../../db";
+import { instanceSettingsEntity } from "../../../../db/schema";
+
+export async function getInstanceSettingsByCategory(category: string) {
+	return await db
+		.select()
+		.from(instanceSettingsEntity)
+		.where(eq(instanceSettingsEntity.category, category as any));
+}

--- a/apps/server/src/api/v1/instance-settings/get-by-category/route.ts
+++ b/apps/server/src/api/v1/instance-settings/get-by-category/route.ts
@@ -1,0 +1,75 @@
+import {
+	describeRoute,
+	DescribeRouteOptions,
+	resolver,
+	validator,
+} from "hono-openapi";
+import { requestRouteSchema, responseSchema } from "./dto";
+import handleRequest from "./service";
+import zodErrorCallbackParser from "../../../../middlewares/zodErrorCallbackParser";
+import { errorSchema } from "../../../../errors/customError";
+import { validationErrorSchema } from "../../../../errors/validationError";
+import { HonoServer } from "../../../../types";
+import { requireSystemAdmin } from "../../../auth/middleware";
+
+const openapiRouteOptions: DescribeRouteOptions = {
+	description: "Get instance settings by category",
+	operationId: "get-instance-settings-by-category",
+	tags: ["Instance Settings"],
+	responses: {
+		200: {
+			description: "Successful",
+			content: {
+				"application/json": {
+					schema: resolver(responseSchema),
+				},
+			},
+		},
+		400: {
+			description: "Validation Error",
+			content: {
+				"application/json": {
+					schema: resolver(validationErrorSchema),
+				},
+			},
+		},
+		401: {
+			description: "Unauthorized",
+			content: {
+				"application/json": {
+					schema: resolver(errorSchema),
+				},
+			},
+		},
+		403: {
+			description: "Forbidden",
+			content: {
+				"application/json": {
+					schema: resolver(errorSchema),
+				},
+			},
+		},
+		500: {
+			description: "Internal Server Error",
+			content: {
+				"application/json": {
+					schema: resolver(errorSchema),
+				},
+			},
+		},
+	},
+};
+
+export default function (app: HonoServer) {
+	app.get(
+		"/category/:category",
+		describeRoute(openapiRouteOptions),
+		requireSystemAdmin,
+		validator("param", requestRouteSchema, zodErrorCallbackParser),
+		async (c) => {
+			const { category } = c.req.valid("param");
+			const result = await handleRequest(category);
+			return c.json(result);
+		},
+	);
+}

--- a/apps/server/src/api/v1/instance-settings/get-by-category/service.ts
+++ b/apps/server/src/api/v1/instance-settings/get-by-category/service.ts
@@ -1,0 +1,7 @@
+import { redactSecrets } from "../../../../lib/instance-settings/schemas";
+import { getInstanceSettingsByCategory } from "./repository";
+
+export default async function handleRequest(category: string) {
+	const rows = await getInstanceSettingsByCategory(category);
+	return rows.map((row) => ({ ...row, value: redactSecrets(row.value) }));
+}

--- a/apps/server/src/api/v1/instance-settings/get-by-category/tests/get-by-category.test.ts
+++ b/apps/server/src/api/v1/instance-settings/get-by-category/tests/get-by-category.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, mock, beforeEach } from "bun:test";
+import handleRequest from "../service";
+import * as repository from "../repository";
+
+mock.module("../repository", () => ({
+	getInstanceSettingsByCategory: mock(),
+}));
+
+describe("get-by-category instance settings service", () => {
+	beforeEach(() => {
+		(repository.getInstanceSettingsByCategory as any).mockClear();
+	});
+
+	it("should return settings for the requested category", async () => {
+		const mockSettings = [
+			{
+				id: "setting-1",
+				key: "sso_config",
+				category: "auth",
+				value: { enabled: true, provider: "oidc", issuer: "https://auth.example.com", domain: "example.com" },
+				isPublic: true,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			},
+		];
+		(repository.getInstanceSettingsByCategory as any).mockResolvedValue(mockSettings);
+
+		const result = await handleRequest("auth");
+
+		expect(repository.getInstanceSettingsByCategory).toHaveBeenCalledWith("auth");
+		expect(result).toEqual(mockSettings);
+	});
+});

--- a/apps/server/src/api/v1/instance-settings/get-by-key/dto.ts
+++ b/apps/server/src/api/v1/instance-settings/get-by-key/dto.ts
@@ -1,0 +1,8 @@
+import z from "zod";
+import { instanceSettingItemSchema } from "../dto";
+
+export const requestRouteSchema = z.object({
+	key: z.string(),
+});
+
+export const responseSchema = instanceSettingItemSchema;

--- a/apps/server/src/api/v1/instance-settings/get-by-key/repository.ts
+++ b/apps/server/src/api/v1/instance-settings/get-by-key/repository.ts
@@ -1,0 +1,11 @@
+import { eq } from "drizzle-orm";
+import { db } from "../../../../db";
+import { instanceSettingsEntity } from "../../../../db/schema";
+
+export async function getInstanceSettingByKey(key: string) {
+	const rows = await db
+		.select()
+		.from(instanceSettingsEntity)
+		.where(eq(instanceSettingsEntity.key, key));
+	return rows[0] ?? null;
+}

--- a/apps/server/src/api/v1/instance-settings/get-by-key/route.ts
+++ b/apps/server/src/api/v1/instance-settings/get-by-key/route.ts
@@ -1,0 +1,83 @@
+import {
+	describeRoute,
+	DescribeRouteOptions,
+	resolver,
+	validator,
+} from "hono-openapi";
+import { requestRouteSchema, responseSchema } from "./dto";
+import handleRequest from "./service";
+import zodErrorCallbackParser from "../../../../middlewares/zodErrorCallbackParser";
+import { errorSchema } from "../../../../errors/customError";
+import { validationErrorSchema } from "../../../../errors/validationError";
+import { HonoServer } from "../../../../types";
+import { requireSystemAdmin } from "../../../auth/middleware";
+
+const openapiRouteOptions: DescribeRouteOptions = {
+	description: "Get instance setting by key",
+	operationId: "get-instance-setting-by-key",
+	tags: ["Instance Settings"],
+	responses: {
+		200: {
+			description: "Successful",
+			content: {
+				"application/json": {
+					schema: resolver(responseSchema),
+				},
+			},
+		},
+		400: {
+			description: "Validation Error",
+			content: {
+				"application/json": {
+					schema: resolver(validationErrorSchema),
+				},
+			},
+		},
+		401: {
+			description: "Unauthorized",
+			content: {
+				"application/json": {
+					schema: resolver(errorSchema),
+				},
+			},
+		},
+		403: {
+			description: "Forbidden",
+			content: {
+				"application/json": {
+					schema: resolver(errorSchema),
+				},
+			},
+		},
+		404: {
+			description: "Not Found",
+			content: {
+				"application/json": {
+					schema: resolver(errorSchema),
+				},
+			},
+		},
+		500: {
+			description: "Internal Server Error",
+			content: {
+				"application/json": {
+					schema: resolver(errorSchema),
+				},
+			},
+		},
+	},
+};
+
+export default function (app: HonoServer) {
+	app.get(
+		"/key/:key",
+		describeRoute(openapiRouteOptions),
+		requireSystemAdmin,
+		validator("param", requestRouteSchema, zodErrorCallbackParser),
+		async (c) => {
+			const { key } = c.req.valid("param");
+			const result = await handleRequest(key);
+			return c.json(result);
+		},
+	);
+}

--- a/apps/server/src/api/v1/instance-settings/get-by-key/service.ts
+++ b/apps/server/src/api/v1/instance-settings/get-by-key/service.ts
@@ -1,0 +1,11 @@
+import { NotFoundError } from "../../../../errors/notFoundError";
+import { redactSecrets } from "../../../../lib/instance-settings/schemas";
+import { getInstanceSettingByKey } from "./repository";
+
+export default async function handleRequest(key: string) {
+	const setting = await getInstanceSettingByKey(key);
+	if (!setting) {
+		throw new NotFoundError(`Instance setting with key '${key}' not found`);
+	}
+	return { ...setting, value: redactSecrets(setting.value) };
+}

--- a/apps/server/src/api/v1/instance-settings/get-by-key/tests/get-by-key.test.ts
+++ b/apps/server/src/api/v1/instance-settings/get-by-key/tests/get-by-key.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, mock, beforeEach } from "bun:test";
+import handleRequest from "../service";
+import * as repository from "../repository";
+import { NotFoundError } from "../../../../../errors/notFoundError";
+
+mock.module("../repository", () => ({
+	getInstanceSettingByKey: mock(),
+}));
+
+describe("get-by-key instance settings service", () => {
+	beforeEach(() => {
+		(repository.getInstanceSettingByKey as any).mockClear();
+	});
+
+	it("should return setting if found", async () => {
+		const mockSetting = {
+			id: "setting-1",
+			key: "sso_config",
+			category: "auth",
+			value: { enabled: true, provider: "oidc", issuer: "https://auth.example.com", domain: "example.com" },
+			isPublic: true,
+			createdAt: new Date(),
+			updatedAt: new Date(),
+		};
+		(repository.getInstanceSettingByKey as any).mockResolvedValue(mockSetting);
+
+		const result = await handleRequest("sso_config");
+
+		expect(repository.getInstanceSettingByKey).toHaveBeenCalledWith("sso_config");
+		expect(result).toEqual(mockSetting);
+	});
+
+	it("should throw NotFoundError if setting is not found", async () => {
+		(repository.getInstanceSettingByKey as any).mockResolvedValue(null);
+
+		expect(handleRequest("non_existent")).rejects.toThrow(NotFoundError);
+	});
+});

--- a/apps/server/src/api/v1/instance-settings/register.ts
+++ b/apps/server/src/api/v1/instance-settings/register.ts
@@ -1,0 +1,16 @@
+import registerGetAllRoute from "./get-all/route";
+import registerGetByCategoryRoute from "./get-by-category/route";
+import registerGetByKeyRoute from "./get-by-key/route";
+import registerUpsertRoute from "./upsert/route";
+import { HonoServer } from "../../../types";
+
+export default {
+	name: "instance-settings",
+	registerHandler(app: HonoServer) {
+		const router = app.basePath("/instance-settings");
+		registerGetAllRoute(router);
+		registerGetByCategoryRoute(router);
+		registerGetByKeyRoute(router);
+		registerUpsertRoute(router);
+	},
+};

--- a/apps/server/src/api/v1/instance-settings/upsert/dto.ts
+++ b/apps/server/src/api/v1/instance-settings/upsert/dto.ts
@@ -1,0 +1,15 @@
+import z from "zod";
+import { instanceSettingCategorySchema } from "../../../../lib/instance-settings/schemas";
+import { instanceSettingItemSchema } from "../dto";
+
+export const requestBodySchema = z.object({
+	key: z.string(),
+	value: z.record(z.string(), z.unknown()),
+	category: instanceSettingCategorySchema.optional(),
+	isPublic: z.boolean().optional(),
+});
+
+export const responseSchema = z.object({
+	message: z.string(),
+	data: instanceSettingItemSchema,
+});

--- a/apps/server/src/api/v1/instance-settings/upsert/repository.ts
+++ b/apps/server/src/api/v1/instance-settings/upsert/repository.ts
@@ -1,0 +1,47 @@
+import { eq } from "drizzle-orm";
+import { db } from "../../../../db";
+import { instanceSettingsEntity } from "../../../../db/schema";
+import { generateID } from "@fluxify/lib";
+
+export async function getInstanceSettingByKey(key: string) {
+	const rows = await db
+		.select()
+		.from(instanceSettingsEntity)
+		.where(eq(instanceSettingsEntity.key, key));
+	return rows[0] ?? null;
+}
+
+export async function upsertInstanceSetting(data: {
+	key: string;
+	category: string;
+	value: Record<string, unknown>;
+	isPublic?: boolean;
+}) {
+	const now = new Date();
+	const existing = await getInstanceSettingByKey(data.key);
+	const isPublic = data.isPublic ?? existing?.isPublic ?? false;
+
+	const [updated] = await db
+		.insert(instanceSettingsEntity)
+		.values({
+			id: generateID(),
+			key: data.key,
+			category: data.category as any,
+			value: data.value,
+			isPublic,
+			createdAt: now,
+			updatedAt: now,
+		})
+		.onConflictDoUpdate({
+			target: instanceSettingsEntity.key,
+			set: {
+				value: data.value,
+				category: data.category as any,
+				isPublic,
+				updatedAt: now,
+			},
+		})
+		.returning();
+
+	return updated;
+}

--- a/apps/server/src/api/v1/instance-settings/upsert/route.ts
+++ b/apps/server/src/api/v1/instance-settings/upsert/route.ts
@@ -1,0 +1,75 @@
+import {
+	describeRoute,
+	DescribeRouteOptions,
+	resolver,
+	validator,
+} from "hono-openapi";
+import { requestBodySchema, responseSchema } from "./dto";
+import handleRequest from "./service";
+import zodErrorCallbackParser from "../../../../middlewares/zodErrorCallbackParser";
+import { errorSchema } from "../../../../errors/customError";
+import { validationErrorSchema } from "../../../../errors/validationError";
+import { HonoServer } from "../../../../types";
+import { requireSystemAdmin } from "../../../auth/middleware";
+
+const openapiRouteOptions: DescribeRouteOptions = {
+	description: "Upsert instance setting",
+	operationId: "upsert-instance-setting",
+	tags: ["Instance Settings"],
+	responses: {
+		200: {
+			description: "Successful",
+			content: {
+				"application/json": {
+					schema: resolver(responseSchema),
+				},
+			},
+		},
+		400: {
+			description: "Validation Error",
+			content: {
+				"application/json": {
+					schema: resolver(validationErrorSchema),
+				},
+			},
+		},
+		401: {
+			description: "Unauthorized",
+			content: {
+				"application/json": {
+					schema: resolver(errorSchema),
+				},
+			},
+		},
+		403: {
+			description: "Forbidden",
+			content: {
+				"application/json": {
+					schema: resolver(errorSchema),
+				},
+			},
+		},
+		500: {
+			description: "Internal Server Error",
+			content: {
+				"application/json": {
+					schema: resolver(errorSchema),
+				},
+			},
+		},
+	},
+};
+
+export default function (app: HonoServer) {
+	app.put(
+		"/",
+		describeRoute(openapiRouteOptions),
+		requireSystemAdmin,
+		validator("json", requestBodySchema, zodErrorCallbackParser),
+		async (c) => {
+			const body = c.req.valid("json");
+			const result = await handleRequest(body);
+			return c.json(result);
+		},
+	);
+}

--- a/apps/server/src/api/v1/instance-settings/upsert/service.ts
+++ b/apps/server/src/api/v1/instance-settings/upsert/service.ts
@@ -1,0 +1,140 @@
+import { BadRequestError } from "../../../../errors/badRequestError";
+import {
+	INSTANCE_SETTINGS_REGISTRY,
+	isInstanceSettingKey,
+	ssoConfigSchema,
+	authConfigSchema,
+} from "../../../../lib/instance-settings/schemas";
+import { getInstanceSettingByKey, upsertInstanceSetting } from "./repository";
+import { CHAN_ON_INSTANCE_SETTING_CHANGE, publishMessage } from "../../../../db/redis";
+
+export interface UpsertSettingPayload {
+	key: string;
+	value: Record<string, unknown>;
+	category?: string;
+	isPublic?: boolean;
+}
+
+export default async function handleRequest(payload: UpsertSettingPayload) {
+	const { key, value, category: inputCategory, isPublic } = payload;
+
+	if (!isInstanceSettingKey(key)) {
+		throw new BadRequestError(
+			`Invalid or unregistered instance setting key: '${key}'. Valid keys are: ${Object.keys(
+				INSTANCE_SETTINGS_REGISTRY,
+			).join(", ")}`,
+		);
+	}
+
+	const registryItem = INSTANCE_SETTINGS_REGISTRY[key];
+	const category = inputCategory ?? registryItem.category;
+
+	if (inputCategory && inputCategory !== registryItem.category) {
+		throw new BadRequestError(
+			`Invalid category '${inputCategory}' for setting '${key}'. Expected '${registryItem.category}'.`,
+		);
+	}
+
+	const parseResult = registryItem.schema.safeParse(value);
+	if (!parseResult.success) {
+		const issues = parseResult.error.issues ?? [];
+		const formattedErrors = issues
+			.map((e) => `${e.path.join(".") || "value"}: ${e.message}`)
+			.join("; ");
+		throw new BadRequestError(
+			`Validation failed for instance setting '${key}': ${formattedErrors}`,
+		);
+	}
+
+	const parsedValue = parseResult.data;
+
+	// Edge case handling for SSO and Auth settings
+	if (key === "sso_config") {
+		const ssoVal = parsedValue as ReturnType<typeof ssoConfigSchema.parse>;
+		if (ssoVal.enabled) {
+			if (ssoVal.provider === "oidc") {
+				if (!ssoVal.clientId || !ssoVal.clientId.trim()) {
+					throw new BadRequestError(
+						"SSO configuration is enabled for OIDC provider, but required field 'clientId' is missing or empty.",
+					);
+				}
+				if (!ssoVal.clientSecret || !ssoVal.clientSecret.trim()) {
+					throw new BadRequestError(
+						"SSO configuration is enabled for OIDC provider, but required field 'clientSecret' is missing or empty.",
+					);
+				}
+			} else if (ssoVal.provider === "saml") {
+				if (!ssoVal.entryPoint || !ssoVal.entryPoint.trim()) {
+					throw new BadRequestError(
+						"SSO configuration is enabled for SAML provider, but required field 'entryPoint' is missing or empty.",
+					);
+				}
+				if (!ssoVal.samlCert || !ssoVal.samlCert.trim()) {
+					throw new BadRequestError(
+						"SSO configuration is enabled for SAML provider, but required field 'samlCert' is missing or empty.",
+					);
+				}
+			}
+		} else {
+			// If disabling SSO, verify current auth_config isn't sso_only
+			const currentAuthRow = await getInstanceSettingByKey("auth_config");
+			if (currentAuthRow) {
+				const currentAuthVal = currentAuthRow.value as { mode?: string };
+				if (currentAuthVal.mode === "sso_only") {
+					throw new BadRequestError(
+						"Cannot disable SSO configuration while authentication mode is set to 'sso_only'. Please update auth_config mode to 'traditional' first.",
+					);
+				}
+			}
+		}
+	} else if (key === "auth_config") {
+		const authVal = parsedValue as ReturnType<typeof authConfigSchema.parse>;
+		if (authVal.mode === "sso_only") {
+			const currentSsoRow = await getInstanceSettingByKey("sso_config");
+			if (!currentSsoRow) {
+				throw new BadRequestError(
+					"Cannot set authentication mode to 'sso_only' because SSO is not configured.",
+				);
+			}
+
+			const ssoParse = ssoConfigSchema.safeParse(currentSsoRow.value);
+			if (!ssoParse.success || !ssoParse.data.enabled) {
+				throw new BadRequestError(
+					"Cannot set authentication mode to 'sso_only' because SSO configuration is disabled or invalid.",
+				);
+			}
+
+			const ssoVal = ssoParse.data;
+			if (ssoVal.provider === "oidc") {
+				if (!ssoVal.clientId?.trim() || !ssoVal.clientSecret?.trim()) {
+					throw new BadRequestError(
+						"Cannot set authentication mode to 'sso_only' because OIDC SSO configuration is incomplete (missing clientId or clientSecret).",
+					);
+				}
+			} else if (ssoVal.provider === "saml") {
+				if (!ssoVal.entryPoint?.trim() || !ssoVal.samlCert?.trim()) {
+					throw new BadRequestError(
+						"Cannot set authentication mode to 'sso_only' because SAML SSO configuration is incomplete (missing entryPoint or samlCert).",
+					);
+				}
+			}
+		}
+	}
+
+	const updated = await upsertInstanceSetting({
+		key,
+		category,
+		value: parsedValue as Record<string, unknown>,
+		isPublic,
+	});
+
+	// Notify all instances (incl. this one) to reload settings + rebuild auth.
+	// The channel subscriber handles the reload; do NOT reload inline (that
+	// re-subscribes and leaks a listener per call).
+	await publishMessage(CHAN_ON_INSTANCE_SETTING_CHANGE, { key });
+
+	return {
+		message: "Instance setting saved successfully",
+		data: updated,
+	};
+}

--- a/apps/server/src/api/v1/instance-settings/upsert/tests/upsert.test.ts
+++ b/apps/server/src/api/v1/instance-settings/upsert/tests/upsert.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it, mock, beforeEach } from "bun:test";
+import handleRequest from "../service";
+import * as repository from "../repository";
+import * as redis from "../../../../../db/redis";
+import { BadRequestError } from "../../../../../errors/badRequestError";
+
+mock.module("../repository", () => ({
+	getInstanceSettingByKey: mock(),
+	upsertInstanceSetting: mock(),
+}));
+
+mock.module("../../../../../db/redis", () => ({
+	publishMessage: mock(),
+	CHAN_ON_INSTANCE_SETTING_CHANGE: "chan:on-instance-setting-change",
+}));
+
+describe("upsert instance setting service", () => {
+	beforeEach(() => {
+		(repository.getInstanceSettingByKey as any).mockClear();
+		(repository.upsertInstanceSetting as any).mockClear();
+		(redis.publishMessage as any).mockClear();
+	});
+
+	it("should throw BadRequestError for an unregistered key", async () => {
+		expect(
+			handleRequest({ key: "invalid_key", value: {} }),
+		).rejects.toThrow(BadRequestError);
+	});
+
+	it("should throw BadRequestError if schema validation fails", async () => {
+		expect(
+			handleRequest({
+				key: "sso_config",
+				value: { provider: "invalid_provider" },
+			}),
+		).rejects.toThrow(BadRequestError);
+	});
+
+	it("should throw BadRequestError if input category does not match registry category", async () => {
+		expect(
+			handleRequest({
+				key: "sso_config",
+				category: "other" as any,
+				value: {
+					provider: "oidc",
+					enabled: false,
+					issuer: "https://auth.example.com",
+					domain: "example.com",
+				},
+			}),
+		).rejects.toThrow(BadRequestError);
+	});
+
+	it("should throw BadRequestError if OIDC SSO is enabled but missing clientId or clientSecret", async () => {
+		expect(
+			handleRequest({
+				key: "sso_config",
+				value: {
+					provider: "oidc",
+					enabled: true,
+					issuer: "https://auth.example.com",
+					domain: "example.com",
+				},
+			}),
+		).rejects.toThrow(BadRequestError);
+	});
+
+	it("should throw BadRequestError if SAML SSO is enabled but missing entryPoint or samlCert", async () => {
+		expect(
+			handleRequest({
+				key: "sso_config",
+				value: {
+					provider: "saml",
+					enabled: true,
+					issuer: "https://auth.example.com",
+					domain: "example.com",
+				},
+			}),
+		).rejects.toThrow(BadRequestError);
+	});
+
+	it("should throw BadRequestError if disabling SSO while auth mode is sso_only", async () => {
+		(repository.getInstanceSettingByKey as any).mockImplementation((k: string) => {
+			if (k === "auth_config") {
+				return Promise.resolve({
+					id: "auth-1",
+					key: "auth_config",
+					category: "auth",
+					value: { mode: "sso_only" },
+					isPublic: false,
+				});
+			}
+			return Promise.resolve(null);
+		});
+
+		expect(
+			handleRequest({
+				key: "sso_config",
+				value: {
+					provider: "oidc",
+					enabled: false,
+					issuer: "https://auth.example.com",
+					domain: "example.com",
+				},
+			}),
+		).rejects.toThrow(BadRequestError);
+	});
+
+	it("should throw BadRequestError when setting auth_config to sso_only if sso_config is disabled or missing", async () => {
+		(repository.getInstanceSettingByKey as any).mockResolvedValue(null);
+
+		expect(
+			handleRequest({
+				key: "auth_config",
+				value: { mode: "sso_only" },
+			}),
+		).rejects.toThrow(BadRequestError);
+	});
+
+	it("should successfully upsert valid OIDC sso_config", async () => {
+		const validOidcVal = {
+			provider: "oidc",
+			enabled: true,
+			issuer: "https://auth.example.com",
+			domain: "example.com",
+			clientId: "client-123",
+			clientSecret: "secret-456",
+		};
+		const mockUpdated = {
+			id: "sso-1",
+			key: "sso_config",
+			category: "auth",
+			value: validOidcVal,
+			isPublic: false,
+			createdAt: new Date(),
+			updatedAt: new Date(),
+		};
+		(repository.upsertInstanceSetting as any).mockResolvedValue(mockUpdated);
+
+		const result = await handleRequest({
+			key: "sso_config",
+			value: validOidcVal,
+		});
+
+		expect(repository.upsertInstanceSetting).toHaveBeenCalledWith({
+			key: "sso_config",
+			category: "auth",
+			value: expect.objectContaining(validOidcVal),
+			isPublic: undefined,
+		});
+		expect(redis.publishMessage).toHaveBeenCalledWith(
+			"chan:on-instance-setting-change",
+			{ key: "sso_config" },
+		);
+		expect(result).toEqual({
+			message: "Instance setting saved successfully",
+			data: mockUpdated,
+		});
+	});
+});

--- a/apps/server/src/api/v1/register.ts
+++ b/apps/server/src/api/v1/register.ts
@@ -5,6 +5,7 @@ import appConfig from "./app-config/register";
 import integrations from "./integrations/register";
 import testSuites from "./test-suites/register";
 import customBlocks from "./custom-blocks/register";
+import instanceSettings from "./instance-settings/register";
 import { HonoServer } from "../../types";
 
 export default {
@@ -30,5 +31,6 @@ export default {
 		integrations.registerHandler(router);
 		testSuites.registerHandler(router);
 		customBlocks.registerHandler(router);
+		instanceSettings.registerHandler(router);
 	},
 };

--- a/apps/server/src/db/migrations/0040_milky_sunfire.sql
+++ b/apps/server/src/db/migrations/0040_milky_sunfire.sql
@@ -1,0 +1,11 @@
+CREATE TYPE "public"."instance_setting_category" AS ENUM('auth');--> statement-breakpoint
+CREATE TABLE "instance_settings" (
+	"id" varchar(50) PRIMARY KEY NOT NULL,
+	"key" varchar(100) NOT NULL,
+	"category" "instance_setting_category" NOT NULL,
+	"value" jsonb NOT NULL,
+	"is_public" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "instance_settings_key_unique" UNIQUE("key")
+);

--- a/apps/server/src/db/migrations/meta/0040_snapshot.json
+++ b/apps/server/src/db/migrations/meta/0040_snapshot.json
@@ -1,0 +1,3056 @@
+{
+  "id": "824b91ea-74eb-4da7-a9a7-eb0e3f53dcc5",
+  "prevId": "02015bc7-ad98-4d7d-9f9e-fbd4af294b39",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.access_control": {
+      "name": "access_control",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "access_control_roles",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_access_control_user_id": {
+          "name": "idx_access_control_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_access_control_project_id": {
+          "name": "idx_access_control_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "access_control_user_id_user_id_fk": {
+          "name": "access_control_user_id_user_id_fk",
+          "tableFrom": "access_control",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "access_control_project_id_projects_id_fk": {
+          "name": "access_control_project_id_projects_id_fk",
+          "tableFrom": "access_control",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_chat_conversations": {
+      "name": "ai_chat_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'New chat'"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ai_chat_conversation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'not_started'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_chat_conversations_user_id_user_id_fk": {
+          "name": "ai_chat_conversations_user_id_user_id_fk",
+          "tableFrom": "ai_chat_conversations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_chat_conversations_project_id_projects_id_fk": {
+          "name": "ai_chat_conversations_project_id_projects_id_fk",
+          "tableFrom": "ai_chat_conversations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_chat_history": {
+      "name": "ai_chat_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ai_chat_conversation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'running'"
+        },
+        "user_query": {
+          "name": "user_query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "final_output": {
+          "name": "final_output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_execution_history": {
+          "name": "workflow_execution_history",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_chat_history_conversation_id_ai_chat_conversations_id_fk": {
+          "name": "ai_chat_history_conversation_id_ai_chat_conversations_id_fk",
+          "tableFrom": "ai_chat_history",
+          "tableTo": "ai_chat_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_workflow_builder_steps": {
+      "name": "ai_workflow_builder_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_history_id": {
+          "name": "chat_history_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_type": {
+          "name": "step_type",
+          "type": "ai_workflow_builder_step_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_status": {
+          "name": "step_status",
+          "type": "ai_workflow_builder_step_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "step_order": {
+          "name": "step_order",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_data": {
+          "name": "input_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_data": {
+          "name": "output_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ai_wf_steps_chat_history_id": {
+          "name": "idx_ai_wf_steps_chat_history_id",
+          "columns": [
+            {
+              "expression": "chat_history_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_wf_steps_conversation_id": {
+          "name": "idx_ai_wf_steps_conversation_id",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_wf_steps_step_type": {
+          "name": "idx_ai_wf_steps_step_type",
+          "columns": [
+            {
+              "expression": "step_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_wf_steps_step_status": {
+          "name": "idx_ai_wf_steps_step_status",
+          "columns": [
+            {
+              "expression": "step_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_workflow_builder_steps_chat_history_id_ai_chat_history_id_fk": {
+          "name": "ai_workflow_builder_steps_chat_history_id_ai_chat_history_id_fk",
+          "tableFrom": "ai_workflow_builder_steps",
+          "tableTo": "ai_chat_history",
+          "columnsFrom": [
+            "chat_history_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_workflow_builder_steps_conversation_id_ai_chat_conversations_id_fk": {
+          "name": "ai_workflow_builder_steps_conversation_id_ai_chat_conversations_id_fk",
+          "tableFrom": "ai_workflow_builder_steps",
+          "tableTo": "ai_chat_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_config": {
+      "name": "app_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key_name": {
+          "name": "key_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_encrypted": {
+          "name": "is_encrypted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "encoding_type": {
+          "name": "encoding_type",
+          "type": "encoding_types",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "app_config_data_types",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'string'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_app_config_key_name": {
+          "name": "idx_app_config_key_name",
+          "columns": [
+            {
+              "expression": "key_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_app_config_project_id": {
+          "name": "idx_app_config_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_app_config_is_encrypted": {
+          "name": "idx_app_config_is_encrypted",
+          "columns": [
+            {
+              "expression": "is_encrypted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_app_config_encoding_type": {
+          "name": "idx_app_config_encoding_type",
+          "columns": [
+            {
+              "expression": "encoding_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_app_config_key_name_fts": {
+          "name": "idx_app_config_key_name_fts",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', \"key_name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_app_config_desc_fts": {
+          "name": "idx_app_config_desc_fts",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', coalesce(\"description\", ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_config_project_id_projects_id_fk": {
+          "name": "app_config_project_id_projects_id_fk",
+          "tableFrom": "app_config",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocks": {
+      "name": "blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_id": {
+          "name": "route_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_blocks_route_id": {
+          "name": "idx_blocks_route_id",
+          "columns": [
+            {
+              "expression": "route_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blocks_route_id_routes_id_fk": {
+          "name": "blocks_route_id_routes_id_fk",
+          "tableFrom": "blocks",
+          "tableTo": "routes",
+          "columnsFrom": [
+            "route_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_block_graphs": {
+      "name": "custom_block_graphs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "custom_block_id": {
+          "name": "custom_block_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_block_id": {
+          "name": "next_block_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_custom_block_graphs_custom_block_id": {
+          "name": "idx_custom_block_graphs_custom_block_id",
+          "columns": [
+            {
+              "expression": "custom_block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "custom_block_graphs_custom_block_id_custom_blocks_list_id_fk": {
+          "name": "custom_block_graphs_custom_block_id_custom_blocks_list_id_fk",
+          "tableFrom": "custom_block_graphs",
+          "tableTo": "custom_blocks_list",
+          "columnsFrom": [
+            "custom_block_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_blocks_list": {
+      "name": "custom_blocks_list",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "custom_block_icon_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_params": {
+          "name": "input_params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "custom_block_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user-defined'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_custom_blocks_list_project_id": {
+          "name": "idx_custom_blocks_list_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_custom_blocks_list_name": {
+          "name": "idx_custom_blocks_list_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "custom_blocks_list_project_id_projects_id_fk": {
+          "name": "custom_blocks_list_project_id_projects_id_fk",
+          "tableFrom": "custom_blocks_list",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.edges": {
+      "name": "edges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "from": {
+          "name": "from",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to": {
+          "name": "to",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_handle": {
+          "name": "from_handle",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_handle": {
+          "name": "to_handle",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_id": {
+          "name": "route_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_edges_from": {
+          "name": "idx_edges_from",
+          "columns": [
+            {
+              "expression": "from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_edges_to": {
+          "name": "idx_edges_to",
+          "columns": [
+            {
+              "expression": "to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_edges_route_id": {
+          "name": "idx_edges_route_id",
+          "columns": [
+            {
+              "expression": "route_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "edges_from_blocks_id_fk": {
+          "name": "edges_from_blocks_id_fk",
+          "tableFrom": "edges",
+          "tableTo": "blocks",
+          "columnsFrom": [
+            "from"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edges_to_blocks_id_fk": {
+          "name": "edges_to_blocks_id_fk",
+          "tableFrom": "edges",
+          "tableTo": "blocks",
+          "columnsFrom": [
+            "to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edges_route_id_routes_id_fk": {
+          "name": "edges_route_id_routes_id_fk",
+          "tableFrom": "edges",
+          "tableTo": "routes",
+          "columnsFrom": [
+            "route_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instance_settings": {
+      "name": "instance_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "instance_setting_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "instance_settings_key_unique": {
+          "name": "instance_settings_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integrations": {
+      "name": "integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group": {
+          "name": "group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_integrations_name": {
+          "name": "idx_integrations_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integrations_group": {
+          "name": "idx_integrations_group",
+          "columns": [
+            {
+              "expression": "group",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integrations_variant": {
+          "name": "idx_integrations_variant",
+          "columns": [
+            {
+              "expression": "variant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integrations_tags": {
+          "name": "idx_integrations_tags",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integrations_project_id": {
+          "name": "idx_integrations_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integrations_name_fts": {
+          "name": "idx_integrations_name_fts",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', \"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integrations_project_id_projects_id_fk": {
+          "name": "integrations_project_id_projects_id_fk",
+          "tableFrom": "integrations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_settings": {
+      "name": "project_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_project_settings_project_id": {
+          "name": "idx_project_settings_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_settings_key": {
+          "name": "idx_project_settings_key",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_settings_project_id_projects_id_fk": {
+          "name": "project_settings_project_id_projects_id_fk",
+          "tableFrom": "project_settings",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_projects_id": {
+          "name": "idx_projects_id",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_projects_name": {
+          "name": "idx_projects_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_projects_updated_at": {
+          "name": "idx_projects_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.routes": {
+      "name": "routes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "NULL"
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_schema": {
+          "name": "body_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query_schema": {
+          "name": "query_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "params_schema": {
+          "name": "params_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_routes_project_id": {
+          "name": "idx_routes_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_routes_path": {
+          "name": "idx_routes_path",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_routes_name_fts": {
+          "name": "idx_routes_name_fts",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', \"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "routes_project_id_projects_id_fk": {
+          "name": "routes_project_id_projects_id_fk",
+          "tableFrom": "routes",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_suites": {
+      "name": "test_suites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_id": {
+          "name": "route_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "query_params": {
+          "name": "query_params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "route_params": {
+          "name": "route_params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "body": {
+          "name": "body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assertions": {
+          "name": "assertions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "integration_overrides": {
+          "name": "integration_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "app_config_overrides": {
+          "name": "app_config_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_suites_route_id_routes_id_fk": {
+          "name": "test_suites_route_id_routes_id_fk",
+          "tableFrom": "test_suites",
+          "tableTo": "routes",
+          "columnsFrom": [
+            "route_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_harness_artifacts": {
+      "name": "agent_harness_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_harness_artifacts_conv_id": {
+          "name": "idx_harness_artifacts_conv_id",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_harness_artifacts_run_id": {
+          "name": "idx_harness_artifacts_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_harness_artifacts_conversation_id_agent_harness_conversations_id_fk": {
+          "name": "agent_harness_artifacts_conversation_id_agent_harness_conversations_id_fk",
+          "tableFrom": "agent_harness_artifacts",
+          "tableTo": "agent_harness_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_harness_artifacts_run_id_agent_harness_runs_id_fk": {
+          "name": "agent_harness_artifacts_run_id_agent_harness_runs_id_fk",
+          "tableFrom": "agent_harness_artifacts",
+          "tableTo": "agent_harness_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_harness_conversations": {
+      "name": "agent_harness_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'New Chat'"
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_harness_conversation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "active_run_id": {
+          "name": "active_run_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_harness_conv_user_id": {
+          "name": "idx_harness_conv_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_harness_conv_project_id": {
+          "name": "idx_harness_conv_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_harness_conversations_user_id_user_id_fk": {
+          "name": "agent_harness_conversations_user_id_user_id_fk",
+          "tableFrom": "agent_harness_conversations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_harness_conversations_project_id_projects_id_fk": {
+          "name": "agent_harness_conversations_project_id_projects_id_fk",
+          "tableFrom": "agent_harness_conversations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_harness_hitl_actions": {
+      "name": "agent_harness_hitl_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_id": {
+          "name": "step_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "agent_harness_hitl_action_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_response": {
+          "name": "user_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_harness_hitl_run_id": {
+          "name": "idx_harness_hitl_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_harness_hitl_step_id": {
+          "name": "idx_harness_hitl_step_id",
+          "columns": [
+            {
+              "expression": "step_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_harness_hitl_actions_run_id_agent_harness_runs_id_fk": {
+          "name": "agent_harness_hitl_actions_run_id_agent_harness_runs_id_fk",
+          "tableFrom": "agent_harness_hitl_actions",
+          "tableTo": "agent_harness_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_harness_hitl_actions_step_id_agent_harness_steps_id_fk": {
+          "name": "agent_harness_hitl_actions_step_id_agent_harness_steps_id_fk",
+          "tableFrom": "agent_harness_hitl_actions",
+          "tableTo": "agent_harness_steps",
+          "columnsFrom": [
+            "step_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_harness_live_states": {
+      "name": "agent_harness_live_states",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_state": {
+          "name": "current_state",
+          "type": "agent_harness_live_state_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "active_step_id": {
+          "name": "active_step_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "working_memory": {
+          "name": "working_memory",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_harness_live_conv_id": {
+          "name": "idx_harness_live_conv_id",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_harness_live_states_run_id_agent_harness_runs_id_fk": {
+          "name": "agent_harness_live_states_run_id_agent_harness_runs_id_fk",
+          "tableFrom": "agent_harness_live_states",
+          "tableTo": "agent_harness_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_harness_live_states_conversation_id_agent_harness_conversations_id_fk": {
+          "name": "agent_harness_live_states_conversation_id_agent_harness_conversations_id_fk",
+          "tableFrom": "agent_harness_live_states",
+          "tableTo": "agent_harness_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_harness_runs": {
+      "name": "agent_harness_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_query": {
+          "name": "user_query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_response": {
+          "name": "ai_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_harness_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "interrupted_at": {
+          "name": "interrupted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_harness_runs_conv_id": {
+          "name": "idx_harness_runs_conv_id",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_harness_runs_status": {
+          "name": "idx_harness_runs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_harness_runs_conversation_id_agent_harness_conversations_id_fk": {
+          "name": "agent_harness_runs_conversation_id_agent_harness_conversations_id_fk",
+          "tableFrom": "agent_harness_runs",
+          "tableTo": "agent_harness_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_harness_steps": {
+      "name": "agent_harness_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_type": {
+          "name": "step_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_order": {
+          "name": "step_order",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sub_agent_role": {
+          "name": "sub_agent_role",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sub_agent_id": {
+          "name": "sub_agent_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_harness_step_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_harness_steps_run_id": {
+          "name": "idx_harness_steps_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_harness_steps_sub_agent_id": {
+          "name": "idx_harness_steps_sub_agent_id",
+          "columns": [
+            {
+              "expression": "sub_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_harness_steps_run_sub_agent": {
+          "name": "uq_harness_steps_run_sub_agent",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sub_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_harness_steps_run_id_agent_harness_runs_id_fk": {
+          "name": "agent_harness_steps_run_id_agent_harness_runs_id_fk",
+          "tableFrom": "agent_harness_steps",
+          "tableTo": "agent_harness_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_harness_steps_conversation_id_agent_harness_conversations_id_fk": {
+          "name": "agent_harness_steps_conversation_id_agent_harness_conversations_id_fk",
+          "tableFrom": "agent_harness_steps",
+          "tableTo": "agent_harness_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_harness_sub_artifacts": {
+      "name": "agent_harness_sub_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sub_agent_id": {
+          "name": "sub_agent_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_harness_sub_artifacts_artifact_id": {
+          "name": "idx_harness_sub_artifacts_artifact_id",
+          "columns": [
+            {
+              "expression": "artifact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_harness_sub_artifacts_run_id": {
+          "name": "idx_harness_sub_artifacts_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_harness_sub_artifacts_artifact_id_agent_harness_artifacts_id_fk": {
+          "name": "agent_harness_sub_artifacts_artifact_id_agent_harness_artifacts_id_fk",
+          "tableFrom": "agent_harness_sub_artifacts",
+          "tableTo": "agent_harness_artifacts",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_harness_sub_artifacts_conversation_id_agent_harness_conversations_id_fk": {
+          "name": "agent_harness_sub_artifacts_conversation_id_agent_harness_conversations_id_fk",
+          "tableFrom": "agent_harness_sub_artifacts",
+          "tableTo": "agent_harness_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_harness_sub_artifacts_run_id_agent_harness_runs_id_fk": {
+          "name": "agent_harness_sub_artifacts_run_id_agent_harness_runs_id_fk",
+          "tableFrom": "agent_harness_sub_artifacts",
+          "tableTo": "agent_harness_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system_admin": {
+          "name": "is_system_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.access_control_roles": {
+      "name": "access_control_roles",
+      "schema": "public",
+      "values": [
+        "viewer",
+        "creator",
+        "project_admin",
+        "system_admin"
+      ]
+    },
+    "public.ai_chat_conversation_status": {
+      "name": "ai_chat_conversation_status",
+      "schema": "public",
+      "values": [
+        "not_started",
+        "running",
+        "success",
+        "error",
+        "paused",
+        "plan_rejected"
+      ]
+    },
+    "public.ai_workflow_builder_step_status": {
+      "name": "ai_workflow_builder_step_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "completed",
+        "failed",
+        "paused",
+        "awaiting_review"
+      ]
+    },
+    "public.ai_workflow_builder_step_type": {
+      "name": "ai_workflow_builder_step_type",
+      "schema": "public",
+      "values": [
+        "verify",
+        "planner",
+        "orchestrator",
+        "sub_agent",
+        "evaluator"
+      ]
+    },
+    "public.app_config_data_types": {
+      "name": "app_config_data_types",
+      "schema": "public",
+      "values": [
+        "string",
+        "number",
+        "boolean"
+      ]
+    },
+    "public.custom_block_icon_type": {
+      "name": "custom_block_icon_type",
+      "schema": "public",
+      "values": [
+        "premade-list",
+        "custom"
+      ]
+    },
+    "public.custom_block_source_type": {
+      "name": "custom_block_source_type",
+      "schema": "public",
+      "values": [
+        "plugin",
+        "inhouse",
+        "user-defined"
+      ]
+    },
+    "public.encoding_types": {
+      "name": "encoding_types",
+      "schema": "public",
+      "values": [
+        "plaintext",
+        "base64",
+        "hex"
+      ]
+    },
+    "public.instance_setting_category": {
+      "name": "instance_setting_category",
+      "schema": "public",
+      "values": [
+        "auth"
+      ]
+    },
+    "public.agent_harness_conversation_status": {
+      "name": "agent_harness_conversation_status",
+      "schema": "public",
+      "values": [
+        "idle",
+        "running",
+        "paused_hitl",
+        "interrupted",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.agent_harness_hitl_action_type": {
+      "name": "agent_harness_hitl_action_type",
+      "schema": "public",
+      "values": [
+        "plan_approval",
+        "plan_rejection",
+        "user_input",
+        "confirmation",
+        "cancellation",
+        "custom"
+      ]
+    },
+    "public.agent_harness_live_state_status": {
+      "name": "agent_harness_live_state_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "paused_hitl",
+        "interrupted",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.agent_harness_run_status": {
+      "name": "agent_harness_run_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "routing",
+        "verifying",
+        "planning",
+        "orchestrating",
+        "executing",
+        "awaiting_hitl",
+        "completed",
+        "interrupted",
+        "failed"
+      ]
+    },
+    "public.agent_harness_step_status": {
+      "name": "agent_harness_step_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "interrupted"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/server/src/db/migrations/meta/_journal.json
+++ b/apps/server/src/db/migrations/meta/_journal.json
@@ -281,6 +281,13 @@
       "when": 1784756948216,
       "tag": "0039_wonderful_black_bolt",
       "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "7",
+      "when": 1784804873823,
+      "tag": "0040_milky_sunfire",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/db/redis.ts
+++ b/apps/server/src/db/redis.ts
@@ -13,6 +13,7 @@ export const CHAN_AI_WORKER = "chan:ai-worker";
 export const CHAN_AI_SSE_PREFIX = "chan:ai-sse:";
 export const CHAN_ON_PROJECT_SETTING_CHANGE = "chan:on-project-setting-change";
 export const CHAN_ON_CUSTOM_BLOCK_CHANGE = "chan:on-custom-block-change";
+export const CHAN_ON_INSTANCE_SETTING_CHANGE = "chan:on-instance-setting-change";
 
 export function initializeRedis(hotReload?: boolean) {
 	const canHotreload = hotReload || process.env.HOT_RELOAD_ROUTES == "true";
@@ -29,6 +30,7 @@ export function initializeRedis(hotReload?: boolean) {
 			CHAN_ON_APPCONFIG_CHANGE,
 			CHAN_ON_INTEGRATION_CHANGE,
 			CHAN_ON_CUSTOM_BLOCK_CHANGE,
+			CHAN_ON_INSTANCE_SETTING_CHANGE,
 		);
 	}
 }

--- a/apps/server/src/db/schema.ts
+++ b/apps/server/src/db/schema.ts
@@ -531,5 +531,28 @@ export const aiWorkflowBuilderStepsEntity = pgTable(
 	],
 );
 
+/* ============================================================================
+ * INSTANCE SETTINGS (dynamic public/private config, e.g. SSO/auth mode)
+ * ============================================================================ */
+
+export const instanceSettingCategoryEnum = pgEnum("instance_setting_category", [
+	"auth",
+]); // add values as new categories appear
+
+export const instanceSettingsEntity = pgTable("instance_settings", {
+	id: varchar({ length: 50 })
+		.primaryKey()
+		.$defaultFn(() => generateID()),
+	key: varchar({ length: 100 }).notNull().unique(),
+	category: instanceSettingCategoryEnum("category").notNull(),
+	value: jsonb().$type<Record<string, unknown>>().notNull(),
+	isPublic: boolean("is_public").default(false).notNull(),
+	createdAt: timestamp("created_at").defaultNow().notNull(),
+	updatedAt: timestamp("updated_at")
+		.defaultNow()
+		.notNull()
+		.$onUpdate(() => new Date()),
+});
+
 export * from "./agent-harness-schema";
 

--- a/apps/server/src/lib/auth.ts
+++ b/apps/server/src/lib/auth.ts
@@ -6,9 +6,59 @@ import { eq } from "drizzle-orm";
 import { customSession } from "better-auth/plugins";
 import * as authSchemas from "../db/auth-schema";
 import { admin } from "better-auth/plugins";
+import { sso } from "@better-auth/sso";
 import { generateID } from "@fluxify/lib";
+import { getSetting } from "../loaders/instanceSettingsLoader";
 
 export let auth: ReturnType<typeof initializeAuth> = null!;
+
+function trustedOrigins() {
+	return (
+		process.env.TRUSTED_ORIGINS?.split(",").map((o) => o.trim()) ?? [
+			process.env.SERVER_URL!,
+		]
+	);
+}
+
+// Build a single inline SSO provider from instance_settings.sso_config.
+// Precedence over any DB providers; we never create the ssoProvider table.
+function ssoDefaults(): NonNullable<Parameters<typeof sso>[0]>["defaultSSO"] {
+	const cfg = getSetting("sso_config");
+	if (!cfg || !cfg.enabled) return [];
+	if (cfg.provider === "oidc") {
+		return [
+			{
+				domain: cfg.domain,
+				providerId: cfg.providerId,
+				oidcConfig: {
+					issuer: cfg.issuer,
+					clientId: cfg.clientId!,
+					clientSecret: cfg.clientSecret!,
+					discoveryEndpoint:
+						cfg.discoveryEndpoint ??
+						`${cfg.issuer.replace(/\/$/, "")}/.well-known/openid-configuration`,
+					pkce: true,
+					scopes: cfg.scopes ?? ["openid", "email", "profile"],
+				},
+			},
+		];
+	}
+	// ponytail: SAML mapped from minimal fields; spMetadata/signing left default,
+	// wire fully when a real SAML IdP is onboarded.
+	return [
+		{
+			domain: cfg.domain,
+			providerId: cfg.providerId,
+			samlConfig: {
+				issuer: cfg.issuer,
+				entryPoint: cfg.entryPoint!,
+				cert: cfg.samlCert!,
+				callbackUrl: `${process.env.SERVER_URL!}/_/admin/api/auth/sso/saml2/callback/${cfg.providerId}`,
+				spMetadata: { metadata: "" },
+			},
+		},
+	];
+}
 
 export function initializeAuth(db: DB) {
   const _auth = betterAuth({
@@ -17,7 +67,7 @@ export function initializeAuth(db: DB) {
       schema: authSchemas,
     }),
     basePath: "/_/admin/api/auth",
-    trustedOrigins: [process.env.SERVER_URL!],
+    trustedOrigins: trustedOrigins(),
     user: {
       additionalFields: {
         isSystemAdmin: {
@@ -61,6 +111,26 @@ export function initializeAuth(db: DB) {
         };
       }),
       admin(),
+      sso({
+        defaultSSO: ssoDefaults(),
+        disableImplicitSignUp: true, // no JIT: unknown emails are never provisioned
+        providersLimit: 0, // single config comes from instance_settings; no runtime registration
+        provisionUser: async ({ userInfo }) => {
+          // Explicit no-JIT guard. disableImplicitSignUp already prevents orphan
+          // rows; this asserts the pre-provisioned invariant and surfaces the
+          // named error if that ever changes.
+          const email = userInfo.email;
+          const existing = email
+            ? await db
+                .select({ id: authSchemas.user.id })
+                .from(authSchemas.user)
+                .where(eq(authSchemas.user.email, email))
+            : [];
+          if (existing.length === 0) {
+            throw new Error("ACCOUNT_NOT_PRE_PROVISIONED");
+          }
+        },
+      }),
     ],
   });
   auth = _auth;

--- a/apps/server/src/lib/instance-settings/schemas.test.ts
+++ b/apps/server/src/lib/instance-settings/schemas.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "bun:test";
+import {
+	ssoConfigSchema,
+	ssoConfigPublicSchema,
+	INSTANCE_SETTINGS_REGISTRY,
+} from "./schemas";
+
+// The security-critical path: is_public rows must never leak IdP secrets.
+describe("instance-settings leak guard", () => {
+	const full = ssoConfigSchema.parse({
+		provider: "oidc",
+		enabled: true,
+		issuer: "https://idp.company.com",
+		domain: "company.com",
+		clientId: "abc",
+		clientSecret: "super-secret",
+		samlCert: "-----BEGIN CERT-----",
+	});
+
+	it("strips clientSecret and samlCert from the public projection", () => {
+		const pub = ssoConfigPublicSchema.parse(full) as Record<string, unknown>;
+		expect(pub.clientSecret).toBeUndefined();
+		expect(pub.samlCert).toBeUndefined();
+		expect(pub.clientId).toBeUndefined();
+		expect(pub.domain).toBe("company.com"); // non-secret fields survive
+	});
+
+	it("every registered key has a publicSchema", () => {
+		for (const key of Object.keys(INSTANCE_SETTINGS_REGISTRY)) {
+			expect(
+				INSTANCE_SETTINGS_REGISTRY[key as keyof typeof INSTANCE_SETTINGS_REGISTRY]
+					.publicSchema,
+			).toBeDefined();
+		}
+	});
+});

--- a/apps/server/src/lib/instance-settings/schemas.ts
+++ b/apps/server/src/lib/instance-settings/schemas.ts
@@ -61,3 +61,21 @@ export type InstanceSettingValue<K extends InstanceSettingKey> = z.infer<
 export function isInstanceSettingKey(key: string): key is InstanceSettingKey {
 	return key in INSTANCE_SETTINGS_REGISTRY;
 }
+
+// ponytail: name-based secret list; add fields as new secret-bearing keys appear.
+const SECRET_FIELDS = new Set(["clientSecret", "samlCert", "privateKey"]);
+
+/**
+ * Mask secret fields for admin reads. Secrets are write-only: config stays
+ * visible/editable but the values are never echoed back. A present secret
+ * becomes "••••••" so the UI can show "set" without exposing it.
+ */
+export function redactSecrets(
+	value: Record<string, unknown>,
+): Record<string, unknown> {
+	const out: Record<string, unknown> = {};
+	for (const [k, v] of Object.entries(value)) {
+		out[k] = SECRET_FIELDS.has(k) && v != null && v !== "" ? "••••••" : v;
+	}
+	return out;
+}

--- a/apps/server/src/lib/instance-settings/schemas.ts
+++ b/apps/server/src/lib/instance-settings/schemas.ts
@@ -1,0 +1,63 @@
+import z from "zod";
+
+/**
+ * Per-key registry for the `instance_settings` table.
+ * Each key maps to a strict full schema (server-side, may hold secrets) and a
+ * `publicSchema` projection that strips secrets — the leak guard for rows with
+ * `is_public: true`.
+ */
+
+export const ssoConfigSchema = z.object({
+	provider: z.enum(["oidc", "saml"]),
+	enabled: z.boolean().default(false),
+	providerId: z.string().default("enterprise"),
+	issuer: z.string().url(),
+	domain: z.string(), // e.g. company.com — drives the no-JIT domain check
+	// OIDC
+	clientId: z.string().optional(),
+	clientSecret: z.string().optional(), // SECRET
+	discoveryEndpoint: z.string().url().optional(), // defaults to `${issuer}/.well-known/openid-configuration`
+	scopes: z.array(z.string()).optional(),
+	// SAML (ponytail: minimal fields; expand when a real SAML IdP is onboarded)
+	entryPoint: z.string().url().optional(),
+	samlCert: z.string().optional(), // SECRET
+});
+
+// public projection: no secrets, no endpoints
+export const ssoConfigPublicSchema = ssoConfigSchema.pick({
+	provider: true,
+	enabled: true,
+	providerId: true,
+	issuer: true,
+	domain: true,
+});
+
+export const authConfigSchema = z.object({
+	mode: z.enum(["traditional", "sso_only"]),
+});
+
+export const instanceSettingCategorySchema = z.enum(["auth"]); // mirrors the pgEnum
+
+export const INSTANCE_SETTINGS_REGISTRY = {
+	sso_config: {
+		category: "auth",
+		schema: ssoConfigSchema,
+		publicSchema: ssoConfigPublicSchema,
+	},
+	auth_config: {
+		category: "auth",
+		schema: authConfigSchema,
+		publicSchema: authConfigSchema,
+	},
+} as const;
+
+export type InstanceSettingKey = keyof typeof INSTANCE_SETTINGS_REGISTRY;
+
+// discriminated key→value map drives the typed nullable getter
+export type InstanceSettingValue<K extends InstanceSettingKey> = z.infer<
+	(typeof INSTANCE_SETTINGS_REGISTRY)[K]["schema"]
+>;
+
+export function isInstanceSettingKey(key: string): key is InstanceSettingKey {
+	return key in INSTANCE_SETTINGS_REGISTRY;
+}

--- a/apps/server/src/loaders/instanceSettingsLoader.ts
+++ b/apps/server/src/loaders/instanceSettingsLoader.ts
@@ -1,0 +1,62 @@
+import { db } from "../db";
+import { instanceSettingsEntity } from "../db/schema";
+import {
+	CHAN_ON_INSTANCE_SETTING_CHANGE,
+	subscribeToChannel,
+} from "../db/redis";
+import { logger } from "@fluxify/common";
+import {
+	INSTANCE_SETTINGS_REGISTRY,
+	InstanceSettingKey,
+	InstanceSettingValue,
+	isInstanceSettingKey,
+} from "../lib/instance-settings/schemas";
+import { initializeAuth } from "../lib/auth";
+
+type CacheEntry = { value: unknown; isPublic: boolean };
+
+let cache: Partial<Record<InstanceSettingKey, CacheEntry>> = {};
+
+export async function loadInstanceSettings() {
+	await loadFromDB();
+	subscribeToChannel(CHAN_ON_INSTANCE_SETTING_CHANGE, async () => {
+		logger.info("instance settings reloaded");
+		await loadFromDB();
+		initializeAuth(db); // rebuild global `auth` with fresh sso_config
+	});
+}
+
+async function loadFromDB() {
+	const next: Partial<Record<InstanceSettingKey, CacheEntry>> = {};
+	const rows = await db.select().from(instanceSettingsEntity);
+	for (const row of rows) {
+		if (!isInstanceSettingKey(row.key)) continue; // unknown key, ignore
+		const parsed = INSTANCE_SETTINGS_REGISTRY[row.key].schema.safeParse(
+			row.value,
+		);
+		if (!parsed.success) {
+			logger.warn(`instance_settings '${row.key}' invalid, skipping`);
+			continue;
+		}
+		next[row.key] = { value: parsed.data, isPublic: row.isPublic };
+	}
+	cache = next;
+}
+
+/** Typed, nullable getter keyed by the discriminated union. */
+export function getSetting<K extends InstanceSettingKey>(
+	key: K,
+): InstanceSettingValue<K> | null {
+	return (cache[key]?.value as InstanceSettingValue<K>) ?? null;
+}
+
+/** Public feature flags: only `is_public` rows, secrets stripped via publicSchema. */
+export function getPublicSettings(): Record<string, unknown> {
+	const out: Record<string, unknown> = {};
+	for (const key of Object.keys(cache) as InstanceSettingKey[]) {
+		const entry = cache[key]!;
+		if (!entry.isPublic) continue;
+		out[key] = INSTANCE_SETTINGS_REGISTRY[key].publicSchema.parse(entry.value);
+	}
+	return out;
+}

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -9,6 +9,7 @@ import { loadAppConfig } from "./loaders/appconfigLoader";
 import { loadIntegrations } from "./loaders/integrationsLoader";
 import { loadProjectSettings } from "./loaders/projectSettingsLoader";
 import { loadCustomBlocks, initializeCustomBlocksSubscription } from "./loaders/customBlocksLoader";
+import { loadInstanceSettings } from "./loaders/instanceSettingsLoader";
 import { mapVersionedAdminRoutes } from "./api/register";
 import { errorHandler } from "./middlewares/errorHandler";
 import { auth, initializeAuth } from "./lib/auth";
@@ -37,10 +38,12 @@ app.use(
 	"*",
 	cors({
 		origin: (origin) => {
-			if (origin?.startsWith("http://localhost:")) {
-				return origin;
-			}
-			return null;
+			if (!origin) return null;
+			// dev: any localhost port; prod: explicit TRUSTED_ORIGINS (real DNS behind proxy)
+			if (origin.startsWith("http://localhost:")) return origin;
+			const trusted =
+				process.env.TRUSTED_ORIGINS?.split(",").map((o) => o.trim()) ?? [];
+			return trusted.includes(origin) ? origin : null;
 		},
 		allowHeaders: ["Content-Type", "Authorization", "Accept"],
 		allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"],
@@ -71,6 +74,7 @@ async function main() {
 
 	if (adminRoutesEnabled) {
 		app.use("*", setSession);
+		await loadInstanceSettings(); // must precede initializeAuth so sso_config is available
 		initializeAuth(db);
 		authenticationRouter.registerHandler(app);
 		mapVersionedAdminRoutes(app);

--- a/bun.lock
+++ b/bun.lock
@@ -68,6 +68,7 @@
       "name": "@fluxify/server",
       "version": "1.0.0",
       "dependencies": {
+        "@better-auth/sso": "^1.6.24",
         "@fluxify/adapters": "workspace:*",
         "@fluxify/blocks": "workspace:*",
         "@fluxify/common": "workspace:*",
@@ -247,7 +248,7 @@
     "@faker-js/faker",
   ],
   "overrides": {
-    "bson": "7.2.0",
+    "ansi-regex": "5.0.1",
   },
   "packages": {
     "@ai-sdk/anthropic": ["@ai-sdk/anthropic@4.0.8", "", { "dependencies": { "@ai-sdk/provider": "4.0.2", "@ai-sdk/provider-utils": "5.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ZqT9kLxS2Cbo/4juwtEGbYyP0jNQTnUUKy2nQ8Vn28xqNu50+TukO/oCEWCpm18YbQq7N+hr6ClJs/ATTFpBTg=="],
@@ -312,6 +313,8 @@
 
     "@arizeai/openinference-semantic-conventions": ["@arizeai/openinference-semantic-conventions@2.5.0", "", {}, "sha512-4ZeSwiFX3YxB0WSE6x568wM4PVHiYmz3yiOxic6WGKVrE/KIGggMFP/eqUNQhikBKP68IDV0qiILlZAIYnheAQ=="],
 
+    "@authenio/xml-encryption": ["@authenio/xml-encryption@2.0.2", "", { "dependencies": { "@xmldom/xmldom": "^0.8.6", "escape-html": "^1.0.3", "xpath": "0.0.32" } }, "sha512-cTlrKttbrRHEw3W+0/I609A2Matj5JQaRvfLtEIGZvlN0RaPi+3ANsMeqAyCAVlH/lUIW2tmtBlSMni74lcXeg=="],
+
     "@azu/format-text": ["@azu/format-text@1.0.2", "", {}, "sha512-Swi4N7Edy1Eqq82GxgEECXSSLyn6GOb5htRFPzBDdUkECGXtlf12ynO5oJSpWKPwCaUssOu7NfhDcCWpIC6Ywg=="],
 
     "@azu/style-format": ["@azu/style-format@1.0.1", "", { "dependencies": { "@azu/format-text": "^1.0.1" } }, "sha512-AHcTojlNBdD/3/KxIKlg8sxIWHfOtQszLvOpagLTO+bjC3u7SAszu1lf//u7JJC50aUSH+BVWDD/KvaA6Gfn5g=="],
@@ -341,6 +344,8 @@
     "@better-auth/mongo-adapter": ["@better-auth/mongo-adapter@1.6.23", "", { "peerDependencies": { "@better-auth/core": "^1.6.23", "@better-auth/utils": "0.4.2", "mongodb": "^6.0.0 || ^7.0.0" }, "optionalPeers": ["mongodb"] }, "sha512-7+QdevitGlKBbP6JbiSk5SBnzPsKV/mDrQBGBn8hwByQLeJwqpqbuBPw7ZI8vzUlFfAAnyFiqwP3Eb8mxnp7pA=="],
 
     "@better-auth/prisma-adapter": ["@better-auth/prisma-adapter@1.6.23", "", { "peerDependencies": { "@better-auth/core": "^1.6.23", "@better-auth/utils": "0.4.2", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["@prisma/client", "prisma"] }, "sha512-2qSdzidq4tkb1eS5TTqb4Nzg0mdZWm3Qky9SYeXeb8PpVQbC2sxqJhEM5mK7y12uU6I8hc64wO9f7AFVNL+6UQ=="],
+
+    "@better-auth/sso": ["@better-auth/sso@1.6.24", "", { "dependencies": { "fast-xml-parser": "^5.8.0", "jose": "^6.1.3", "samlify": "^2.13.1", "tldts": "^6.1.0", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/core": "^1.6.24", "@better-auth/utils": "0.4.2", "@better-fetch/fetch": "1.3.1", "better-auth": "^1.6.24", "better-call": "1.3.7" } }, "sha512-o9rO0UNyJlFG3pgpKWfmp02aI6NwErb7TSpdjrbIKR3V/aE1s74A7zMhN355F28nkQAUTk8mjBSC2Mzl7uXwsw=="],
 
     "@better-auth/telemetry": ["@better-auth/telemetry@1.6.23", "", { "peerDependencies": { "@better-auth/core": "^1.6.23", "@better-auth/utils": "0.4.2", "@better-fetch/fetch": "1.3.1" } }, "sha512-/R2Kb+z2BpDOOWwVHqOk+c0VNpuwfCv4Hp5Yr9003WIZPax/zyNraGLB9CFE8qF2gZW8Dsz419k4I8CPrGzpDA=="],
 
@@ -727,6 +732,8 @@
     "@noble/ciphers": ["@noble/ciphers@2.2.0", "", {}, "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA=="],
 
     "@noble/hashes": ["@noble/hashes@2.2.0", "", {}, "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="],
+
+    "@nodable/entities": ["@nodable/entities@3.0.0", "", {}, "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -1190,6 +1197,10 @@
 
     "@workflow/serde": ["@workflow/serde@4.1.0", "", {}, "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ=="],
 
+    "@xmldom/is-dom-node": ["@xmldom/is-dom-node@1.0.1", "", {}, "sha512-CJDxIgE5I0FH+ttq/Fxy6nRpxP70+e2O048EPe85J2use3XKdatVM7dDVvFNjQudd9B49NPoZ+8PG49zj4Er8Q=="],
+
+    "@xmldom/xmldom": ["@xmldom/xmldom@0.8.13", "", {}, "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw=="],
+
     "@xyflow/react": ["@xyflow/react@12.11.1", "", { "dependencies": { "@xyflow/system": "0.0.78", "classcat": "^5.0.3", "zustand": "^4.4.0" }, "peerDependencies": { "@types/react": ">=17", "@types/react-dom": ">=17", "react": ">=17", "react-dom": ">=17" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-L+zBoLGSXham0MnlY8QqjfR7/C5JNw0zxkaey5aZ5XmCgJBAdH4+WRIu8CR40d3l/BdU635V6YbhBK1jMo8/6Q=="],
 
     "@xyflow/system": ["@xyflow/system@0.0.78", "", { "dependencies": { "@types/d3-drag": "^3.0.7", "@types/d3-interpolate": "^3.0.4", "@types/d3-selection": "^3.0.10", "@types/d3-transition": "^3.0.8", "@types/d3-zoom": "^3.0.8", "d3-drag": "^3.0.0", "d3-interpolate": "^3.0.1", "d3-selection": "^3.0.0", "d3-zoom": "^3.0.0" } }, "sha512-lY0z2qP33fUhTva9Vaxrk0lqZta2pkbxB1trHAx1omnJqRtPvDlAQYV2r5fhS6AdpkulYmbNW0svy+A4/t4B/g=="],
@@ -1216,9 +1227,11 @@
 
     "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
 
-    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "anynum": ["anynum@1.0.1", "", {}, "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A=="],
 
     "argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
@@ -1594,6 +1607,10 @@
 
     "fast-uri": ["fast-uri@3.1.3", "", {}, "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg=="],
 
+    "fast-xml-builder": ["fast-xml-builder@1.3.0", "", { "dependencies": { "path-expression-matcher": "^1.6.2", "xml-naming": "^0.3.0" } }, "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ=="],
+
+    "fast-xml-parser": ["fast-xml-parser@5.10.1", "", { "dependencies": { "@nodable/entities": "^3.0.0", "fast-xml-builder": "^1.2.0", "is-unsafe": "^2.0.0", "path-expression-matcher": "^1.6.2", "strnum": "^2.4.1", "xml-naming": "^0.3.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw=="],
+
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
@@ -1875,6 +1892,8 @@
     "is-typed-array": ["is-typed-array@1.1.15", "", { "dependencies": { "which-typed-array": "^1.1.16" } }, "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ=="],
 
     "is-unicode-supported": ["is-unicode-supported@2.1.0", "", {}, "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="],
+
+    "is-unsafe": ["is-unsafe@2.0.0", "", {}, "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA=="],
 
     "is-weakmap": ["is-weakmap@2.0.2", "", {}, "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w=="],
 
@@ -2174,6 +2193,8 @@
 
     "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
 
+    "node-rsa": ["node-rsa@1.1.1", "", { "dependencies": { "asn1": "^0.2.4" } }, "sha512-Jd4cvbJMryN21r5HgxQOpMEqv+ooke/korixNNK3mGqfGJmy0M77WDDzo/05969+OkMy3XW1UuZsSmW9KQm7Fw=="],
+
     "normalize-package-data": ["normalize-package-data@8.0.0", "", { "dependencies": { "hosted-git-info": "^9.0.0", "semver": "^7.3.5", "validate-npm-package-license": "^3.0.4" } }, "sha512-RWk+PI433eESQ7ounYxIp67CYuVsS1uYSonX3kA6ps/3LWfjVQa/ptEg6Y3T6uAMq1mWpX9PQ+qx+QaHpsc7gQ=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
@@ -2245,6 +2266,8 @@
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-expression-matcher": ["path-expression-matcher@1.6.2", "", {}, "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
@@ -2448,6 +2471,8 @@
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
+    "samlify": ["samlify@2.13.1", "", { "dependencies": { "@authenio/xml-encryption": "^2.0.2", "@xmldom/xmldom": "^0.8.11", "node-rsa": "^1.1.1", "xml": "^1.0.1", "xml-crypto": "^6.1.2", "xml-escape": "^1.1.0", "xpath": "^0.0.34" } }, "sha512-vdYr/zohDGBbfWNU4miEzc1jmWOtkLySPViapC6nfGkv9KxzLq4UlGkKyryzwLw4jVlZk88Rw93HaCRVpe+t+g=="],
+
     "scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
 
     "search-insights": ["search-insights@2.17.3", "", {}, "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ=="],
@@ -2584,6 +2609,8 @@
 
     "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
 
+    "strnum": ["strnum@2.4.1", "", { "dependencies": { "anynum": "^1.0.1" } }, "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg=="],
+
     "structured-source": ["structured-source@4.0.0", "", { "dependencies": { "boundary": "^2.0.0" } }, "sha512-qGzRFNJDjFieQkl/sVOI2dUjHKRyL9dAJi2gCPGJLbJHBIkyOHxjuocpIEfbLioX+qSJpvbYdT49/YCdMznKxA=="],
 
     "style-mod": ["style-mod@4.1.3", "", {}, "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ=="],
@@ -2633,6 +2660,10 @@
     "time-span": ["time-span@5.1.0", "", { "dependencies": { "convert-hrtime": "^5.0.0" } }, "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA=="],
 
     "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "tldts": ["tldts@6.1.86", "", { "dependencies": { "tldts-core": "^6.1.86" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ=="],
+
+    "tldts-core": ["tldts-core@6.1.86", "", {}, "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
@@ -2796,6 +2827,16 @@
 
     "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
+    "xml": ["xml@1.0.1", "", {}, "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw=="],
+
+    "xml-crypto": ["xml-crypto@6.1.2", "", { "dependencies": { "@xmldom/is-dom-node": "^1.0.1", "@xmldom/xmldom": "^0.8.10", "xpath": "^0.0.33" } }, "sha512-leBOVQdVi8FvPJrMYoum7Ici9qyxfE4kVi+AkpUoYCSXaQF4IlBm1cneTK9oAxR61LpYxTx7lNcsnBIeRpGW2w=="],
+
+    "xml-escape": ["xml-escape@1.1.0", "", {}, "sha512-B/T4sDK8Z6aUh/qNr7mjKAwwncIljFuUP+DO/D5hloYFj+90O88z8Wf7oSucZTHxBAsC1/CTP4rtx/x1Uf72Mg=="],
+
+    "xml-naming": ["xml-naming@0.3.0", "", {}, "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ=="],
+
+    "xpath": ["xpath@0.0.34", "", {}, "sha512-FxF6+rkr1rNSQrhUNYrAFJpRXNzlDoMxeXN5qI84939ylEv3qqPFKa85Oxr6tDaJKqwW6KKyo2v26TSv3k6LeA=="],
+
     "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
@@ -2821,6 +2862,8 @@
     "@ai-sdk/vue/ai": ["ai@6.0.33", "", { "dependencies": { "@ai-sdk/gateway": "3.0.13", "@ai-sdk/provider": "3.0.2", "@ai-sdk/provider-utils": "4.0.5", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-bVokbmy2E2QF6Efl+5hOJx5MRWoacZ/CZY/y1E+VcewknvGlgaiCzMu8Xgddz6ArFJjiMFNUPHKxAhIePE4rmg=="],
 
     "@arizeai/openinference-instrumentation-langchain/@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.46.0", "", { "dependencies": { "@types/shimmer": "^1.0.2", "import-in-the-middle": "1.7.1", "require-in-the-middle": "^7.1.1", "semver": "^7.5.2", "shimmer": "^1.2.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-a9TijXZZbk0vI5TGLZl+0kxyFfrXHhX6Svtz7Pp2/VBlCSKrazuULEyoJQrOknJyFWNMEmbbJgOciHCCpQcisw=="],
+
+    "@authenio/xml-encryption/xpath": ["xpath@0.0.32", "", {}, "sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw=="],
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 
@@ -3016,6 +3059,8 @@
 
     "wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
+    "xml-crypto/xpath": ["xpath@0.0.33", "", {}, "sha512-NNXnzrkDrAzalLhIUc01jO2mOzXGXh1JwPgkihcLLzw98c0WgYDmmjSh1Kl3wzaxSVWMuA+fe0WTWOBDWCBmNA=="],
+
     "@ai-sdk/vue/@ai-sdk/provider-utils/@ai-sdk/provider": ["@ai-sdk/provider@3.0.2", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-HrEmNt/BH/hkQ7zpi2o6N3k1ZR1QTb7z85WYhYygiTxOQuaml4CMtHCWRbric5WPU+RNsYI7r1EpyVQMKO1pYw=="],
 
     "@ai-sdk/vue/ai/@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.13", "", { "dependencies": { "@ai-sdk/provider": "3.0.2", "@ai-sdk/provider-utils": "4.0.5", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-g7nE4PFtngOZNZSy1lOPpkC+FAiHxqBJXqyRMEG7NUrEVZlz5goBdtHg1YgWRJIX776JTXAmbOI5JreAKVAsVA=="],
@@ -3114,8 +3159,6 @@
 
     "@textlint/linter-formatter/js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
-    "@textlint/linter-formatter/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
     "@types/docker-modem/@types/node/undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
     "@types/dockerode/@types/node/undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
@@ -3133,8 +3176,6 @@
     "bullmq/ioredis/@ioredis/commands": ["@ioredis/commands@1.5.1", "", {}, "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw=="],
 
     "bun-types/@types/node/undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
-
-    "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "color/color-convert/color-name": ["color-name@2.1.0", "", {}, "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg=="],
 
@@ -3155,10 +3196,6 @@
     "radix-vue/@vueuse/core/@vueuse/metadata": ["@vueuse/metadata@10.11.1", "", {}, "sha512-IGa5FXd003Ug1qAZmyE8wF3sJ81xGLSqTqtQ6jaVfkeZ4i5kS2mwQF61yhVqojRnenVew5PldLyRgvdl4YYuSw=="],
 
     "rc-config-loader/js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
-
-    "string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
-    "table/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
 
@@ -3257,8 +3294,6 @@
     "vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
 
     "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
-
-    "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "@ai-sdk/vue/ai/@ai-sdk/gateway/@vercel/oidc": ["@vercel/oidc@3.1.0", "", {}, "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w=="],
 


### PR DESCRIPTION
## Why

Enterprise deployments need SSO (OIDC/SAML) with **pre-provisioned accounts only** (no just-in-time user creation), plus a way to toggle login methods and store IdP config dynamically without a redeploy. This adds a generic, admin-managed instance-settings layer and wires it into a single-provider Better Auth SSO setup.

## What

### SSO + instance-settings foundation (`36e63fb`)
- **`instance_settings` table** (Drizzle migration `0040`): `id`, unique `key`, `category` (pgEnum), `jsonb` `value`, `is_public`, timestamps.
- **Per-key Zod registry** (`lib/instance-settings/schemas.ts`): each key maps to a strict full schema + a `publicSchema` projection that strips secrets. Typed, nullable `getSetting<K>()` getter.
- **Runtime loader** (`loaders/instanceSettingsLoader.ts`): loads settings at boot, subscribes to `CHAN_ON_INSTANCE_SETTING_CHANGE`, and rebuilds the global `auth` on change — mirroring the existing integrations/app-config loader pattern.
- **Public endpoint** `GET /_/admin/api/public-settings`: unauthenticated feature flags, secrets stripped via `publicSchema` — IdP credentials never leak even for `is_public` rows.
- **Better Auth SSO** (`lib/auth.ts`): single inline provider fed from `sso_config` via the plugin's `defaultSSO` (no `ssoProvider` table). `disableImplicitSignUp: true` enforces no-JIT; `provisionUser` throws `ACCOUNT_NOT_PRE_PROVISIONED` as the explicit guard. `trustedOrigins` + CORS are now env-driven (`TRUSTED_ORIGINS`) for real DNS behind the proxy.
- **Mode-aware admin user creation** (`create-user`): reads `auth_config.mode`. Traditional → requires password. `sso_only` → creates a pre-provisioned user row only and rejects emails whose domain ≠ the configured IdP domain.

### Instance-settings admin CRUD (`4e9cbaa`)
- Authenticated (`requireSystemAdmin`) routes under `/_/admin/api/v1/instance-settings`: `get-all`, `get-by-key`, `get-by-category`, `upsert`.
- Upsert validates against the Zod registry, enforces category/SSO/auth-mode invariants, then `publishMessage(CHAN_ON_INSTANCE_SETTING_CHANGE)` so all instances reload (pub/sub only — no inline re-subscribe).
- **Admin reads mask secrets** (`clientSecret`/`samlCert`/`privateKey` → `••••••`) via `redactSecrets` — secrets are write-only.

## Security notes
- Public endpoint and admin reads both strip/mask IdP secrets; secrets are only ever written, never echoed back.
- No JIT: the admin endpoint is the only user-creation path (domain-checked in `sso_only`); SSO login of an unknown email is blocked by `disableImplicitSignUp` + `provisionUser`.

## Testing
- `bun run lint` (all workspaces) clean.
- Pre-commit hook green: lint, secretlint, analyze, **259 unit tests**.
- Full local run: server unit 156, server integration 63, lib 3, blocks 81, adapters 27 — **0 failures**.
- Migration `0040` generated; exported `schema.sql` includes `instance_settings`.

## Follow-ups (not in this PR)
- No delete endpoint yet (upsert only) — can add mirroring the same pub/sub reload.
- Full SAML `spMetadata`/signing left minimal (marked in code); OIDC is fully wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
