### PR TITLE
feat(harness): NATS progress stream + socket.io live updates

### DIFF
--- a/apps/ai-gateway/package.json
+++ b/apps/ai-gateway/package.json
@@ -4,7 +4,8 @@
 	"type": "module",
 	"private": true,
 	"devDependencies": {
-		"@types/bun": "latest"
+		"@types/bun": "latest",
+		"socket.io-client": "^4.8.3"
 	},
 	"scripts": {
 		"dev": "bun --watch run src/server.ts",
@@ -38,11 +39,13 @@
 		"@langchain/openrouter": "^0.4.5",
 		"@modelcontextprotocol/sdk": "^1.29.0",
 		"@orama/plugin-data-persistence": "^3.1.18",
+		"@socket.io/bun-engine": "^0.1.1",
 		"ai": "^7.0.0",
 		"bullmq": "^5.79.1",
 		"drizzle-orm": "0.44.7",
 		"hono": "^4.12.27",
 		"hono-openapi": "^1.3.0",
+		"socket.io": "^4.8.3",
 		"zod": "^4.4.3",
 		"zod-to-json-schema": "^3.25.2"
 	}

--- a/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/agent.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/agent.ts
@@ -76,7 +76,7 @@ export class BlockBuilderAgent extends BaseAgent {
 			name: "agent_status",
 			data: {
 				status: "Analyzing block builder requirements...",
-				agent: AgentNode.BUILDER,
+				agent: AgentNode.BLOCK_BUILDER,
 				agentId: activeTask.id,
 			},
 		});
@@ -121,7 +121,7 @@ export class BlockBuilderAgent extends BaseAgent {
 			name: "agent_status",
 			data: {
 				status: "Block building intent formulated",
-				agent: AgentNode.BUILDER,
+				agent: AgentNode.BLOCK_BUILDER,
 				data: processedResponse,
 				agentId: activeTask.id,
 			},
@@ -130,7 +130,7 @@ export class BlockBuilderAgent extends BaseAgent {
 		const currentResults = this.state.orchestratorState?.subAgentResults || {};
 
 		return {
-			currentAgent: AgentNode.BUILDER,
+			currentAgent: AgentNode.BLOCK_BUILDER,
 			orchestratorState: {
 				...this.state.orchestratorState,
 				subAgentResults: {

--- a/apps/ai-gateway/src/harness/agents/sub-agents/index.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/index.ts
@@ -13,7 +13,7 @@ export const subAgents: SubAgentMetadata[] = [
 	},
 	{
 		name: "Block Builder Agent",
-		nodeName: AgentNode.BUILDER,
+		nodeName: AgentNode.BLOCK_BUILDER,
 		ability: "Create, modify, or delete canvas blocks and edge connections for routes or custom blocks",
 		description:
 			"Responsible for building and modifying the canvas of a workflow DAG by configuring individual blocks and connecting them. This agent is capable of building both for a custom block or a route. The input task should clearly define where the canvas needs to be edited. If the canvas needs to be set up for a new route/custom block which wasn't created in the DB but is listed in a previous agent's output, the task description MUST include the previous agent's task ID. The builder will use its tools to fetch this output. Because of this, large configuration details should not be exposed to the user and should be stored in just the scratchpad and passed via task IDs.",

--- a/apps/ai-gateway/src/harness/agents/supervisor.ts
+++ b/apps/ai-gateway/src/harness/agents/supervisor.ts
@@ -46,7 +46,7 @@ export class SupervisorAgent extends BaseAgent {
 				case AgentNode.ROUTE_CONFIG_AGENT:
 					error = await validateRouteConfig(result, task.id, this.state);
 					break;
-				case AgentNode.BUILDER:
+				case AgentNode.BLOCK_BUILDER:
 					error = await validateBlockBuilderOutput(result, task.id, this.state);
 					break;
 				default:

--- a/apps/ai-gateway/src/harness/callbacks.ts
+++ b/apps/ai-gateway/src/harness/callbacks.ts
@@ -1,4 +1,3 @@
-import type { Job } from "bullmq";
 import { dispatchCustomEvent } from "@langchain/core/callbacks/dispatch";
 import { logger } from "@fluxify/common";
 import {
@@ -19,7 +18,7 @@ import {
 } from "./streamTypes";
 import type { HarnessService } from "./internal/harnessService";
 import type { RedisService } from "./internal/redisService";
-import type { HarnessJobData } from "./queue";
+import { publishHarnessEvent } from "./notifications";
 
 export async function dispatchAgentEvent(event: AgentCustomEvent): Promise<void> {
 	await dispatchCustomEvent(event.name, event.data);
@@ -37,7 +36,9 @@ export interface HarnessCallbackContext {
 	runId: string;
 	harnessService: HarnessService;
 	redisService: RedisService;
-	job?: Job<HarnessJobData>;
+	/** Conversation owner — the `conversations.<userId>` subject to publish to.
+	 *  Null when the conversation has no owner (e.g. the local demo). */
+	userId: string | null;
 }
 
 /**
@@ -55,7 +56,7 @@ export class HarnessCallbacks {
 	private runId: string;
 	private harnessService: HarnessService;
 	private redisService: RedisService;
-	private job?: Job<HarnessJobData>;
+	private userId: string | null;
 	/** Shallow-merged accumulation of node outputs for live-state snapshots. */
 	private mergedState: Partial<GlobalGraphState>;
 	/** Serialized, off-hot-path emit chain. Emitting must never block the
@@ -69,7 +70,7 @@ export class HarnessCallbacks {
 		this.runId = ctx.runId;
 		this.harnessService = ctx.harnessService;
 		this.redisService = ctx.redisService;
-		this.job = ctx.job;
+		this.userId = ctx.userId;
 		this.mergedState = { ...ctx.state };
 	}
 
@@ -103,12 +104,12 @@ export class HarnessCallbacks {
 	}
 
 	/** Non-blocking: schedules the event on the serialized emit chain and returns
-	 *  immediately so the graph is never gated on Redis / BullMQ. */
+	 *  immediately so the graph is never gated on Redis / NATS. */
 	private emit(event: HarnessStreamEvent): void {
 		this.emitChain = this.emitChain.then(async () => {
 			try {
 				await this.redisService.appendEvent(event);
-				await this.job?.updateProgress(event as any);
+				if (this.userId) publishHarnessEvent(this.userId, event);
 			} catch (error) {
 				logger.error("Error emitting event", "HarnessCallbacks", {
 					runId: this.runId,

--- a/apps/ai-gateway/src/harness/callbacks.ts
+++ b/apps/ai-gateway/src/harness/callbacks.ts
@@ -163,13 +163,13 @@ export class HarnessCallbacks {
 			}
 			case AgentNode.SUMMARIZER:
 				return { node: AgentNode.SUMMARIZER, data: output.summarizerState ?? {} };
-			case AgentNode.BUILDER:
+			case AgentNode.BLOCK_BUILDER:
 			case AgentNode.ROUTE_CONFIG_AGENT: {
 				const task = output.activeTask ?? input.activeTask;
 				if (!task) return undefined;
 				const result = output.orchestratorState?.subAgentResults?.[task.id];
 				return {
-					node: node as AgentNode.BUILDER | AgentNode.ROUTE_CONFIG_AGENT,
+					node: node as AgentNode.BLOCK_BUILDER | AgentNode.ROUTE_CONFIG_AGENT,
 					data: {
 						task: {
 							id: task.id,

--- a/apps/ai-gateway/src/harness/graph.ts
+++ b/apps/ai-gateway/src/harness/graph.ts
@@ -47,7 +47,7 @@ const workflow = new StateGraph(GraphState)
 		const agent = new RouteConfigAgent(state);
 		return await agent.execute();
 	})
-	.addNode(AgentNode.BUILDER, async (state: GlobalGraphState) => {
+	.addNode(AgentNode.BLOCK_BUILDER, async (state: GlobalGraphState) => {
 		const agent = new BlockBuilderAgent(state);
 		return await agent.execute();
 	})
@@ -113,7 +113,7 @@ const workflow = new StateGraph(GraphState)
 	.addEdge(AgentNode.HUMAN_IN_THE_LOOP, END)
 	.addEdge(AgentNode.DISCUSSION, END)
 	.addEdge(AgentNode.ROUTE_CONFIG_AGENT, AgentNode.SUPERVISOR)
-	.addEdge(AgentNode.BUILDER, AgentNode.SUPERVISOR)
+	.addEdge(AgentNode.BLOCK_BUILDER, AgentNode.SUPERVISOR)
 	.addEdge(AgentNode.SUPERVISOR, AgentNode.ORCHESTRATOR)
 	.addEdge(AgentNode.SUMMARIZER, END);
 

--- a/apps/ai-gateway/src/harness/harness-client-implementation-guide.md
+++ b/apps/ai-gateway/src/harness/harness-client-implementation-guide.md
@@ -1,0 +1,471 @@
+# Harness Web Client Implementation Guide
+
+How a web (React) client consumes live harness run updates over socket.io. This
+is the **client-facing contract** — everything you need to build the UI without
+reading the backend. Pairs with `notification-implementation.md` (the backend
+wiring).
+
+> **Golden rule:** the transport delivers events, but the client owns
+> correctness. A single mishandled message (missed, applied out of order, or
+> merged wrong) leaves the UI stale or inconsistent. Read the
+> [Edge cases](#edge-cases--react-state-correctness) section before writing the
+> reducer — it is the point of this document.
+
+---
+
+## 1. Connection
+
+| Property | Value |
+| --- | --- |
+| Library | `socket.io-client` v4 (server is `socket.io` v4) |
+| URL | same origin as the web app (`window.location.origin`) |
+| `path` | **`/_/admin/ai/socket.io/`** (the reverse proxy routes this prefix to the AI gateway) |
+| Auth | the better-auth **session cookie**, sent automatically by the browser |
+| `withCredentials` | **`true`** (required so the cookie rides the handshake cross-origin) |
+| Event name | **`conversation`** (single event; discriminated by `type` inside the payload) |
+| Room (server-side) | `conversations:<userId>` — you never name it; you are auto-joined |
+
+```ts
+import { io, type Socket } from "socket.io-client";
+
+const socket: Socket = io(window.location.origin, {
+  path: "/_/admin/ai/socket.io/",
+  withCredentials: true,
+  // reconnection is ON by default; see §6 before changing these
+  reconnection: true,
+  reconnectionAttempts: Infinity,
+  reconnectionDelay: 1000,
+  reconnectionDelayMax: 5000,
+});
+```
+
+### Authentication
+
+- The browser sends the **HttpOnly** `better-auth.session_token` cookie
+  automatically on the handshake — **you cannot and must not set it manually**
+  (`extraHeaders`/`Cookie` is for the Node demo only; browsers forbid it).
+- The server authenticates **during the handshake, before `connect` fires**. No
+  valid session → the connection is **refused** and the client receives
+  `connect_error` with message `"unauthorized"`. There is no half-open state.
+- **The socket only ever joins the logged-in user's own room.** You cannot
+  subscribe to another user. All of a user's conversations arrive on this one
+  connection.
+
+```ts
+socket.on("connect_error", (err) => {
+  if (err.message === "unauthorized") {
+    // session expired / not logged in → send them to login, then reconnect
+  }
+});
+```
+
+---
+
+## 2. The message contract
+
+One event, `conversation`, carrying a **discriminated union** keyed by `type`:
+
+```ts
+type HarnessSocketMessage =
+  | { type: "full_state"; conversations: HarnessSnapshot[] }
+  | {
+      type: "update";
+      conversationId: string;
+      runId: string;
+      stepId?: string;
+      event: HarnessStreamEvent;
+    };
+```
+
+| `type` | When | Meaning |
+| --- | --- | --- |
+| `full_state` | **once per (re)connect** | Baseline catch-up: the current cached state of **every** conversation the user has running. |
+| `update` | continuously | One live harness event. `conversationId` says which conversation; `stepId` identifies the individual step. |
+
+```ts
+socket.on("conversation", (msg: HarnessSocketMessage) => {
+  if (msg.type === "full_state") applyFullState(msg.conversations);
+  else applyUpdate(msg); // msg.conversationId, msg.runId, msg.stepId, msg.event
+});
+```
+
+---
+
+## 3. Payload types (copy into the client)
+
+These mirror the server types exactly. Treat them as the wire schema.
+
+```ts
+/** Which tier produced the event. */
+type HarnessLevel = "harness" | "sub_agent";
+
+/** Lifecycle phase of a single event. */
+type HarnessPhase = "node_start" | "node_end" | "status" | "hitl_required";
+
+/** Overall run status (mirrors the DB run status). */
+type HarnessRunStatus =
+  | "queued" | "routing" | "verifying" | "planning" | "orchestrating"
+  | "executing" | "awaiting_hitl" | "completed" | "interrupted" | "failed";
+
+/** Graph node names (the `node` field). */
+type AgentNodeName =
+  | "router" | "classifier" | "verifyUserQuery" | "planner" | "taskGenerator"
+  | "discussion" | "blockBuilder" | "orchestrator" | "humanInTheLoop"
+  | "routeConfig" | "supervisor" | "summarizer";
+
+/** A single task in the DAG view. */
+interface HarnessTaskView {
+  id: string;
+  title: string;
+  status: "pending" | "running" | "completed" | "failed";
+  assignedAgentNode: AgentNodeName;
+  level: number;
+}
+
+/** The core event — the unit of everything. */
+interface HarnessStreamEvent {
+  conversationId: string;
+  runId: string;
+  stepId?: string;          // present for node_start/node_end; absent for most status events
+  level: HarnessLevel;
+  phase: HarnessPhase;
+  node: AgentNodeName;
+  status: string;           // human-readable label, e.g. "Running planner"
+  runStatus: HarnessRunStatus;
+  payload?: HarnessNodePayload; // present mainly on node_end / hitl_required
+  timestamp: number;        // epoch ms — USE THIS for ordering/merge (see §5)
+}
+
+/** Cached per-run snapshot delivered inside full_state. */
+interface HarnessSnapshot {
+  conversationId: string;
+  runId: string;
+  runStatus: HarnessRunStatus;
+  currentNode?: AgentNodeName;
+  currentLevel?: HarnessLevel;
+  events: HarnessStreamEvent[]; // bounded to the last 200 events (see §5)
+  updatedAt: number;
+}
+```
+
+### The node-typed payload (discriminated by `node`)
+
+`event.payload` is present mostly on `node_end` (and `hitl_required`). It is a
+discriminated union on `node`, so you narrow the `data` shape from `event.node`:
+
+```ts
+type HarnessNodePayload =
+  | { node: "router";          data: { intent?: "discussion" | "builder"; reason?: string } }
+  | { node: "verifyUserQuery"; data: { capable?: boolean; rejectReason?: string } }
+  | { node: "planner";         data: { markdownPlan?: string; scratchpadNote?: string; confidenceScore?: number; implementationComplexity?: "high" | "mid" | "low" } }
+  | { node: "discussion";      data: { markdown?: string } }
+  | { node: "taskGenerator";   data: { tasksByLevel: HarnessTaskView[][] } }
+  | { node: "orchestrator";    data: { tasksByLevel: HarnessTaskView[][]; activeLevel: number } }
+  | { node: "supervisor";      data: { tasksByLevel: HarnessTaskView[][] } }
+  | { node: "blockBuilder";    data: { task: HarnessTaskView; result?: SubAgentResult } }
+  | { node: "routeConfig";     data: { task: HarnessTaskView; result?: SubAgentResult } }
+  | { node: "summarizer";      data: { markdown?: string; artifactId?: string } }
+  | { node: "humanInTheLoop";  data: { reason: string; markdownPlan?: string } };
+
+/** Sub-agent output — shape depends on the agent; treat as opaque unless you
+ *  need it. `routeConfig` → RouteConfigAgentResult, `blockBuilder` → BlockBuilderAgentResult. */
+type SubAgentResult = Record<string, unknown>;
+```
+
+> **Important merge semantics:** the `tasksByLevel` arrays are the **whole task
+> DAG re-computed each time** — always **replace**, never merge, the tasks for a
+> conversation from the newest `orchestrator`/`taskGenerator`/`supervisor` event.
+
+---
+
+## 4. What a run looks like on the wire
+
+A typical run streams (per conversation) roughly:
+
+```
+node_start router        (runStatus: routing)
+node_end   router        payload.router        (intent)
+node_start verifyUserQuery (verifying)
+node_end   verifyUserQuery payload.verifyUserQuery
+node_start planner        (planning)
+node_end   planner        payload.planner       (markdownPlan)
+   ── may park here ──
+hitl_required humanInTheLoop  payload.humanInTheLoop (reason, markdownPlan)
+status     humanInTheLoop  runStatus: awaiting_hitl   ← TERMINAL for this pass
+   ── or continue ──
+node_start taskGenerator   (orchestrating)
+node_end   taskGenerator   payload.taskGenerator  (tasksByLevel)
+node_start orchestrator
+node_end   orchestrator    payload.orchestrator   (tasksByLevel, activeLevel)
+node_start blockBuilder    (executing, level: sub_agent)   per task
+node_end   blockBuilder    payload.blockBuilder   (task, result)
+node_start supervisor
+node_end   supervisor      payload.supervisor
+node_start summarizer
+node_end   summarizer      payload.summarizer     (markdown)
+status     <node>          runStatus: completed        ← TERMINAL
+```
+
+**Terminal signal:** a message where `event.phase === "status"` **and**
+`event.runStatus ∈ { "completed", "failed", "awaiting_hitl" }`. After this, no
+more updates arrive for that run.
+
+- `stepId` is **stable across `node_start` → `node_end`** for the same step
+  (it's an upsert). Use it to update a step in place.
+- Sub-agent steps (`level: "sub_agent"`, nodes `blockBuilder`/`routeConfig`) can run
+  **many in parallel** at the same DAG level — expect interleaving.
+
+---
+
+## 5. Recommended client state shape
+
+Key everything by `conversationId`, then track steps by `stepId` and tasks by
+task `id`. Never store a flat list you append to blindly.
+
+```ts
+interface ConversationUIState {
+  conversationId: string;
+  runId: string;
+  runStatus: HarnessRunStatus;
+  currentNode?: AgentNodeName;
+  isTerminal: boolean;
+  lastTimestamp: number;                 // newest event applied (for ordering)
+  steps: Record<string, StepUIState>;    // keyed by stepId
+  tasksByLevel: HarnessTaskView[][];      // replaced wholesale from payloads
+  plan?: string;                          // planner.markdownPlan
+  summary?: string;                       // summarizer.markdown
+  hitl?: { reason: string; markdownPlan?: string };
+}
+
+interface StepUIState {
+  stepId: string;
+  node: AgentNodeName;
+  level: HarnessLevel;
+  status: "running" | "completed";       // node_start → running, node_end → completed
+  label: string;                         // event.status
+  payload?: HarnessNodePayload;
+  timestamp: number;
+}
+
+// top-level: Record<conversationId, ConversationUIState>
+```
+
+### The merge function (apply both `full_state` events and live `update`s through it)
+
+```ts
+function applyEvent(state: ConversationUIState, e: HarnessStreamEvent): ConversationUIState {
+  // 1) Never regress overall status/node to an OLDER event.
+  const isNewer = e.timestamp >= state.lastTimestamp;
+
+  const next = { ...state };
+  if (isNewer) {
+    next.runStatus = e.runStatus;
+    next.currentNode = e.node;
+    next.lastTimestamp = e.timestamp;
+    next.isTerminal =
+      e.phase === "status" &&
+      (e.runStatus === "completed" || e.runStatus === "failed" || e.runStatus === "awaiting_hitl");
+  }
+
+  // 2) Step upsert keyed by stepId (node_start/node_end share the stepId).
+  if (e.stepId) {
+    const prev = next.steps[e.stepId];
+    // don't let an older node_start overwrite a newer node_end
+    if (!prev || e.timestamp >= prev.timestamp) {
+      next.steps = {
+        ...next.steps,
+        [e.stepId]: {
+          stepId: e.stepId,
+          node: e.node,
+          level: e.level,
+          status: e.phase === "node_end" ? "completed" : prev?.status === "completed" ? "completed" : "running",
+          label: e.status,
+          payload: e.payload ?? prev?.payload,
+          timestamp: e.timestamp,
+        },
+      };
+    }
+  }
+
+  // 3) Payload-driven fields — REPLACE (tasksByLevel is a full recompute).
+  switch (e.payload?.node) {
+    case "taskGenerator":
+    case "supervisor":
+      next.tasksByLevel = e.payload.data.tasksByLevel;
+      break;
+    case "orchestrator":
+      next.tasksByLevel = e.payload.data.tasksByLevel;
+      break;
+    case "planner":
+      if (e.payload.data.markdownPlan) next.plan = e.payload.data.markdownPlan;
+      break;
+    case "summarizer":
+      if (e.payload.data.markdown) next.summary = e.payload.data.markdown;
+      break;
+    case "humanInTheLoop":
+      next.hitl = e.payload.data;
+      break;
+  }
+  return next;
+}
+```
+
+`applyFullState` seeds/merges each snapshot's `events` through `applyEvent` (and
+sets `runStatus`/`currentNode` from the snapshot as a floor). `applyUpdate` runs
+the single `msg.event` through `applyEvent`. **Both paths share one idempotent
+reducer** — that is what makes replays and races safe.
+
+---
+
+## 6. Edge cases — React state correctness
+
+This is the part that makes or breaks the UI. Each item below is a real way the
+naive implementation goes stale.
+
+### 6.1 `full_state` can arrive AFTER live `update`s (race)
+On connect the server joins your room **then** does an async DB+Redis read
+before emitting `full_state`. A live `update` for an event happening in that
+window is emitted to the room and **can reach you before `full_state`**.
+- **Consequence:** if you blindly overwrite state on `full_state`, you clobber
+  newer data with an older baseline.
+- **Fix:** the reducer is idempotent and **timestamp-guarded** (§5). Apply
+  `full_state` events through the same `applyEvent`; older events simply don't
+  regress newer fields. Never do `state = snapshot`.
+
+### 6.2 `full_state` and live streams overlap (duplicates)
+The same event may appear both in the connect snapshot and as a live update.
+- **Fix:** dedupe by `stepId` (upsert) and guard scalar fields by `timestamp`.
+  Applying the same event twice must be a no-op. Never `push` events into an array.
+
+### 6.3 Reconnection replays `full_state` — and you MUST re-merge it
+socket.io auto-reconnects. On every reconnect the server treats it as a **new
+connection** and re-sends `full_state`.
+- **Consequence:** events emitted **while you were disconnected** are not
+  delivered as live updates — they exist only in the reconnect `full_state`
+  snapshot.
+- **Fix:** always handle `full_state` on **every** connect, not just the first.
+  Do **not** reset your store on reconnect; merge the snapshot in. Track a
+  `connected` flag for UI, but keep the data.
+
+### 6.4 The snapshot event log is bounded to the last 200 events
+`HarnessSnapshot.events` keeps only the most recent 200. A long run that
+disconnected early may have dropped the earliest `node_start`s from the snapshot.
+- **Consequence:** after a long-disconnect reconnect you might see a `node_end`
+  for a step whose `node_start` you never got.
+- **Fix:** treat any event as an **upsert** — a `node_end` with no prior
+  `node_start` still creates the step (status `completed`). Don't assume start
+  precedes end.
+
+### 6.5 Completed runs disappear from `full_state` after ~60s
+The Redis snapshot's TTL drops to **60 seconds** once a run reaches a terminal
+state. Reconnect >60s after completion and that run is **absent** from
+`full_state`.
+- **Consequence:** if you rely on `full_state` alone, a finished run vanishes
+  from the UI on reconnect.
+- **Fix:** once you mark a run `isTerminal`, **persist its final state
+  client-side** (or fetch history from the REST API). Absence in a later
+  `full_state` means "already finished", not "never existed" — never delete a
+  known terminal run because a new snapshot omits it.
+
+### 6.6 Multiple concurrent runs interleave on one socket
+A user can trigger several conversations at once; their updates arrive
+interleaved on the same connection.
+- **Fix:** **always** route by `msg.conversationId` (updates) /
+  `snapshot.conversationId` (full_state). Never assume "the current run". A UI
+  bound to a single active run will corrupt when a second one emits.
+
+### 6.7 `stepId` is optional
+`status` events (including the terminal one) and `agent_status` events often have
+**no `stepId`**.
+- **Fix:** only do the step upsert when `event.stepId` is present. Drive overall
+  status from `runStatus`/`phase`, which are always present.
+
+### 6.8 `payload` is optional
+`node_start` and `status` events usually carry **no payload**. Only read
+`event.payload` after narrowing on `event.payload?.node`.
+- **Fix:** never assume `payload` exists; guard every access.
+
+### 6.9 `tasksByLevel` must be replaced, not merged
+Each orchestrator/supervisor/taskGenerator event carries the **entire** recomputed
+DAG. Merging arrays produces duplicate/stale tasks.
+- **Fix:** `next.tasksByLevel = payload.data.tasksByLevel` (full replace). Task
+  status changes come through as a **new full DAG**, not per-task deltas.
+
+### 6.10 HITL is terminal-but-resumable
+`awaiting_hitl` ends the current run pass. The run resumes later as a **new job**
+(and may reuse the run id) — you'll receive fresh `node_start`s again after the
+user submits their decision via the REST API.
+- **Fix:** render the `humanInTheLoop` payload (reason + `markdownPlan`) and
+  treat `awaiting_hitl` as "paused, waiting on user", not "done". Clear the
+  `hitl` block when new non-HITL events arrive.
+
+### 6.11 React StrictMode / effect cleanup double-connects
+In dev, `useEffect` runs twice; without cleanup you open two sockets and get
+duplicate events.
+- **Fix:** create the socket in `useEffect` and **`socket.disconnect()` in the
+  cleanup**. One socket per mounted provider. See §7.
+
+### 6.12 Stale closures in event handlers
+Registering `socket.on("conversation", …)` with a handler that closes over state
+captures a stale snapshot.
+- **Fix:** update state via a **functional reducer** (`setState(prev => …)`) or
+  `useReducer`, so the handler never reads stale `state` directly. Register the
+  listener **once**; don't re-bind on every render.
+
+### 6.13 Ordering guarantee is per-connection only
+Within one connection socket.io preserves emit order. Across a
+disconnect/reconnect that guarantee is gone (see 6.3/6.4).
+- **Fix:** the `timestamp` guard in the reducer is the ordering source of truth,
+  not arrival order.
+
+---
+
+## 7. Reference React hook (shape, not a drop-in)
+
+```tsx
+function useHarnessSocket() {
+  const [conversations, dispatch] = useReducer(reducer, {} as Record<string, ConversationUIState>);
+  const [connected, setConnected] = useState(false);
+
+  useEffect(() => {
+    const socket = io(window.location.origin, {
+      path: "/_/admin/ai/socket.io/",
+      withCredentials: true,
+    });
+
+    socket.on("connect", () => setConnected(true));
+    socket.on("disconnect", () => setConnected(false)); // keep data; just flag UI
+    socket.on("connect_error", (err) => {
+      if (err.message === "unauthorized") {/* redirect to login */}
+    });
+
+    // ONE listener, functional dispatch → no stale closures
+    socket.on("conversation", (msg: HarnessSocketMessage) => {
+      dispatch({ type: "socket", msg }); // reducer fans full_state/update through applyEvent
+    });
+
+    return () => { socket.disconnect(); }; // StrictMode-safe
+  }, []); // empty deps: connect once
+
+  return { conversations, connected };
+}
+```
+
+The `reducer` handles `msg.type === "full_state"` by merging every snapshot's
+events, and `msg.type === "update"` by applying the single event — both through
+the idempotent, timestamp-guarded `applyEvent` from §5.
+
+---
+
+## 8. Checklist before shipping
+
+- [ ] `withCredentials: true` and correct `path`.
+- [ ] `connect_error: "unauthorized"` routes to login.
+- [ ] `full_state` handled on **every** connect (incl. reconnects), merged not replaced.
+- [ ] All state keyed by `conversationId`; multiple runs supported.
+- [ ] Reducer is idempotent and timestamp-guarded (safe to replay).
+- [ ] Steps upserted by `stepId`; missing `stepId`/`payload` guarded.
+- [ ] `tasksByLevel` replaced wholesale.
+- [ ] Terminal runs persisted client-side (survive the 60s snapshot eviction).
+- [ ] Socket disconnected on unmount; single listener; functional dispatch.
+```

--- a/apps/ai-gateway/src/harness/index.ts
+++ b/apps/ai-gateway/src/harness/index.ts
@@ -33,6 +33,7 @@ import {
 	type HarnessRunStatus,
 	type HarnessStreamEvent,
 } from "./streamTypes";
+import { publishHarnessEvent } from "./notifications";
 import type { HarnessJobData, HarnessJobMetadata } from "./queue";
 
 /** Everything a single harness run needs — supplied by the worker from job data. */
@@ -123,13 +124,16 @@ export class FluxifyHarness {
 		state: Partial<GlobalGraphState>,
 	) {
 		const harnessService = state.internal!.harnessService;
+		// Resolve the conversation owner once — it's the `conversations.<userId>`
+		// pub/sub subject every event for this run is published to.
+		const userId = await harnessService.getOwnerUserId();
 		const callbacks = new this.callbacksClass({
 			state,
 			conversationId: ctx.conversationId,
 			runId: ctx.runId,
 			harnessService,
 			redisService: this.redisService,
-			job: ctx.job,
+			userId,
 		});
 		// Attach the OTEL tracer as a run callback (app.invoke used to pass this;
 		// the streamEvents path must supply it explicitly for LLM/agent tracing).
@@ -176,7 +180,7 @@ export class FluxifyHarness {
 			);
 
 			await callbacks.flush();
-			await this.finalizeRun(ctx, harnessService, finalState);
+			await this.finalizeRun(ctx, harnessService, userId, finalState);
 		} catch (error) {
 			logger.error("[FluxifyHarness] Graph execution failed", {
 				conversationId: ctx.conversationId,
@@ -186,7 +190,7 @@ export class FluxifyHarness {
 			// Raw dump so the underlying stack is visible in foreground runs.
 			logger.error("Graph error", "FluxifyHarness", { error });
 			await callbacks.flush().catch(() => {});
-			await this.failRun(ctx, harnessService, error);
+			await this.failRun(ctx, harnessService, userId, error);
 			throw error;
 		} finally {
 			await harnessService.awaitAllPendingBackgroundTasks();
@@ -204,6 +208,7 @@ export class FluxifyHarness {
 	private async finalizeRun(
 		ctx: HarnessRunContext,
 		harnessService: HarnessService,
+		userId: string | null,
 		finalState?: Partial<GlobalGraphState>,
 	) {
 		const reachedHITL =
@@ -224,7 +229,9 @@ export class FluxifyHarness {
 				graphState: finalState,
 			});
 			await harnessService.updateConversationStatus("paused_hitl", ctx.runId);
-			await this.emitTerminal(ctx, "awaiting_hitl", AgentNode.HUMAN_IN_THE_LOOP);
+			await this.emitTerminal(ctx, userId, "awaiting_hitl", AgentNode.HUMAN_IN_THE_LOOP);
+			// HITL is terminal for this run pass — evict its live-state snapshot soon.
+			await this.redisService.finalizeSnapshot(ctx.runId);
 			logger.info("[FluxifyHarness] Run parked for HITL", {
 				runId: ctx.runId,
 				conversationId: ctx.conversationId,
@@ -254,14 +261,17 @@ export class FluxifyHarness {
 		await this.redisService.clearActiveRun(ctx.conversationId);
 		await this.emitTerminal(
 			ctx,
+			userId,
 			"completed",
 			finalState?.currentAgent ?? AgentNode.ORCHESTRATOR,
 		);
+		await this.redisService.finalizeSnapshot(ctx.runId);
 	}
 
 	private async failRun(
 		ctx: HarnessRunContext,
 		harnessService: HarnessService,
+		userId: string | null,
 		error?: unknown,
 	) {
 		const message =
@@ -276,7 +286,8 @@ export class FluxifyHarness {
 			});
 			await harnessService.updateConversationStatus("failed", null);
 			await this.redisService.clearActiveRun(ctx.conversationId);
-			await this.emitTerminal(ctx, "failed", AgentNode.ROUTER, message);
+			await this.emitTerminal(ctx, userId, "failed", AgentNode.ROUTER, message);
+			await this.redisService.finalizeSnapshot(ctx.runId);
 		} catch (e) {
 			logger.error("[FluxifyHarness] Error persisting run failure", {
 				runId: ctx.runId,
@@ -285,9 +296,10 @@ export class FluxifyHarness {
 		}
 	}
 
-	/** Emits a run-level terminal event so SSE subscribers get a close signal. */
+	/** Emits a run-level terminal event so subscribers get a close signal. */
 	private async emitTerminal(
 		ctx: HarnessRunContext,
+		userId: string | null,
 		runStatus: HarnessRunStatus,
 		node: AgentNodeName,
 		statusText?: string,
@@ -304,7 +316,7 @@ export class FluxifyHarness {
 		};
 		try {
 			await this.redisService.appendEvent(event);
-			await ctx.job?.updateProgress(event as any);
+			if (userId) publishHarnessEvent(userId, event);
 		} catch (e) {
 			logger.error("[FluxifyHarness] Error emitting terminal event", {
 				runId: ctx.runId,

--- a/apps/ai-gateway/src/harness/internal/harnessService.ts
+++ b/apps/ai-gateway/src/harness/internal/harnessService.ts
@@ -94,6 +94,27 @@ export class HarnessService {
 	}
 
 	/**
+	 * Returns the userId that owns this conversation (the pub/sub subject key), or
+	 * null if the conversation has no owner / does not exist.
+	 */
+	async getOwnerUserId(): Promise<string | null> {
+		try {
+			const rows = await db
+				.select({ userId: agentHarnessConversationsEntity.userId })
+				.from(agentHarnessConversationsEntity)
+				.where(eq(agentHarnessConversationsEntity.id, this.conversationId))
+				.limit(1);
+			return rows[0]?.userId ?? null;
+		} catch (error) {
+			logger.error("[HarnessService] Error reading conversation owner", {
+				conversationId: this.conversationId,
+				error,
+			});
+			return null;
+		}
+	}
+
+	/**
 	 * Ensures a conversation row exists for this service's conversationId.
 	 * Inserts with the given owner/project if absent, otherwise leaves it as-is.
 	 * Used before APIs exist to bootstrap a conversation for a run.

--- a/apps/ai-gateway/src/harness/internal/redisService.ts
+++ b/apps/ai-gateway/src/harness/internal/redisService.ts
@@ -14,9 +14,13 @@ import type {
  * is race-free. Uses the shared `@fluxify/server` cache helpers (ioredis).
  */
 export class RedisService {
-	/** TTL for cached snapshots (seconds). Kept alive past completion so late
-	 *  subscribers still receive the final state. */
-	private static readonly SNAPSHOT_TTL = 3600;
+	/** TTL while a run is live (seconds). Long enough to never evict mid-run; acts
+	 *  only as a safety net if a worker dies without finalizing (see finalizeSnapshot).
+	 *  ponytail: fixed 6h ceiling — only leaks on a hard worker crash, self-heals. */
+	private static readonly RUNNING_TTL = 6 * 3600;
+	/** TTL applied once a run finishes (any terminal state) so the key auto-evicts
+	 *  shortly after, giving late subscribers a brief window to read the final state. */
+	private static readonly FINALIZE_TTL = 60;
 	/** Max events retained in a snapshot to bound cache size. */
 	private static readonly MAX_EVENTS = 200;
 
@@ -33,7 +37,7 @@ export class RedisService {
 			await setCacheEx(
 				this.activeRunKey(conversationId),
 				runId,
-				RedisService.SNAPSHOT_TTL,
+				RedisService.RUNNING_TTL,
 			);
 		} catch (e) {
 			logger.error("[RedisService] Error setting active run", { conversationId, error: e });
@@ -86,7 +90,7 @@ export class RedisService {
 			await setCacheEx(
 				this.snapshotKey(event.runId),
 				JSON.stringify(snapshot),
-				RedisService.SNAPSHOT_TTL,
+				RedisService.RUNNING_TTL,
 			);
 		} catch (e) {
 			logger.error("[RedisService] Error appending event", {
@@ -94,6 +98,26 @@ export class RedisService {
 				node: event.node,
 				error: e,
 			});
+		}
+	}
+
+	/**
+	 * Marks a run's snapshot as finished by shortening its TTL to FINALIZE_TTL, so
+	 * the whole-run-state key auto-evicts a minute after completion (success,
+	 * failure, or HITL) instead of being deleted instantly. No-op if the snapshot
+	 * has already expired.
+	 */
+	async finalizeSnapshot(runId: string): Promise<void> {
+		try {
+			const snapshot = await this.getSnapshot(runId);
+			if (!snapshot) return;
+			await setCacheEx(
+				this.snapshotKey(runId),
+				JSON.stringify(snapshot),
+				RedisService.FINALIZE_TTL,
+			);
+		} catch (e) {
+			logger.error("[RedisService] Error finalizing snapshot", { runId, error: e });
 		}
 	}
 

--- a/apps/ai-gateway/src/harness/notification-implementation.md
+++ b/apps/ai-gateway/src/harness/notification-implementation.md
@@ -54,7 +54,6 @@ Exports:
 | `CONVERSATIONS_WILDCARD` | `conversations.*` |
 | `publishHarnessEvent(userId, event)` | wrap event in envelope, publish |
 | `subscribeConversations(handler)` | validated wildcard subscription → async unsubscribe |
-| `startConversationEventBridge()` | subscribe + re-emit into the in-process bus |
 
 ## Transport
 
@@ -75,8 +74,7 @@ BullMQ job → FluxifyHarness.executeGraph
 
 - Owner `userId` is resolved **once** in `executeGraph` and threaded into
   `HarnessCallbacks` and the terminal emitters. If a conversation has no owner
-  (e.g. the local demo with an empty user table) the publish is **skipped** —
-  there is no subject to publish to.
+  the publish is **skipped** — there is no subject to publish to.
 - `initializeHarnessWorker` `await`s `initializePubSub()` (idempotent) so the
   worker's NATS connection is live before any job runs. In the real app it is
   already connected at `server.ts` startup; this is a defensive re-init.
@@ -85,14 +83,13 @@ BullMQ job → FluxifyHarness.executeGraph
 
 ## Consumer side (main thread)
 
-`runMain` calls `startConversationEventBridge()`, which subscribes to
-`conversations.*`, validates, and re-emits `message.event` into
-`harnessEventEmitter` keyed by `conversationId`. That in-process bus is what SSE
-reads today and what socket.io rooms will read next (room per `userId`, targeted
-by `conversationId`).
+`runMain` calls `initializeHarnessSocket()` (see below), which subscribes to
+`conversations.*`, validates each message, and fans it to the owner's socket.io
+room. That is the only consumer of the subject; there is no in-process
+`EventEmitter` bridge.
 
-The old `QueueEvents("progress")` bridge in `queue.ts` was removed; the emitter
-is now fed exclusively from NATS. `harnessQueue` (job add/trigger) is unchanged.
+The old `QueueEvents("progress")` bridge in `queue.ts` was removed; `harnessQueue`
+(job add/trigger) is unchanged.
 
 ## Redis whole-run-state KV — `redisService.ts`
 
@@ -111,6 +108,63 @@ TTL lifecycle:
 auto-evicts ~60s after the run ends instead of being deleted instantly — late
 subscribers still get a brief window to read the final state.
 
+## Socket.io layer — `socketGateway.ts`
+
+The client-facing edge. socket.io runs on the **Bun engine**
+(`@socket.io/bun-engine`) and has no Hono adapter, so both share **one**
+`Bun.serve` router in `main.ts`:
+
+```
+fetch(req, server):
+  /_/admin/ai/socket.io/*  → engine.handleRequest   (socket.io transport)
+  everything else          → app.fetch              (Hono)
+websocket: engine.handler().websocket               (Bun native WebSocket handler)
+```
+
+The transport path is prefixed with `/_/admin/ai` (exported as `SOCKET_PATH`) so
+the reverse proxy — which forwards `/_/admin/*` to this backend, alongside
+`/_/admin/api/ai/v1` and `/_/admin/mcp` — routes the handshake here. Clients must
+connect with `{ path: "/_/admin/ai/socket.io/", withCredentials: true }`.
+
+`initializeHarnessSocket()` builds the server and returns `{ fetch, websocket }`
+for `main.ts` to mount. It:
+
+1. **Authenticates** every connection *before it is established* — the `io.use`
+   middleware runs during the handshake, before any `connection` event, and calls
+   `auth.api.getSession({ headers })` against the handshake cookies. No valid
+   session → the handshake is rejected (client gets `connect_error`), so an
+   unauthenticated client never connects. A user only ever joins their **own** room.
+2. **Joins** the socket to `conversations:<userId>` (colon-delimited room;
+   distinct from the dot-delimited NATS subject). One room per user fans all of a
+   user's concurrent conversation runs to all their tabs.
+3. **Catch-up** on connect: reads the Redis snapshot for every conversation the
+   user has active (`activeRunId` not null) and emits a `full_state` message to
+   the connecting socket only.
+4. **Live fan-out**: subscribes to `conversations.*` (via
+   `subscribeConversations`) and emits an `update` message to
+   `conversations:<userId>` for each event.
+
+Client contract — one event name `conversation`, payload discriminated by `type`:
+
+| `type` | when | fields |
+| --- | --- | --- |
+| `full_state` | on connect | `conversations: HarnessSnapshot[]` (all active runs) |
+| `update` | per live event | `conversationId`, `runId`, `stepId?`, `event` |
+
+`conversationId` identifies which conversation an update belongs to; `stepId`
+identifies the individual step. Shape is intentionally coarse for now — to be
+refined with the UI (future updates should carry only the running conversation's
+state, not every conversation's).
+
+## End-to-end test — `demo.ts`
+
+`demo.ts` exercises the whole pipeline without the frontend: it boots redis, db,
+auth, NATS, the harness worker, and the socket.io server in one process, then
+connects a socket.io **client** carrying a `DEMO_COOKIE` (paste a real session
+cookie). It resolves the session's userId from that cookie, enqueues a run owned
+by that user, and prints the `full_state` + `update` messages the client
+receives until a terminal status. Run with `bun run src/harness/demo.ts`.
+
 ## Threads / connections
 
 `server.ts` runs the same file on the main thread and a spawned worker thread;
@@ -123,13 +177,15 @@ share one connection (NATS still delivers to self).
 
 | File | Change |
 | --- | --- |
-| `harness/notifications.ts` | **new** — contract, publish, subscribe, bridge |
+| `harness/notifications.ts` | **new** — contract, publish, subscribe |
 | `harness/notifications.spec.ts` | **new** — envelope parser tests |
+| `harness/socketGateway.ts` | **new** — socket.io on Bun engine; auth, rooms, catch-up, fan-out |
 | `harness/callbacks.ts` | publish instead of `job.updateProgress`; carry `userId` |
 | `harness/index.ts` | resolve owner userId; publish terminals; `finalizeSnapshot` |
 | `harness/internal/redisService.ts` | running vs finalize TTL; `finalizeSnapshot` |
 | `harness/internal/harnessService.ts` | `getOwnerUserId()` |
-| `harness/queue.ts` | drop dead QueueEvents progress bridge |
+| `harness/queue.ts` | drop dead QueueEvents progress bridge + unused emitter |
 | `harness/worker.ts` | `await initializePubSub()` on worker init |
-| `main.ts` | start the conversation bridge |
-| `worker.ts` / `harness/demo.ts` | await async worker init; demo resolves owner |
+| `main.ts` | share Bun.serve between socket.io (`/_/admin/ai/socket.io/`) and Hono |
+| `worker.ts` | await async worker init |
+| `harness/demo.ts` | end-to-end socket.io client test with a session cookie |

--- a/apps/ai-gateway/src/harness/notification-implementation.md
+++ b/apps/ai-gateway/src/harness/notification-implementation.md
@@ -1,0 +1,135 @@
+# Harness Notifications — Architecture Notes
+
+How harness run progress reaches clients after the move off BullMQ job progress
+onto NATS pub/sub. Covers only the backend wiring in `apps/ai-gateway`.
+
+## Why
+
+BullMQ `job.updateProgress` → `QueueEvents("progress")` → local `EventEmitter`
+did not survive reconnects and scaled poorly (single QueueEvents connection per
+process, no cross-instance fan-out). A user can also run **multiple** harness
+sessions at once, so updates are keyed per **conversation owner**, not per job.
+
+BullMQ still owns **triggering** runs (persistent, retry-safe). Only the
+**progress stream** moved to NATS.
+
+## Subject scheme
+
+```
+conversations.<userId>      ← publish target (one per conversation owner)
+conversations.*             ← gateway subscribes to the wildcard
+```
+
+One subject per owner is enough to fan every one of a user's concurrent sessions
+out to their sockets. `conversationId` rides inside the payload so a future
+socket.io layer can route to a room per conversation while subscribing per user.
+
+## Message contract — `notifications.ts`
+
+Messages are a zod **discriminated union** on `type` (`z.discriminatedUnion`),
+so new kinds stay type-safe and parseable. Today there is one variant:
+
+```ts
+{
+  type: "harness_event",            // discriminant (ConversationMsgType.HARNESS_EVENT)
+  userId, conversationId, runId,    // top-level routing/metadata
+  timestamp,
+  event: HarnessStreamEvent         // the original progress payload, unchanged
+}
+```
+
+- `conversationMessageSchema` validates the **envelope** strictly.
+- `event` is carried as the internally-produced, already-TS-typed
+  `HarnessStreamEvent`; it is guarded shallowly (`z.custom` — must be an object
+  with a string `conversationId`) rather than re-validated field-by-field. The
+  nested `HarnessNodePayload` union is **not** duplicated in zod.
+- Malformed / non-JSON messages on the wildcard are dropped with a warn, never
+  thrown.
+
+Exports:
+
+| Symbol | Role |
+| --- | --- |
+| `conversationSubject(userId)` | builds `conversations.<userId>` |
+| `CONVERSATIONS_WILDCARD` | `conversations.*` |
+| `publishHarnessEvent(userId, event)` | wrap event in envelope, publish |
+| `subscribeConversations(handler)` | validated wildcard subscription → async unsubscribe |
+| `startConversationEventBridge()` | subscribe + re-emit into the in-process bus |
+
+## Transport
+
+NATS client is the existing one from `@fluxify/server` (re-exported through
+`db/redis.ts`): `publishMessage`, `subscribeToChannel`, `initializePubSub`.
+Nothing new was added to the server package.
+
+## Producer side (worker thread)
+
+```
+BullMQ job → FluxifyHarness.executeGraph
+  └─ getOwnerUserId() once per run  (conversations.userId, FK → system_users)
+  └─ HarnessCallbacks.emit(event)   per node lifecycle event
+  └─ emitTerminal(event)            on completed / failed / awaiting_hitl
+        each: redisService.appendEvent(event)         (redis snapshot KV)
+              publishHarnessEvent(userId, event)       (NATS)
+```
+
+- Owner `userId` is resolved **once** in `executeGraph` and threaded into
+  `HarnessCallbacks` and the terminal emitters. If a conversation has no owner
+  (e.g. the local demo with an empty user table) the publish is **skipped** —
+  there is no subject to publish to.
+- `initializeHarnessWorker` `await`s `initializePubSub()` (idempotent) so the
+  worker's NATS connection is live before any job runs. In the real app it is
+  already connected at `server.ts` startup; this is a defensive re-init.
+- Publish is fire-and-forget off the callbacks' serialized emit chain — the
+  graph is never gated on NATS or Redis.
+
+## Consumer side (main thread)
+
+`runMain` calls `startConversationEventBridge()`, which subscribes to
+`conversations.*`, validates, and re-emits `message.event` into
+`harnessEventEmitter` keyed by `conversationId`. That in-process bus is what SSE
+reads today and what socket.io rooms will read next (room per `userId`, targeted
+by `conversationId`).
+
+The old `QueueEvents("progress")` bridge in `queue.ts` was removed; the emitter
+is now fed exclusively from NATS. `harnessQueue` (job add/trigger) is unchanged.
+
+## Redis whole-run-state KV — `redisService.ts`
+
+Key `harness:run:<runId>:snapshot` holds the run's live state (status, current
+node/level, bounded event log). Written on **every** event via `appendEvent`.
+
+TTL lifecycle:
+
+| Phase | TTL |
+| --- | --- |
+| running | `RUNNING_TTL` = 6h (safety net; only leaks on a hard worker crash, self-heals) |
+| terminal (completed / failed / HITL) | `finalizeSnapshot()` → `FINALIZE_TTL` = 60s |
+
+`finalizeSnapshot` is called from both `finalizeRun` (completed + HITL) and
+`failRun` (failed) **after** the terminal event is appended, so the key
+auto-evicts ~60s after the run ends instead of being deleted instantly — late
+subscribers still get a brief window to read the final state.
+
+## Threads / connections
+
+`server.ts` runs the same file on the main thread and a spawned worker thread;
+each thread initializes its **own** NATS connection via `initializePubSub()`.
+The worker thread publishes, the main thread subscribes, and the NATS broker
+routes between them. In the single-process `demo.ts`, publish and subscribe
+share one connection (NATS still delivers to self).
+
+## Files touched
+
+| File | Change |
+| --- | --- |
+| `harness/notifications.ts` | **new** — contract, publish, subscribe, bridge |
+| `harness/notifications.spec.ts` | **new** — envelope parser tests |
+| `harness/callbacks.ts` | publish instead of `job.updateProgress`; carry `userId` |
+| `harness/index.ts` | resolve owner userId; publish terminals; `finalizeSnapshot` |
+| `harness/internal/redisService.ts` | running vs finalize TTL; `finalizeSnapshot` |
+| `harness/internal/harnessService.ts` | `getOwnerUserId()` |
+| `harness/queue.ts` | drop dead QueueEvents progress bridge |
+| `harness/worker.ts` | `await initializePubSub()` on worker init |
+| `main.ts` | start the conversation bridge |
+| `worker.ts` / `harness/demo.ts` | await async worker init; demo resolves owner |

--- a/apps/ai-gateway/src/harness/notifications.spec.ts
+++ b/apps/ai-gateway/src/harness/notifications.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+import {
+	ConversationMsgType,
+	conversationMessageSchema,
+	conversationSubject,
+} from "./notifications";
+import type { HarnessStreamEvent } from "./streamTypes";
+import { AgentNode } from "./types";
+
+const event: HarnessStreamEvent = {
+	conversationId: "conv-1",
+	runId: "run-1",
+	level: "harness",
+	phase: "node_start",
+	node: AgentNode.ROUTER,
+	status: "Running router",
+	runStatus: "routing",
+	timestamp: 123,
+};
+
+const message = {
+	type: ConversationMsgType.HARNESS_EVENT,
+	userId: "user-1",
+	conversationId: event.conversationId,
+	runId: event.runId,
+	timestamp: event.timestamp,
+	event,
+};
+
+describe("conversation pub/sub contract", () => {
+	it("builds a per-user subject", () => {
+		expect(conversationSubject("user-1")).toBe("conversations.user-1");
+	});
+
+	it("accepts a well-formed harness event message", () => {
+		expect(conversationMessageSchema.safeParse(message).success).toBe(true);
+	});
+
+	it("rejects an unknown message type", () => {
+		const parsed = conversationMessageSchema.safeParse({ ...message, type: "nope" });
+		expect(parsed.success).toBe(false);
+	});
+
+	it("rejects a foreign event payload", () => {
+		const parsed = conversationMessageSchema.safeParse({ ...message, event: {} });
+		expect(parsed.success).toBe(false);
+	});
+});

--- a/apps/ai-gateway/src/harness/notifications.ts
+++ b/apps/ai-gateway/src/harness/notifications.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 import { logger } from "@fluxify/common";
 import { publishMessage, subscribeToChannel } from "@fluxify/server";
-import { harnessEventEmitter } from "./queue";
 import type { HarnessStreamEvent } from "./streamTypes";
 
 /* ============================================================================
@@ -104,21 +103,4 @@ export async function subscribeConversations(
 		}
 		handler(parsed.data);
 	});
-}
-
-/**
- * Bridges `conversations.*` into the in-process event bus so local consumers
- * (SSE today, socket.io rooms next) can read live updates without touching
- * NATS directly. Re-emits harness events keyed by conversationId.
- */
-export async function startConversationEventBridge(): Promise<
-	() => Promise<void>
-> {
-	const unsubscribe = await subscribeConversations((message) => {
-		if (message.type === ConversationMsgType.HARNESS_EVENT) {
-			harnessEventEmitter.emit(message.conversationId, message.event);
-		}
-	});
-	logger.info("Subscribed to conversations.*", "Conversations");
-	return unsubscribe;
 }

--- a/apps/ai-gateway/src/harness/notifications.ts
+++ b/apps/ai-gateway/src/harness/notifications.ts
@@ -1,0 +1,124 @@
+import { z } from "zod";
+import { logger } from "@fluxify/common";
+import { publishMessage, subscribeToChannel } from "@fluxify/server";
+import { harnessEventEmitter } from "./queue";
+import type { HarnessStreamEvent } from "./streamTypes";
+
+/* ============================================================================
+ * CONVERSATION PUB/SUB CONTRACT (NATS)
+ * ----------------------------------------------------------------------------
+ * Harness progress is published to `conversations.<userId>` — one subject per
+ * conversation owner, since a user may run several harness sessions at once and
+ * a single subscription per user is enough to fan updates out to their sockets.
+ *
+ * A gateway subscribes to the wildcard `conversations.*` and (future) routes
+ * each message to a socket.io room keyed by userId, using `conversationId` in
+ * the payload to target the right conversation. Messages are a discriminated
+ * union on `type` so new message kinds stay type-safe and easy to parse.
+ * ========================================================================== */
+
+export const CONVERSATIONS_SUBJECT_PREFIX = "conversations";
+export const CONVERSATIONS_WILDCARD = `${CONVERSATIONS_SUBJECT_PREFIX}.*`;
+
+/** Subject carrying a single conversation-owner's live updates. */
+export function conversationSubject(userId: string): string {
+	return `${CONVERSATIONS_SUBJECT_PREFIX}.${userId}`;
+}
+
+/** Discriminant for the conversation message union. */
+export const ConversationMsgType = {
+	HARNESS_EVENT: "harness_event",
+} as const;
+
+/** The harness stream event is produced internally and already TS-typed, so it
+ *  is carried through rather than re-validated field-by-field; the guard only
+ *  rejects clearly-foreign payloads that land on the wildcard subject. */
+const harnessStreamEventSchema = z.custom<HarnessStreamEvent>(
+	(v) =>
+		typeof v === "object" &&
+		v !== null &&
+		typeof (v as { conversationId?: unknown }).conversationId === "string",
+);
+
+const harnessEventMessageSchema = z.object({
+	type: z.literal(ConversationMsgType.HARNESS_EVENT),
+	userId: z.string(),
+	conversationId: z.string(),
+	runId: z.string(),
+	timestamp: z.number(),
+	event: harnessStreamEventSchema,
+});
+
+/** All message shapes carried on the conversation subject. Extend the union as
+ *  new kinds are added — the `type` discriminant keeps consumers type-safe. */
+export const conversationMessageSchema = z.discriminatedUnion("type", [
+	harnessEventMessageSchema,
+]);
+
+export type ConversationMessage = z.infer<typeof conversationMessageSchema>;
+export type HarnessEventMessage = z.infer<typeof harnessEventMessageSchema>;
+
+/** Publishes a harness stream event to its owner's conversation subject. */
+export function publishHarnessEvent(
+	userId: string,
+	event: HarnessStreamEvent,
+): void {
+	const message: HarnessEventMessage = {
+		type: ConversationMsgType.HARNESS_EVENT,
+		userId,
+		conversationId: event.conversationId,
+		runId: event.runId,
+		timestamp: event.timestamp,
+		event,
+	};
+	try {
+		publishMessage(conversationSubject(userId), message);
+	} catch (error) {
+		logger.error("[Conversations] Failed to publish harness event", {
+			userId,
+			runId: event.runId,
+			error,
+		});
+	}
+}
+
+/** Subscribes to every conversation owner's updates (`conversations.*`),
+ *  validating each message before handing it off. Returns an async unsubscribe. */
+export async function subscribeConversations(
+	handler: (message: ConversationMessage) => void,
+): Promise<() => Promise<void>> {
+	return subscribeToChannel(CONVERSATIONS_WILDCARD, (raw) => {
+		let json: unknown;
+		try {
+			json = JSON.parse(raw);
+		} catch (error) {
+			logger.warn("[Conversations] Dropped non-JSON message", { error });
+			return;
+		}
+		const parsed = conversationMessageSchema.safeParse(json);
+		if (!parsed.success) {
+			logger.warn("[Conversations] Dropped malformed message", {
+				error: parsed.error.message,
+			});
+			return;
+		}
+		handler(parsed.data);
+	});
+}
+
+/**
+ * Bridges `conversations.*` into the in-process event bus so local consumers
+ * (SSE today, socket.io rooms next) can read live updates without touching
+ * NATS directly. Re-emits harness events keyed by conversationId.
+ */
+export async function startConversationEventBridge(): Promise<
+	() => Promise<void>
+> {
+	const unsubscribe = await subscribeConversations((message) => {
+		if (message.type === ConversationMsgType.HARNESS_EVENT) {
+			harnessEventEmitter.emit(message.conversationId, message.event);
+		}
+	});
+	logger.info("Subscribed to conversations.*", "Conversations");
+	return unsubscribe;
+}

--- a/apps/ai-gateway/src/harness/queue.ts
+++ b/apps/ai-gateway/src/harness/queue.ts
@@ -1,5 +1,4 @@
 import { Queue } from "bullmq";
-import { EventEmitter } from "events";
 import { logger } from "@fluxify/common";
 import { REDIS_HOST, REDIS_PASS, REDIS_PORT, REDIS_USER } from "../lib/env";
 import type { HitlPlanAction } from "./internal/harnessService";
@@ -42,10 +41,6 @@ function connection() {
 }
 
 export let harnessQueue: Queue<HarnessJobData> = null!;
-/** In-process fan-out for live subscribers (SSE today, socket.io next), keyed by
- *  conversationId. Fed from the NATS `conversations.*` subscriber, not BullMQ —
- *  see notifications.startConversationEventBridge. */
-export let harnessEventEmitter: EventEmitter = null!;
 
 let initialized = false;
 
@@ -55,9 +50,6 @@ export function initializeHarnessQueue() {
 	harnessQueue = new Queue<HarnessJobData>(HARNESS_QUEUE_NAME, {
 		connection: connection(),
 	});
-	harnessEventEmitter = new EventEmitter();
-	// Allow many concurrent subscribers per process.
-	harnessEventEmitter.setMaxListeners(0);
 
 	initialized = true;
 	logger.info("Initialized", "HarnessQueue");

--- a/apps/ai-gateway/src/harness/queue.ts
+++ b/apps/ai-gateway/src/harness/queue.ts
@@ -1,9 +1,8 @@
-import { Queue, QueueEvents } from "bullmq";
+import { Queue } from "bullmq";
 import { EventEmitter } from "events";
 import { logger } from "@fluxify/common";
 import { REDIS_HOST, REDIS_PASS, REDIS_PORT, REDIS_USER } from "../lib/env";
 import type { HitlPlanAction } from "./internal/harnessService";
-import type { HarnessStreamEvent } from "./streamTypes";
 
 export const HARNESS_QUEUE_NAME = "AGENT_HARNESS_QUEUE";
 export const HARNESS_START_JOB = "HARNESS_START_JOB";
@@ -43,9 +42,9 @@ function connection() {
 }
 
 export let harnessQueue: Queue<HarnessJobData> = null!;
-export let harnessQueueEvents: QueueEvents = null!;
-/** Local fan-out for SSE streams, keyed by conversationId. BullMQ QueueEvents is
- *  a single connection, so we re-emit progress locally for multiple clients. */
+/** In-process fan-out for live subscribers (SSE today, socket.io next), keyed by
+ *  conversationId. Fed from the NATS `conversations.*` subscriber, not BullMQ —
+ *  see notifications.startConversationEventBridge. */
 export let harnessEventEmitter: EventEmitter = null!;
 
 let initialized = false;
@@ -56,19 +55,9 @@ export function initializeHarnessQueue() {
 	harnessQueue = new Queue<HarnessJobData>(HARNESS_QUEUE_NAME, {
 		connection: connection(),
 	});
-	harnessQueueEvents = new QueueEvents(HARNESS_QUEUE_NAME, {
-		connection: connection(),
-	});
 	harnessEventEmitter = new EventEmitter();
-	// Allow many concurrent SSE subscribers per process.
+	// Allow many concurrent subscribers per process.
 	harnessEventEmitter.setMaxListeners(0);
-
-	harnessQueueEvents.on("progress", (args) => {
-		const event = args.data as unknown as HarnessStreamEvent;
-		if (event?.conversationId) {
-			harnessEventEmitter.emit(event.conversationId, event);
-		}
-	});
 
 	initialized = true;
 	logger.info("Initialized", "HarnessQueue");

--- a/apps/ai-gateway/src/harness/socketGateway.ts
+++ b/apps/ai-gateway/src/harness/socketGateway.ts
@@ -1,0 +1,170 @@
+import { Server as SocketServer } from "socket.io";
+import { Server as Engine } from "@socket.io/bun-engine";
+import { logger } from "@fluxify/common";
+import { and, eq, isNotNull } from "drizzle-orm";
+import { auth, db, agentHarnessConversationsEntity } from "@fluxify/server";
+import { RedisService } from "./internal/redisService";
+import { subscribeConversations, ConversationMsgType } from "./notifications";
+import type { HarnessSnapshot, HarnessStreamEvent } from "./streamTypes";
+
+/* ============================================================================
+ * SOCKET.IO GATEWAY
+ * ----------------------------------------------------------------------------
+ * socket.io runs on the Bun engine (@socket.io/bun-engine) and shares the same
+ * Bun HTTP router as Hono — main.ts routes `/socket.io/*` to the engine and
+ * everything else to `app.fetch` (socket.io has no Hono adapter, so both reuse
+ * one Bun.serve).
+ *
+ * Each connection is authenticated against the better-auth session and joined to
+ * a single per-user room `conversations:<userId>`. One room per user fans every
+ * conversation run they may have triggered concurrently out to all their tabs;
+ * `conversationId` in the message identifies which conversation, `stepId`
+ * identifies the individual step update.
+ *
+ * On connect the client receives a `full_state` catch-up (the whole run state we
+ * cache in Redis). Live `update` messages then stream in per node event. The
+ * shape is intentionally coarse for now — to be refined once the UI is designed.
+ * ========================================================================== */
+
+/** Transport path. Prefixed with `/_/admin/ai` so the reverse proxy (which routes
+ *  `/_/admin/*` to the backend, alongside `/_/admin/api/ai/v1` and `/_/admin/mcp`)
+ *  forwards the socket.io handshake here. Clients must connect with this `path`.
+ *  main.ts routes this prefix to the engine; keep the two in sync via this export. */
+export const SOCKET_PATH = "/_/admin/ai/socket.io/";
+
+/** The single socket.io event name; the `type` discriminant inside the payload
+ *  tells the client whether it's a catch-up snapshot or a live update. */
+export const HARNESS_SOCKET_EVENT = "conversation";
+
+/** Per-user room. Colon-delimited (socket.io convention); independent of the
+ *  dot-delimited NATS subject `conversations.<userId>`. */
+export function conversationRoom(userId: string): string {
+	return `conversations:${userId}`;
+}
+
+/**
+ * Server -> client message, discriminated by `type`:
+ *  - `full_state`: sent once on connect — current run state for every active
+ *    conversation the user owns (read from Redis).
+ *  - `update`: a single live harness event; `conversationId` + `stepId` identify it.
+ */
+export type HarnessSocketMessage =
+	| { type: "full_state"; conversations: HarnessSnapshot[] }
+	| {
+			type: "update";
+			conversationId: string;
+			runId: string;
+			stepId?: string;
+			event: HarnessStreamEvent;
+	  };
+
+/** Events the server emits to clients (keyed by HARNESS_SOCKET_EVENT). */
+interface ServerToClientEvents {
+	conversation: (message: HarnessSocketMessage) => void;
+}
+
+interface HarnessSocketData {
+	userId: string;
+}
+
+/** Pieces main.ts wires into its shared Bun.serve. */
+export interface HarnessSocketHandler {
+	fetch: (req: Request, server: unknown) => Response | Promise<Response>;
+	websocket: ReturnType<Engine["handler"]>["websocket"];
+}
+
+const redisService = new RedisService();
+
+/** Current cached run state for every conversation the user has active (one with
+ *  a live `activeRunId`). Snapshots already evicted from Redis are skipped. */
+async function activeSnapshotsForUser(userId: string): Promise<HarnessSnapshot[]> {
+	const rows = await db
+		.select({ activeRunId: agentHarnessConversationsEntity.activeRunId })
+		.from(agentHarnessConversationsEntity)
+		.where(
+			and(
+				eq(agentHarnessConversationsEntity.userId, userId),
+				isNotNull(agentHarnessConversationsEntity.activeRunId),
+			),
+		);
+
+	const snapshots = await Promise.all(
+		rows.map((r) => redisService.getSnapshot(r.activeRunId!)),
+	);
+	return snapshots.filter((s): s is HarnessSnapshot => s !== null);
+}
+
+/**
+ * Builds the socket.io server on the Bun engine, authenticates connections,
+ * joins the per-user room, sends the Redis catch-up state, and streams live NATS
+ * `conversations.*` events to rooms. Returns the fetch/websocket handlers for
+ * main.ts to mount on the shared Bun.serve.
+ */
+export async function initializeHarnessSocket(): Promise<HarnessSocketHandler> {
+	const engine = new Engine({ path: SOCKET_PATH });
+	const io = new SocketServer<
+		Record<string, never>,
+		ServerToClientEvents,
+		Record<string, never>,
+		HarnessSocketData
+	>({ cors: { origin: true, credentials: true } });
+	// bun-engine's Server is duck-compatible with the engine.io Server socket.io
+	// expects, but not nominally — bind through an unknown cast.
+	io.bind(engine as unknown as Parameters<typeof io.bind>[0]);
+
+	// Auth boundary: only a logged-in user may connect, and only to their own
+	// room. Resolve the better-auth session from the handshake cookies.
+	io.use(async (socket, next) => {
+		try {
+			const headers = new Headers(
+				socket.handshake.headers as Record<string, string>,
+			);
+			const session = await auth.api.getSession({ headers });
+			if (!session?.user?.id) return next(new Error("unauthorized"));
+			socket.data.userId = session.user.id;
+			next();
+		} catch (error) {
+			logger.error("[HarnessSocket] Auth failed", { error });
+			next(new Error("unauthorized"));
+		}
+	});
+
+	io.on("connection", async (socket) => {
+		const userId = socket.data.userId;
+		await socket.join(conversationRoom(userId));
+		logger.info("[HarnessSocket] Client connected", {
+			userId,
+			socketId: socket.id,
+		});
+
+		// Catch-up: current run state for all the user's active conversations. Sent
+		// only to the connecting socket so other tabs aren't re-flooded.
+		try {
+			const conversations = await activeSnapshotsForUser(userId);
+			const message: HarnessSocketMessage = { type: "full_state", conversations };
+			socket.emit(HARNESS_SOCKET_EVENT, message);
+		} catch (error) {
+			logger.error("[HarnessSocket] Failed to send full state", { userId, error });
+		}
+	});
+
+	// Live fan-out: every NATS conversation event to its owner's room.
+	await subscribeConversations((incoming) => {
+		if (incoming.type !== ConversationMsgType.HARNESS_EVENT) return;
+		const message: HarnessSocketMessage = {
+			type: "update",
+			conversationId: incoming.conversationId,
+			runId: incoming.runId,
+			stepId: incoming.event.stepId,
+			event: incoming.event,
+		};
+		io.to(conversationRoom(incoming.userId)).emit(HARNESS_SOCKET_EVENT, message);
+	});
+
+	const handler = engine.handler();
+	logger.info(`Initialized on ${SOCKET_PATH}`, "HarnessSocket");
+	return {
+		fetch: handler.fetch as HarnessSocketHandler["fetch"],
+		websocket: handler.websocket,
+	};
+}

--- a/apps/ai-gateway/src/harness/streamTypes.ts
+++ b/apps/ai-gateway/src/harness/streamTypes.ts
@@ -61,7 +61,7 @@ export type HarnessNodePayload =
 			data: { tasksByLevel: HarnessTaskView[][]; activeLevel: number };
 	  }
 	| {
-			node: AgentNode.BUILDER;
+			node: AgentNode.BLOCK_BUILDER;
 			data: { task: HarnessTaskView; result?: SubAgentResult };
 	  }
 	| {
@@ -106,7 +106,7 @@ export interface HarnessSnapshot {
 
 /** Sub-agent nodes are dispatched by the orchestrator with an `activeTask`. */
 const SUB_AGENT_NODES: ReadonlySet<AgentNodeName> = new Set<AgentNodeName>([
-	AgentNode.BUILDER,
+	AgentNode.BLOCK_BUILDER,
 	AgentNode.ROUTE_CONFIG_AGENT,
 ]);
 
@@ -129,7 +129,7 @@ export function runStatusForNode(node: AgentNodeName): HarnessRunStatus {
 		case AgentNode.SUPERVISOR:
 		case AgentNode.SUMMARIZER:
 			return "orchestrating";
-		case AgentNode.BUILDER:
+		case AgentNode.BLOCK_BUILDER:
 		case AgentNode.ROUTE_CONFIG_AGENT:
 			return "executing";
 		case AgentNode.HUMAN_IN_THE_LOOP:

--- a/apps/ai-gateway/src/harness/types.ts
+++ b/apps/ai-gateway/src/harness/types.ts
@@ -10,7 +10,7 @@ export enum AgentNode {
 	PLANNER = "planner",
 	TASK_GENERATOR = "taskGenerator",
 	DISCUSSION = "discussion",
-	BUILDER = "builder",
+	BLOCK_BUILDER = "blockBuilder",
 	ORCHESTRATOR = "orchestrator",
 	HUMAN_IN_THE_LOOP = "humanInTheLoop",
 	ROUTE_CONFIG_AGENT = "routeConfig",

--- a/apps/ai-gateway/src/harness/worker.ts
+++ b/apps/ai-gateway/src/harness/worker.ts
@@ -1,5 +1,6 @@
 import { Worker } from "bullmq";
 import { logger } from "@fluxify/common";
+import { initializePubSub } from "@fluxify/server";
 import { REDIS_HOST, REDIS_PASS, REDIS_PORT, REDIS_USER } from "../lib/env";
 import { HARNESS_QUEUE_NAME, type HarnessJobData } from "./queue";
 import { AgentFactory } from "./models/factory";
@@ -12,8 +13,12 @@ let worker: Worker<HarnessJobData> | null = null;
  * Starts the BullMQ worker that consumes harness jobs and drives a run through
  * the graph. Runs in the gateway worker thread (see worker.ts -> runWorker).
  */
-export function initializeHarnessWorker() {
+export async function initializeHarnessWorker() {
 	if (worker) return worker;
+
+	// The worker publishes progress to NATS (`conversations.<userId>`); ensure the
+	// pub/sub client is connected before any job runs. Idempotent.
+	await initializePubSub();
 
 	worker = new Worker<HarnessJobData>(
 		HARNESS_QUEUE_NAME,

--- a/apps/ai-gateway/src/main.ts
+++ b/apps/ai-gateway/src/main.ts
@@ -6,7 +6,7 @@ import { logger } from "@fluxify/common";
 import { registerRoutes } from "./api/register";
 import { db, errorHandler, initializeAuth, setSession } from "@fluxify/server";
 import { AI_GATEWAY_PORT } from "./lib/env";
-import { startConversationEventBridge } from "./harness/notifications";
+import { initializeHarnessSocket, SOCKET_PATH } from "./harness/socketGateway";
 
 export async function runMain() {
 	const app = new Hono<any>();
@@ -27,14 +27,22 @@ export async function runMain() {
 	registerRoutes(app);
 	initializeAuth(db);
 
-	// Bridge harness progress from NATS (`conversations.*`) into the in-process
-	// event bus for live subscribers (SSE now, socket.io rooms next).
-	await startConversationEventBridge();
+	// socket.io streams harness progress from NATS (`conversations.*`) to per-user
+	// rooms. It has no Hono adapter, so it shares this one Bun.serve router:
+	// the `/_/admin/ai/socket.io/` prefix goes to the engine, everything else to Hono.
+	const socket = await initializeHarnessSocket();
 
 	const server = serve({
-		fetch: app.fetch,
 		port: AI_GATEWAY_PORT,
 		idleTimeout: 240, // 4 minutes, bcz of ai workflow
+		fetch(req, bunServer) {
+			const url = new URL(req.url);
+			if (url.pathname.startsWith(SOCKET_PATH)) {
+				return socket.fetch(req, bunServer);
+			}
+			return app.fetch(req, bunServer);
+		},
+		websocket: socket.websocket,
 	});
 
 	logger.info(

--- a/apps/ai-gateway/src/main.ts
+++ b/apps/ai-gateway/src/main.ts
@@ -6,6 +6,7 @@ import { logger } from "@fluxify/common";
 import { registerRoutes } from "./api/register";
 import { db, errorHandler, initializeAuth, setSession } from "@fluxify/server";
 import { AI_GATEWAY_PORT } from "./lib/env";
+import { startConversationEventBridge } from "./harness/notifications";
 
 export async function runMain() {
 	const app = new Hono<any>();
@@ -25,6 +26,10 @@ export async function runMain() {
 	mapMcpServer(app);
 	registerRoutes(app);
 	initializeAuth(db);
+
+	// Bridge harness progress from NATS (`conversations.*`) into the in-process
+	// event bus for live subscribers (SSE now, socket.io rooms next).
+	await startConversationEventBridge();
 
 	const server = serve({
 		fetch: app.fetch,

--- a/apps/ai-gateway/src/worker.ts
+++ b/apps/ai-gateway/src/worker.ts
@@ -10,6 +10,6 @@ export async function runWorker() {
 	await loadAppConfig();
 	await loadIntegrations();
 	initializeAIWorkflow();
-	initializeHarnessWorker();
+	await initializeHarnessWorker();
 	logger.info("Worker process started successfully.", "Worker");
 }

--- a/bun.lock
+++ b/bun.lock
@@ -50,16 +50,19 @@
         "@langchain/openrouter": "^0.4.5",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@orama/plugin-data-persistence": "^3.1.18",
+        "@socket.io/bun-engine": "^0.1.1",
         "ai": "^7.0.0",
         "bullmq": "^5.79.1",
         "drizzle-orm": "0.44.7",
         "hono": "^4.12.27",
         "hono-openapi": "^1.3.0",
+        "socket.io": "^4.8.3",
         "zod": "^4.4.3",
         "zod-to-json-schema": "^3.25.2",
       },
       "devDependencies": {
         "@types/bun": "latest",
+        "socket.io-client": "^4.8.3",
       },
       "peerDependencies": {
         "typescript": "^6.0.3",
@@ -1138,6 +1141,10 @@
 
     "@so-ric/colorspace": ["@so-ric/colorspace@1.1.6", "", { "dependencies": { "color": "^5.0.2", "text-hex": "1.0.x" } }, "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw=="],
 
+    "@socket.io/bun-engine": ["@socket.io/bun-engine@0.1.1", "", { "peerDependencies": { "typescript": "*" } }, "sha512-ra6XO9AeRZUDeUNjZFtN7hm9t/uwAckUmcoT8g+xpTbua7fVsOQIV5+1i30dbDX39NxnVLJ8T3MnYn2svAgbjg=="],
+
+    "@socket.io/component-emitter": ["@socket.io/component-emitter@3.1.2", "", {}, "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="],
+
     "@spectrum-icons/ui": ["@spectrum-icons/ui@3.7.1", "", { "dependencies": { "@adobe/react-spectrum-ui": "1.2.1", "@babel/runtime": "^7.24.4", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "@adobe/react-spectrum": "^3.47.0", "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-veQymocUYo5OciXQajSailOdbWe+k6+2ehfF8D4d0V923D4xOUadtT253xXZ5vEQjPat6Kyp2WDKeQNjd7kL1w=="],
 
     "@spectrum-icons/workflow": ["@spectrum-icons/workflow@4.3.1", "", { "dependencies": { "@adobe/react-spectrum-workflow": "2.3.5", "@swc/helpers": "^0.5.0" }, "peerDependencies": { "@adobe/react-spectrum": "^3.47.0", "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-kDF+/EbFVyLGytotqqdYt4uSij4j/PQmDQO5km/C6DyzKjyuic3FnSBFinR+mA6oFv1OjMcLvrrDBqK3wbqRlA=="],
@@ -1238,6 +1245,8 @@
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
+    "@types/cors": ["@types/cors@2.8.19", "", { "dependencies": { "@types/node": "*" } }, "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg=="],
+
     "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
 
     "@types/d3-drag": ["@types/d3-drag@3.0.7", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ=="],
@@ -1311,6 +1320,8 @@
     "@types/webidl-conversions": ["@types/webidl-conversions@7.0.3", "", {}, "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="],
 
     "@types/whatwg-url": ["@types/whatwg-url@13.0.0", "", { "dependencies": { "@types/webidl-conversions": "*" } }, "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.65.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.65.0", "@typescript-eslint/type-utils": "8.65.0", "@typescript-eslint/utils": "8.65.0", "@typescript-eslint/visitor-keys": "8.65.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.65.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA=="],
 
@@ -1444,7 +1455,7 @@
 
     "@xyflow/system": ["@xyflow/system@0.0.79", "", { "dependencies": { "@types/d3-drag": "^3.0.7", "@types/d3-interpolate": "^3.0.4", "@types/d3-selection": "^3.0.10", "@types/d3-transition": "^3.0.8", "@types/d3-zoom": "^3.0.8", "d3-drag": "^3.0.0", "d3-interpolate": "^3.0.1", "d3-selection": "^3.0.0", "d3-zoom": "^3.0.0" } }, "sha512-czLyOh91NF0hIzbNzwi8I6GlqG23BHh2435OddfI6uiaLH3xdrdygO93gqgH1Bv9mhy8XPFQJOBn1FTq4LvEWA=="],
 
-    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+    "accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
 
     "acorn": ["acorn@8.17.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg=="],
 
@@ -1529,6 +1540,8 @@
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "base64id": ["base64id@2.0.0", "", {}, "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.11.1", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-HYXq73DDpCtNzOmrFsm9eSwCvWCql0RzqjpDzXN9EadiLJ4DNat0nsZ/Bzmy+Ud12mb4/zKDY0cQ805ZzN+i0A=="],
 
@@ -1767,6 +1780,12 @@
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
+
+    "engine.io": ["engine.io@6.6.9", "", { "dependencies": { "@types/cors": "^2.8.12", "@types/node": ">=10.0.0", "@types/ws": "^8.5.12", "accepts": "~1.3.4", "base64id": "2.0.0", "cookie": "~0.7.2", "cors": "~2.8.5", "debug": "~4.4.1", "engine.io-parser": "~5.2.1", "ws": "~8.21.0" } }, "sha512-clKkw4C7nJ22mGgoVcCg6V/W/TxdNyIOTr89k2ONZu81qqkddPFDF0LXcbAwhzPD8DjkiRCjzuiO6Y+fkpD4vg=="],
+
+    "engine.io-client": ["engine.io-client@6.6.6", "", { "dependencies": { "@socket.io/component-emitter": "~3.1.0", "debug": "~4.4.1", "engine.io-parser": "~5.2.1", "ws": "~8.21.0", "xmlhttprequest-ssl": "~2.1.1" } }, "sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q=="],
+
+    "engine.io-parser": ["engine.io-parser@5.2.3", "", {}, "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.24.3", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ=="],
 
@@ -2472,7 +2491,7 @@
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
-    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+    "negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
 
     "neverpanic": ["neverpanic@0.0.8", "", {}, "sha512-vVdkelrLxaow/fdWDumzNBO+jwm6X8bxeLJc34THtpj70u0C5QBkcV6CRCu2X726km7XD45N0A3QtYCla4RvKw=="],
 
@@ -2844,6 +2863,14 @@
 
     "snappy": ["snappy@7.3.3", "", { "optionalDependencies": { "@napi-rs/snappy-android-arm-eabi": "7.3.3", "@napi-rs/snappy-android-arm64": "7.3.3", "@napi-rs/snappy-darwin-arm64": "7.3.3", "@napi-rs/snappy-darwin-x64": "7.3.3", "@napi-rs/snappy-freebsd-x64": "7.3.3", "@napi-rs/snappy-linux-arm-gnueabihf": "7.3.3", "@napi-rs/snappy-linux-arm64-gnu": "7.3.3", "@napi-rs/snappy-linux-arm64-musl": "7.3.3", "@napi-rs/snappy-linux-ppc64-gnu": "7.3.3", "@napi-rs/snappy-linux-riscv64-gnu": "7.3.3", "@napi-rs/snappy-linux-s390x-gnu": "7.3.3", "@napi-rs/snappy-linux-x64-gnu": "7.3.3", "@napi-rs/snappy-linux-x64-musl": "7.3.3", "@napi-rs/snappy-openharmony-arm64": "7.3.3", "@napi-rs/snappy-wasm32-wasi": "7.3.3", "@napi-rs/snappy-win32-arm64-msvc": "7.3.3", "@napi-rs/snappy-win32-ia32-msvc": "7.3.3", "@napi-rs/snappy-win32-x64-msvc": "7.3.3" } }, "sha512-UDJVCunvgblRpfTOjo/uT7pQzfrTsSICJ4yVS4aq7SsGBaUSpJwaVP15nF//jqinSLpN7boe/BqbUmtWMTQ5MQ=="],
 
+    "socket.io": ["socket.io@4.8.3", "", { "dependencies": { "accepts": "~1.3.4", "base64id": "~2.0.0", "cors": "~2.8.5", "debug": "~4.4.1", "engine.io": "~6.6.0", "socket.io-adapter": "~2.5.2", "socket.io-parser": "~4.2.4" } }, "sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A=="],
+
+    "socket.io-adapter": ["socket.io-adapter@2.5.8", "", { "dependencies": { "debug": "~4.4.1", "ws": "~8.21.0" } }, "sha512-6Oy52pbg+kvdCVvjcN+FnY7BvxZ7cIHNScbvztT/It5d0vbwoJoVZmF2gjJmnV0/4WlXRfG15zc45ySk9Ah8bw=="],
+
+    "socket.io-client": ["socket.io-client@4.8.3", "", { "dependencies": { "@socket.io/component-emitter": "~3.1.0", "debug": "~4.4.1", "engine.io-client": "~6.6.1", "socket.io-parser": "~4.2.4" } }, "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g=="],
+
+    "socket.io-parser": ["socket.io-parser@4.2.7", "", { "dependencies": { "@socket.io/component-emitter": "~3.1.0", "debug": "~4.4.1" } }, "sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg=="],
+
     "sonic-boom": ["sonic-boom@4.2.1", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q=="],
 
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
@@ -3162,6 +3189,8 @@
 
     "xml-naming": ["xml-naming@0.3.0", "", {}, "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ=="],
 
+    "xmlhttprequest-ssl": ["xmlhttprequest-ssl@2.1.2", "", {}, "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ=="],
+
     "xpath": ["xpath@0.0.34", "", {}, "sha512-FxF6+rkr1rNSQrhUNYrAFJpRXNzlDoMxeXN5qI84939ylEv3qqPFKa85Oxr6tDaJKqwW6KKyo2v26TSv3k6LeA=="],
 
     "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
@@ -3288,6 +3317,8 @@
 
     "@textlint/linter-formatter/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
+    "@types/cors/@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
+
     "@types/docker-modem/@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
 
     "@types/dockerode/@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
@@ -3299,6 +3330,8 @@
     "@types/pg/@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
 
     "@types/ssh2/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
+
+    "@types/ws/@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.6", "", {}, "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw=="],
 
@@ -3316,6 +3349,8 @@
 
     "@xyflow/react/zustand": ["zustand@4.5.7", "", { "dependencies": { "use-sync-external-store": "^1.2.2" }, "peerDependencies": { "@types/react": ">=16.8", "immer": ">=9.0.6", "react": ">=16.8" }, "optionalPeers": ["@types/react", "immer", "react"] }, "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw=="],
 
+    "accepts/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
     "bcrypt-pbkdf/tweetnacl": ["tweetnacl@0.14.5", "", {}, "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="],
 
     "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
@@ -3329,6 +3364,8 @@
     "color/color-convert": ["color-convert@3.1.3", "", { "dependencies": { "color-name": "^2.0.0" } }, "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg=="],
 
     "color-string/color-name": ["color-name@2.1.1", "", {}, "sha512-p2FdgwVx1a9yWBHP2wI0VgShkDpgN4kZISkxdNipGBJWpa5G6b04OINlVWCyJj0JmfvcPrgqt95E9k8yvaOJFg=="],
+
+    "engine.io/@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
 
     "eslint/ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 
@@ -3345,6 +3382,8 @@
     "eslint-plugin-react/resolve": ["resolve@2.0.0-next.7", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.2", "node-exports-info": "^1.6.0", "object-keys": "^1.1.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ=="],
 
     "eslint-plugin-react/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "express/accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
@@ -3536,6 +3575,8 @@
 
     "@textlint/linter-formatter/js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
+    "@types/cors/@types/node/undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
     "@types/docker-modem/@types/node/undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
     "@types/dockerode/@types/node/undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
@@ -3548,17 +3589,25 @@
 
     "@types/ssh2/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
+    "@types/ws/@types/node/undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.8", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg=="],
 
     "@unrs/resolver-binding-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 
     "@vitejs/plugin-vue/vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
 
+    "accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
     "bun-types/@types/node/undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
     "color/color-convert/color-name": ["color-name@2.1.1", "", {}, "sha512-p2FdgwVx1a9yWBHP2wI0VgShkDpgN4kZISkxdNipGBJWpa5G6b04OINlVWCyJj0JmfvcPrgqt95E9k8yvaOJFg=="],
 
+    "engine.io/@types/node/undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
     "eslint/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "express/accepts/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 


### PR DESCRIPTION
## Why

Harness run progress was pushed through BullMQ `job.updateProgress`, which doesn't survive reconnects and scales poorly (single QueueEvents connection, no cross-instance fan-out). A user can also run multiple harness sessions at once, so updates need to be keyed per conversation **owner**, not per job.

## What

Moves the **progress stream** onto NATS pub/sub and adds a socket.io edge for the web client. BullMQ still **triggers/retries** runs (persistent, retry-safe) — only progress moved.

### Backend pipeline
- **NATS**: harness events publish to `conversations.<userId>` (one subject per owner). Message is a zod discriminated-union envelope carrying `conversationId`, `runId`, `stepId`, and the existing stream event.
- **Redis whole-run-state KV**: snapshot updated on every event; TTL persists during the run and drops to **60s** on any terminal state (completed / failed / HITL) so it auto-evicts.
- **socket.io on the Bun engine**: shares one `Bun.serve` router with Hono (socket.io has no Hono adapter), mounted under the proxy prefix `/_/admin/ai/socket.io/`. It:
  - authenticates each connection against the better-auth session (handshake refused if unauthenticated, before `connect`),
  - joins the per-user room `conversations:<userId>`,
  - sends a `full_state` catch-up from Redis on connect,
  - fans NATS `conversations.*` events to rooms as typed `update` messages (`conversationId` + `stepId` identify each).

### Rename
- Harness sub-agent node `builder` → `blockBuilder` (`AgentNode.BLOCK_BUILDER`) to disambiguate from the router `"builder"` intent. Enum-driven, so the LLM task-generator contract and graph dispatch stay consistent.

### Docs & test
- `harness-client-implementation-guide.md` — full web-client contract (message shapes, node→payload map) and the React-state edge cases (full_state/live races, reconnect replays, 200-event snapshot bound, 60s eviction, idempotent timestamp-guarded reducer).
- `notification-implementation.md` — backend wiring notes.
- `notifications.spec.ts` — envelope parser tests.

## Notes
- `demo.ts` is a gitignored end-to-end tester (socket.io client with a session cookie); not part of this diff.
- Verified: typecheck (all 9 packages), unit tests, and a live end-to-end run over the real socket.io path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
