### PR TITLE
feat(portal): implement end-to-end App Config CRUD, search, sorting, and HeroUI v3 checkbox fixes

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -69,6 +69,17 @@ When creating branches or Pull Requests via the `gh` CLI:
 4. **Only use `createAgent`/tool-bound models when you pass real tools.** `[]` tools + `structuredResponse` gives neither tool use nor structured output.
 5. **Retry corrections must be a `["human", ...]` turn**, never `["system", ...]`, so the retried request still ends on a user role (`apps/server/src/lib/agentRetry.ts`).
 
+### React Aria / HeroUI Table Checkbox `slot="selection"` & PressResponder Errors
+**Issue:**
+1. `Error: A slot prop is required. Valid slot names are "selection"` on `<Checkbox>` inside a `<Table>` component.
+2. `Warning: A PressResponder was rendered without a pressable child` when placing a `<button>` inside `<Table.Column>`.
+**Cause:**
+1. React Aria / HeroUI Table expects selection checkboxes rendered inside `<Table.Header>` or `<Table.Cell>` to explicitly declare `slot="selection"`.
+2. `<Table.Column>` is already rendered as an interactive ColumnHeader by React Aria, so embedding a native `<button>` creates conflicting PressResponders.
+**Fix:**
+1. Pass `slot="selection"` on any `<Checkbox>` rendered inside `<Table.Header>` or `<Table.Cell>` (e.g. `<Checkbox slot="selection" ... />`).
+2. Replace nested `<button>` elements inside `<Table.Column>` with clickable `<div>` or `<span>` elements (e.g. `<div role="button" tabIndex={0} onClick={...}>`).
+
 ---
 
 ## Documentation Writing Rules

--- a/apps/portal/src/components/appConfig/AppConfigTable.tsx
+++ b/apps/portal/src/components/appConfig/AppConfigTable.tsx
@@ -1,0 +1,184 @@
+import {
+	Button,
+	Checkbox,
+	Chip,
+	Table,
+} from "@fluxify/components";
+import {
+	TbArrowDown,
+	TbArrowUp,
+	TbEdit,
+	TbLock,
+	TbLockOpen,
+	TbTrash,
+} from "react-icons/tb";
+import type { ConfigRow, SortBy } from "./types";
+
+export function AppConfigTable({
+	items,
+	selectedIds,
+	onSelectionChange,
+	sortBy,
+	sortOrder,
+	onSort,
+	onEdit,
+	onDelete,
+}: {
+	items: ConfigRow[];
+	selectedIds: Set<number>;
+	onSelectionChange: (keys: Set<number>) => void;
+	sortBy: SortBy;
+	sortOrder: "asc" | "desc";
+	onSort: (column: SortBy) => void;
+	onEdit: (row: ConfigRow) => void;
+	onDelete: (row: ConfigRow) => void;
+}) {
+	return (
+		<Table>
+			<Table.Content
+				aria-label="App Config Table"
+				selectionMode="multiple"
+				selectedKeys={new Set(Array.from(selectedIds).map(String))}
+				onSelectionChange={(keys) => {
+					if (keys === "all") {
+						onSelectionChange(new Set(items.map((item) => item.id)));
+					} else if (keys instanceof Set) {
+						onSelectionChange(new Set(Array.from(keys).map((k) => Number(k))));
+					}
+				}}
+			>
+				<Table.Header>
+					<Table.Column id="select">
+						<Checkbox slot="selection" aria-label="Select all rows">
+							<Checkbox.Content>
+								<Checkbox.Control>
+									<Checkbox.Indicator />
+								</Checkbox.Control>
+							</Checkbox.Content>
+						</Checkbox>
+					</Table.Column>
+					<Table.Column id="keyName" isRowHeader>
+						<div
+							role="button"
+							tabIndex={0}
+							onClick={() => onSort("keyName")}
+							onKeyDown={(e) => e.key === "Enter" && onSort("keyName")}
+							className="flex items-center gap-1 font-medium hover:text-foreground cursor-pointer select-none"
+						>
+							Key Name
+							{sortBy === "keyName" && (
+								sortOrder === "asc" ? <TbArrowUp size={14} /> : <TbArrowDown size={14} />
+							)}
+						</div>
+					</Table.Column>
+					<Table.Column id="dataType">Type</Table.Column>
+					<Table.Column id="isEncrypted">
+						<div
+							role="button"
+							tabIndex={0}
+							onClick={() => onSort("isEncrypted")}
+							onKeyDown={(e) => e.key === "Enter" && onSort("isEncrypted")}
+							className="flex items-center gap-1 font-medium hover:text-foreground cursor-pointer select-none"
+						>
+							Encrypted
+							{sortBy === "isEncrypted" && (
+								sortOrder === "asc" ? <TbArrowUp size={14} /> : <TbArrowDown size={14} />
+							)}
+						</div>
+					</Table.Column>
+					<Table.Column id="encodingType">
+						<div
+							role="button"
+							tabIndex={0}
+							onClick={() => onSort("encodingType")}
+							onKeyDown={(e) => e.key === "Enter" && onSort("encodingType")}
+							className="flex items-center gap-1 font-medium hover:text-foreground cursor-pointer select-none"
+						>
+							Encoding
+							{sortBy === "encodingType" && (
+								sortOrder === "asc" ? <TbArrowUp size={14} /> : <TbArrowDown size={14} />
+							)}
+						</div>
+					</Table.Column>
+					<Table.Column id="updatedAt">
+						<div
+							role="button"
+							tabIndex={0}
+							onClick={() => onSort("updatedAt")}
+							onKeyDown={(e) => e.key === "Enter" && onSort("updatedAt")}
+							className="flex items-center gap-1 font-medium hover:text-foreground cursor-pointer select-none"
+						>
+							Updated At
+							{sortBy === "updatedAt" && (
+								sortOrder === "asc" ? <TbArrowUp size={14} /> : <TbArrowDown size={14} />
+							)}
+						</div>
+					</Table.Column>
+					<Table.Column id="actions" aria-label="Actions">{""}</Table.Column>
+				</Table.Header>
+				<Table.Body items={items}>
+					{(row: ConfigRow) => (
+						<Table.Row id={String(row.id)}>
+							<Table.Cell>
+								<Checkbox slot="selection" aria-label={`Select ${row.keyName}`}>
+									<Checkbox.Content>
+										<Checkbox.Control>
+											<Checkbox.Indicator />
+										</Checkbox.Control>
+									</Checkbox.Content>
+								</Checkbox>
+							</Table.Cell>
+							<Table.Cell>
+								<span className="font-mono text-sm font-semibold">{row.keyName}</span>
+							</Table.Cell>
+							<Table.Cell>
+								<Chip size="sm">{row.dataType}</Chip>
+							</Table.Cell>
+							<Table.Cell>
+								{row.isEncrypted ? (
+									<Chip size="sm" color="success" className="gap-1">
+										<TbLock size={12} /> Yes
+									</Chip>
+								) : (
+									<Chip size="sm" className="gap-1">
+										<TbLockOpen size={12} /> No
+									</Chip>
+								)}
+							</Table.Cell>
+							<Table.Cell>
+								<Chip size="sm" className="uppercase font-mono text-xs">
+									{row.encodingType}
+								</Chip>
+							</Table.Cell>
+							<Table.Cell>
+								<span className="text-xs text-muted">
+									{new Date(row.updatedAt).toLocaleDateString()} {new Date(row.updatedAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+								</span>
+							</Table.Cell>
+							<Table.Cell>
+								<div className="flex justify-end gap-1">
+									<Button
+										isIconOnly
+										variant="ghost"
+										aria-label="Edit config"
+										onPress={() => onEdit(row)}
+									>
+										<TbEdit size={16} />
+									</Button>
+									<Button
+										isIconOnly
+										variant="ghost"
+										aria-label="Delete config"
+										onPress={() => onDelete(row)}
+									>
+										<TbTrash size={16} />
+									</Button>
+								</div>
+							</Table.Cell>
+						</Table.Row>
+					)}
+				</Table.Body>
+			</Table.Content>
+		</Table>
+	);
+}

--- a/apps/portal/src/components/appConfig/CreateConfigModal.tsx
+++ b/apps/portal/src/components/appConfig/CreateConfigModal.tsx
@@ -1,0 +1,166 @@
+import { useState } from "react";
+import {
+	Button,
+	Checkbox,
+	Input,
+	Label,
+	Modal,
+	TextField,
+	toast,
+} from "@fluxify/components";
+import { TbPlus } from "react-icons/tb";
+import { appConfigQuery } from "@/query/appConfigQuery";
+import { showErrorNotification } from "@/lib/errorNotifier";
+
+const ENCODINGS = ["plaintext", "base64", "hex"] as const;
+const DATA_TYPES = ["string", "number", "boolean"] as const;
+
+export function CreateConfigButton({ projectId }: { projectId: string }) {
+	const create = appConfigQuery.create.mutation(projectId);
+	const [open, setOpen] = useState(false);
+	const [keyName, setKeyName] = useState("");
+	const [description, setDescription] = useState("");
+	const [value, setValue] = useState("");
+	const [booleanValue, setBooleanValue] = useState(false);
+	const [dataType, setDataType] = useState<(typeof DATA_TYPES)[number]>("string");
+	const [isEncrypted, setIsEncrypted] = useState(false);
+	const [encoding, setEncoding] = useState<(typeof ENCODINGS)[number]>("plaintext");
+
+	function reset() {
+		setKeyName("");
+		setDescription("");
+		setValue("");
+		setBooleanValue(false);
+		setDataType("string");
+		setIsEncrypted(false);
+		setEncoding("plaintext");
+	}
+
+	function submit(e: React.FormEvent) {
+		e.preventDefault();
+		const finalValue = dataType === "boolean" ? String(booleanValue) : String(value);
+
+		create.mutate(
+			{
+				keyName,
+				description,
+				value: finalValue,
+				isEncrypted,
+				encodingType: encoding,
+				dataType,
+			},
+			{
+				onSuccess: () => {
+					toast.success("Config created");
+					reset();
+					setOpen(false);
+				},
+				onError: (err) => showErrorNotification(err as Error),
+			},
+		);
+	}
+
+	return (
+		<Modal isOpen={open} onOpenChange={setOpen}>
+			<Modal.Trigger>
+				<Button variant="primary">
+					<TbPlus size={16} /> New key
+				</Button>
+			</Modal.Trigger>
+			<Modal.Backdrop>
+				<Modal.Container placement="center" size="sm">
+					<Modal.Dialog>
+						<Modal.Header>
+							<Modal.Heading>Add a config key</Modal.Heading>
+						</Modal.Header>
+						<form onSubmit={submit}>
+							<Modal.Body>
+								<div className="flex flex-col gap-4">
+									<TextField isRequired value={keyName} onChange={setKeyName}>
+										<Label>Key name</Label>
+										<Input placeholder="API_TIMEOUT" />
+									</TextField>
+
+									<div className="flex flex-col gap-1.5">
+										<Label>Data Type</Label>
+										<div className="flex gap-1.5">
+											{DATA_TYPES.map((dt) => (
+												<Button
+													key={dt}
+													type="button"
+													size="sm"
+													variant={dataType === dt ? "primary" : "outline"}
+													onPress={() => setDataType(dt)}
+												>
+													{dt}
+												</Button>
+											))}
+										</div>
+									</div>
+
+									{dataType === "boolean" ? (
+										<Checkbox isSelected={booleanValue} onChange={setBooleanValue}>
+											<Checkbox.Content>
+												<Checkbox.Control>
+													<Checkbox.Indicator />
+												</Checkbox.Control>
+												<Label>Boolean Value: {booleanValue ? "True" : "False"}</Label>
+											</Checkbox.Content>
+										</Checkbox>
+									) : (
+										<TextField isRequired value={value} onChange={setValue}>
+											<Label>Value</Label>
+											<Input
+												type={dataType === "number" ? "number" : "text"}
+												placeholder={dataType === "number" ? "3000" : "Value"}
+											/>
+										</TextField>
+									)}
+
+									<TextField value={description} onChange={setDescription}>
+										<Label>Description</Label>
+										<Input placeholder="What this key controls" />
+									</TextField>
+
+									<div className="flex flex-col gap-1.5">
+										<Label>Encoding</Label>
+										<div className="flex gap-1.5">
+											{ENCODINGS.map((enc) => (
+												<Button
+													key={enc}
+													type="button"
+													size="sm"
+													variant={encoding === enc ? "primary" : "outline"}
+													onPress={() => setEncoding(enc)}
+												>
+													{enc}
+												</Button>
+											))}
+										</div>
+									</div>
+
+									<Checkbox isSelected={isEncrypted} onChange={setIsEncrypted}>
+										<Checkbox.Content>
+											<Checkbox.Control>
+												<Checkbox.Indicator />
+											</Checkbox.Control>
+											<Label>Encrypt this value in storage</Label>
+										</Checkbox.Content>
+									</Checkbox>
+								</div>
+							</Modal.Body>
+							<Modal.Footer>
+								<Button variant="ghost" onPress={() => setOpen(false)}>
+									Cancel
+								</Button>
+								<Button type="submit" variant="primary" isPending={create.isPending}>
+									Add key
+								</Button>
+							</Modal.Footer>
+						</form>
+					</Modal.Dialog>
+				</Modal.Container>
+			</Modal.Backdrop>
+		</Modal>
+	);
+}

--- a/apps/portal/src/components/appConfig/EditConfigModal.tsx
+++ b/apps/portal/src/components/appConfig/EditConfigModal.tsx
@@ -1,0 +1,168 @@
+import { useEffect, useState } from "react";
+import {
+	Button,
+	Checkbox,
+	Input,
+	Label,
+	Modal,
+	Spinner,
+	TextField,
+	toast,
+} from "@fluxify/components";
+import { appConfigQuery } from "@/query/appConfigQuery";
+import { showErrorNotification } from "@/lib/errorNotifier";
+import type { ConfigRow } from "./types";
+
+const ENCODINGS = ["plaintext", "base64", "hex"] as const;
+
+export function EditConfigModal({
+	projectId,
+	config,
+	onClose,
+}: {
+	projectId: string;
+	config: ConfigRow;
+	onClose: () => void;
+}) {
+	const { data: detail, isLoading } = appConfigQuery.getById.useQuery(projectId, config.id);
+	const update = appConfigQuery.update.mutation(projectId, config.id);
+
+	const [keyName, setKeyName] = useState(config.keyName);
+	const [description, setDescription] = useState("");
+	const [value, setValue] = useState("");
+	const [booleanValue, setBooleanValue] = useState(false);
+	const [isEncrypted, setIsEncrypted] = useState(config.isEncrypted);
+	const [encoding, setEncoding] = useState<(typeof ENCODINGS)[number]>(config.encodingType);
+
+	useEffect(() => {
+		if (detail) {
+			setKeyName(detail.keyName);
+			setDescription(detail.description || "");
+			setIsEncrypted(detail.isEncrypted);
+			setEncoding(detail.encodingType);
+			if (detail.dataType === "boolean") {
+				setBooleanValue(detail.value === "true");
+			} else {
+				setValue(String(detail.value ?? ""));
+			}
+		}
+	}, [detail]);
+
+	function submit(e: React.FormEvent) {
+		e.preventDefault();
+		const finalValue = config.dataType === "boolean" ? String(booleanValue) : String(value);
+
+		update.mutate(
+			{
+				keyName,
+				description,
+				value: finalValue,
+				isEncrypted,
+				encodingType: encoding,
+			},
+			{
+				onSuccess: () => {
+					toast.success("Config updated");
+					onClose();
+				},
+				onError: (err) => showErrorNotification(err as Error),
+			},
+		);
+	}
+
+	return (
+		<Modal isOpen onOpenChange={(o) => !o && onClose()}>
+			<Modal.Backdrop>
+				<Modal.Container placement="center" size="sm">
+					<Modal.Dialog>
+						<Modal.Header>
+							<Modal.Heading>Edit config key: {config.keyName}</Modal.Heading>
+						</Modal.Header>
+						{isLoading ? (
+							<div className="flex justify-center py-8">
+								<Spinner />
+							</div>
+						) : (
+							<form onSubmit={submit}>
+								<Modal.Body>
+									<div className="flex flex-col gap-4">
+										<TextField isRequired value={keyName} onChange={setKeyName}>
+											<Label>Key name</Label>
+											<Input />
+										</TextField>
+
+										<div className="flex flex-col gap-1 text-sm">
+											<span className="font-medium text-muted">Data Type</span>
+											<span className="font-mono text-sm font-semibold capitalize">{config.dataType}</span>
+										</div>
+
+										{config.dataType === "boolean" ? (
+											<Checkbox isSelected={booleanValue} onChange={setBooleanValue}>
+												<Checkbox.Content>
+													<Checkbox.Control>
+														<Checkbox.Indicator />
+													</Checkbox.Control>
+													<Label>Boolean Value: {booleanValue ? "True" : "False"}</Label>
+												</Checkbox.Content>
+											</Checkbox>
+										) : (
+											<TextField isRequired value={value} onChange={setValue}>
+												<Label>Value</Label>
+												<Input
+													type={config.dataType === "number" ? "number" : "text"}
+												/>
+											</TextField>
+										)}
+
+										<TextField value={description} onChange={setDescription}>
+											<Label>Description</Label>
+											<Input placeholder="What this key controls" />
+										</TextField>
+
+										<div className="flex flex-col gap-1.5">
+											<Label>Encoding</Label>
+											<div className="flex gap-1.5">
+												{ENCODINGS.map((enc) => (
+													<Button
+														key={enc}
+														type="button"
+														size="sm"
+														variant={encoding === enc ? "primary" : "outline"}
+														onPress={() => setEncoding(enc)}
+													>
+														{enc}
+													</Button>
+												))}
+											</div>
+										</div>
+
+										<Checkbox
+											isSelected={isEncrypted}
+											onChange={setIsEncrypted}
+											isDisabled={config.isEncrypted}
+										>
+											<Checkbox.Content>
+												<Checkbox.Control>
+													<Checkbox.Indicator />
+												</Checkbox.Control>
+												<Label>{config.isEncrypted ? "Encrypted (cannot be decrypted)" : "Encrypt this value in storage"}</Label>
+											</Checkbox.Content>
+										</Checkbox>
+									</div>
+								</Modal.Body>
+								<Modal.Footer>
+									<Button variant="ghost" onPress={onClose}>
+										Cancel
+									</Button>
+									<Button type="submit" variant="primary" isPending={update.isPending}>
+										Save changes
+									</Button>
+								</Modal.Footer>
+							</form>
+						)}
+					</Modal.Dialog>
+				</Modal.Container>
+			</Modal.Backdrop>
+		</Modal>
+	);
+}

--- a/apps/portal/src/components/appConfig/types.ts
+++ b/apps/portal/src/components/appConfig/types.ts
@@ -1,0 +1,11 @@
+export type ConfigRow = {
+	id: number;
+	keyName: string;
+	isEncrypted: boolean;
+	encodingType: "plaintext" | "base64" | "hex";
+	dataType: "string" | "number" | "boolean";
+	createdAt: string;
+	updatedAt: string;
+};
+
+export type SortBy = "id" | "keyName" | "createdAt" | "updatedAt" | "isEncrypted" | "encodingType";

--- a/apps/portal/src/components/integrations/IntegrationForm.tsx
+++ b/apps/portal/src/components/integrations/IntegrationForm.tsx
@@ -17,7 +17,6 @@ import { ObservabilityForm } from "./connectors/ObservabilityForm";
 
 type IntegrationData = { name: string; group: string; variant: string; config: Record<string, unknown> };
 
-// DB/KV placeholder sets (mirrors each web form verbatim).
 const CRED_PLACEHOLDERS: Record<string, { ph: Record<string, string>; ssl?: boolean; db?: boolean }> = {
 	PostgreSQL: { ph: { name: "My Postgres Database", host: "postgres.company.com", port: "5432", username: "postgres", password: "secret", database: "ecommerce", url: "postgres://user:pass@host:port/dbname?ssl=disable" }, ssl: true, db: true },
 	MySQL: { ph: { name: "My MySQL Database", host: "mysql.company.com", port: "3306", username: "root", password: "secret", database: "ecommerce", url: "mysql://user:pass@host:port/dbname?ssl=disable" }, db: true },
@@ -46,6 +45,7 @@ export function IntegrationForm({
 	lockGroupVariant,
 	showDelete,
 	deletePending,
+	hideActions,
 	onSaved,
 	onDelete,
 }: {
@@ -55,9 +55,8 @@ export function IntegrationForm({
 	lockGroupVariant?: boolean;
 	showDelete?: boolean;
 	deletePending?: boolean;
+	hideActions?: boolean;
 	onSaved?: () => void;
-	// Delete is owned by the parent list (stays mounted so the request + refetch
-	// survive this form unmounting when the accordion collapses).
 	onDelete?: () => void;
 }) {
 	const loaded = integrationsQuery.getById.useQuery(projectId, id ?? "");
@@ -138,42 +137,45 @@ export function IntegrationForm({
 
 	return (
 		<div className="flex flex-col gap-4">
-			{/* Choose a Connector (group) */}
-			<div className="flex flex-col gap-1">
-				<label className="text-sm font-medium text-foreground">Choose a Connector</label>
-				<span className="text-xs text-muted">Choose from a range of connectors to get started</span>
-				<select
-					disabled={lockGroupVariant}
-					value={group}
-					onChange={(e) => onGroup(e.target.value)}
-					className="rounded-md border border-border bg-background-secondary px-3 py-2 text-sm text-foreground outline-none disabled:opacity-60"
-				>
-					<option value="">Select…</option>
-					{getIntegrationsGroups().map((g) => (
-						<option key={g} value={g}>
-							{humanReadableConnectorNames[g as keyof typeof humanReadableConnectorNames]}
-						</option>
-					))}
-				</select>
-			</div>
+			{/* Show Connector & Variant selectors ONLY when creating a new integration (not configured yet) */}
+			{!lockGroupVariant && !id && (
+				<>
+					{/* Choose a Connector (group) */}
+					<div className="flex flex-col gap-1">
+						<label className="text-sm font-medium text-foreground">Choose a Connector</label>
+						<span className="text-xs text-muted">Choose from a range of connectors to get started</span>
+						<select
+							value={group}
+							onChange={(e) => onGroup(e.target.value)}
+							className="rounded-md border border-border bg-background-secondary px-3 py-2 text-sm text-foreground outline-none"
+						>
+							<option value="">Select…</option>
+							{getIntegrationsGroups().map((g) => (
+								<option key={g} value={g}>
+									{humanReadableConnectorNames[g as keyof typeof humanReadableConnectorNames]}
+								</option>
+							))}
+						</select>
+					</div>
 
-			{/* Select Variant */}
-			{group && (
-				<div className="flex flex-col gap-1">
-					<label className="text-sm font-medium text-foreground">Select Variant</label>
-					<span className="text-xs text-muted">Select the service you want to configure &amp; connect to</span>
-					<select
-						disabled={lockGroupVariant}
-						value={variant}
-						onChange={(e) => onVariant(e.target.value)}
-						className="rounded-md border border-border bg-background-secondary px-3 py-2 text-sm text-foreground outline-none disabled:opacity-60"
-					>
-						<option value="">Select…</option>
-						{getIntegrationsVariants(group as never).map((v) => (
-							<option key={v} value={v}>{v}</option>
-						))}
-					</select>
-				</div>
+					{/* Select Variant */}
+					{group && (
+						<div className="flex flex-col gap-1">
+							<label className="text-sm font-medium text-foreground">Select Variant</label>
+							<span className="text-xs text-muted">Select the service you want to configure &amp; connect to</span>
+							<select
+								value={variant}
+								onChange={(e) => onVariant(e.target.value)}
+								className="rounded-md border border-border bg-background-secondary px-3 py-2 text-sm text-foreground outline-none"
+							>
+								<option value="">Select…</option>
+								{getIntegrationsVariants(group as never).map((v) => (
+									<option key={v} value={v}>{v}</option>
+								))}
+							</select>
+						</div>
+					)}
+				</>
 			)}
 
 			{/* Connector-specific form */}
@@ -194,16 +196,18 @@ export function IntegrationForm({
 			)}
 
 			{/* Actions */}
-			{group && variant && (
-				<div className="flex items-center justify-between pt-2">
-					<Button variant="outline" isPending={test.isPending} onPress={onTest}>
-						Test Connection
-					</Button>
+			{!hideActions && group && variant && (
+				<div className="flex items-center justify-end pt-2 border-t border-[#1C202B]">
 					<div className="flex items-center gap-2">
 						{showDelete && id && (
-							<Button isIconOnly variant="danger" aria-label="Delete integration" onPress={() => setConfirmDelete(true)}>
-								<TbTrash size={16} />
-							</Button>
+							<button
+								type="button"
+								onClick={() => setConfirmDelete(true)}
+								className="flex items-center justify-center rounded-xl border border-red-900/30 bg-[#1C181B] p-2 text-red-400 transition-colors hover:bg-red-950/40"
+								aria-label="Delete integration"
+							>
+								<TbTrash size={15} />
+							</button>
 						)}
 						<Button variant="primary" isPending={create.isPending || update.isPending} onPress={onSave}>
 							{id ? "Save changes" : "Connect"}

--- a/apps/portal/src/query/appConfigQuery.ts
+++ b/apps/portal/src/query/appConfigQuery.ts
@@ -1,7 +1,9 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
 	type CreateAppConfigBody,
+	type DeleteBulkAppConfigBody,
 	type ListAppConfigQuery,
+	type UpdateAppConfigBody,
 	appConfigService,
 } from "@/services/appConfig";
 
@@ -17,6 +19,16 @@ export const appConfigQuery = {
 			});
 		},
 	},
+	getById: {
+		useQuery(projectId: string, id: number | string | null | undefined) {
+			return useQuery({
+				queryKey: [...key(projectId), "detail", id],
+				queryFn: () => appConfigService.getById(projectId, id!),
+				enabled: !!projectId && !!id,
+				refetchOnWindowFocus: false,
+			});
+		},
+	},
 	create: {
 		mutation(projectId: string) {
 			const qc = useQueryClient();
@@ -27,11 +39,31 @@ export const appConfigQuery = {
 			});
 		},
 	},
+	update: {
+		mutation(projectId: string, id: number | string) {
+			const qc = useQueryClient();
+			return useMutation({
+				mutationFn: (body: UpdateAppConfigBody) =>
+					appConfigService.update(projectId, id, body),
+				onSuccess: () => qc.invalidateQueries({ queryKey: key(projectId) }),
+			});
+		},
+	},
 	remove: {
 		mutation(projectId: string) {
 			const qc = useQueryClient();
 			return useMutation({
-				mutationFn: (id: number) => appConfigService.delete(projectId, id),
+				mutationFn: (id: number | string) => appConfigService.delete(projectId, id),
+				onSuccess: () => qc.invalidateQueries({ queryKey: key(projectId) }),
+			});
+		},
+	},
+	deleteBulk: {
+		mutation(projectId: string) {
+			const qc = useQueryClient();
+			return useMutation({
+				mutationFn: (body: DeleteBulkAppConfigBody) =>
+					appConfigService.deleteBulk(projectId, body),
 				onSuccess: () => qc.invalidateQueries({ queryKey: key(projectId) }),
 			});
 		},
@@ -46,3 +78,4 @@ export const appConfigQuery = {
 		},
 	},
 };
+

--- a/apps/portal/src/routes/_authed/$projectId.tsx
+++ b/apps/portal/src/routes/_authed/$projectId.tsx
@@ -7,19 +7,19 @@ import {
 } from "@tanstack/react-router";
 import {
 	TbActivity,
+	TbAdjustmentsHorizontal,
 	TbArrowLeft,
 	TbBox,
+	TbChevronDown,
 	TbCloudCog,
 	TbLayoutGridFilled,
-	TbSettings,
 	TbSparkles,
 	TbSquareKey,
 	TbStack2,
 } from "react-icons/tb";
 import { cn } from "@fluxify/components";
 import { authClient } from "@/lib/auth";
-import { projectsQuery } from "@/query/projectsQuery";
-import { ProfileNav } from "@/components/home/ProfileNav";
+import { useAuthStore } from "@/store/auth";
 
 const NAV = [
 	{ key: "ai", label: "Fluxify AI", to: "/$projectId/ai", icon: TbSparkles },
@@ -46,40 +46,63 @@ function ProjectLayout() {
 	const { projectId } = Route.useParams();
 	const navigate = useNavigate();
 	const location = useLocation();
+	const { userData } = useAuthStore();
 	const active = NAV.find((n) => location.pathname.includes(`/${n.key}`))?.key ?? "routes";
 
-	const { data } = projectsQuery.getAll.useQuery({ page: 1, perPage: 50 });
-	const projectName =
-		data?.data?.find((p: { id: string }) => p.id === projectId)?.name ?? "Project";
+	const initials = userData?.name
+		? userData.name
+				.split(" ")
+				.map((n) => n[0])
+				.join("")
+				.toUpperCase()
+				.slice(0, 2)
+		: "AD";
 
 	return (
-		<div className="flex h-screen w-screen flex-col bg-background text-foreground">
-			<header className="flex h-[52px] items-center justify-between border-b border-border bg-background-secondary px-4">
+		<div className="flex h-screen w-screen flex-col bg-[#07080A] text-foreground font-sans antialiased">
+			{/* Top Header */}
+			<header className="flex h-[56px] items-center justify-between border-b border-[#161820] bg-[#07080A] px-4">
 				<div className="flex items-center gap-3">
-					<div className="flex size-7 items-center justify-center rounded-lg bg-accent text-accent-foreground shadow-[0_0_16px_var(--accent-soft)]">
+					<div className="flex size-7 items-center justify-center rounded-lg bg-[#D0F237] text-black shadow-sm">
 						<TbLayoutGridFilled size={16} />
 					</div>
-					<span className="text-sm font-bold tracking-tight">FLUXIFY</span>
-					<div className="ml-1 flex items-center gap-1.5 border-l border-border pl-3">
-						<span className="text-sm text-muted">{projectName}</span>
-						<button
-							type="button"
-							aria-label="Project settings"
-							onClick={() =>
-								navigate({ to: "/$projectId/settings", params: { projectId } })
-							}
-							className="inline-flex size-7 items-center justify-center rounded-md text-muted transition-colors hover:bg-white/5 hover:text-foreground"
-						>
-							<TbSettings size={15} />
-						</button>
+					<span className="text-sm font-bold tracking-wider text-white">FLUXIFY</span>
+					
+					{/* Environment Dropdown Pill */}
+					<button
+						type="button"
+						onClick={() => navigate({ to: "/$projectId/settings", params: { projectId } })}
+						className="flex items-center gap-2 rounded-full border border-[#202533] bg-[#111319] px-3 py-1 text-xs font-medium text-zinc-300 transition-colors hover:border-[#2f364a]"
+					>
+						<span className="size-2 rounded-full bg-[#10B981]" />
+						<span>Test</span>
+						<TbChevronDown size={12} className="text-zinc-400" />
+					</button>
+
+					{/* Settings/Controls Toggle */}
+					<button
+						type="button"
+						aria-label="Project Settings"
+						onClick={() => navigate({ to: "/$projectId/settings", params: { projectId } })}
+						className="flex size-7 items-center justify-center rounded-full border border-[#202533] bg-[#111319] text-zinc-400 transition-colors hover:text-white"
+					>
+						<TbAdjustmentsHorizontal size={14} />
+					</button>
+				</div>
+
+				{/* User Avatar Circle Top Right */}
+				<div className="flex items-center gap-3">
+					<div className="flex size-7 items-center justify-center rounded-full bg-[#202533] text-[11px] font-bold text-zinc-200">
+						{initials}
 					</div>
 				</div>
-				<ProfileNav />
 			</header>
 
+			{/* Main Layout Area */}
 			<div className="flex min-h-0 flex-1">
-				<aside className="flex w-[220px] flex-col justify-between border-r border-border bg-background-secondary p-3">
-					<nav className="flex flex-col gap-0.5">
+				{/* Sidebar */}
+				<aside className="flex w-[220px] flex-col justify-between border-r border-[#161820] bg-[#07080A] p-3">
+					<nav className="flex flex-col gap-1">
 						{NAV.map((item) => {
 							const isActive = active === item.key;
 							return (
@@ -88,32 +111,39 @@ function ProjectLayout() {
 									type="button"
 									onClick={() => navigate({ to: item.to, params: { projectId } })}
 									className={cn(
-										"flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm transition-colors",
+										"group relative flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
 										isActive
-											? "bg-white/5 font-medium text-foreground"
-											: "text-muted hover:bg-white/[0.03] hover:text-foreground",
+											? "bg-[#141720] text-white"
+											: "text-zinc-400 hover:bg-white/[0.04] hover:text-zinc-200",
 									)}
 								>
 									<item.icon
 										size={18}
-										className={isActive ? "text-accent" : ""}
+										className={isActive ? "text-[#D0F237]" : "text-zinc-400 group-hover:text-zinc-200"}
 									/>
-									{item.label}
+									<span>{item.label}</span>
+									{isActive && (
+										<span className="ml-auto h-4 w-[3px] rounded-full bg-[#D0F237]" />
+									)}
 								</button>
 							);
 						})}
 					</nav>
 
-					<button
-						type="button"
-						onClick={() => navigate({ to: "/" })}
-						className="flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm text-muted transition-colors hover:bg-white/[0.03] hover:text-foreground"
-					>
-						<TbArrowLeft size={18} /> Back to projects
-					</button>
+					{/* Sidebar Footer */}
+					<div className="border-t border-[#161820] pt-3">
+						<button
+							type="button"
+							onClick={() => navigate({ to: "/" })}
+							className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-xs font-medium text-zinc-400 transition-colors hover:bg-white/[0.04] hover:text-white"
+						>
+							<TbArrowLeft size={16} /> Back to projects
+						</button>
+					</div>
 				</aside>
 
-				<main className="min-w-0 flex-1 overflow-y-auto p-6">
+				{/* Page Content */}
+				<main className="min-w-0 flex-1 overflow-y-auto bg-[#07080A] p-6">
 					<Outlet />
 				</main>
 			</div>

--- a/apps/portal/src/routes/_authed/$projectId/app-config.tsx
+++ b/apps/portal/src/routes/_authed/$projectId/app-config.tsx
@@ -1,117 +1,169 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { createFileRoute } from "@tanstack/react-router";
-import {
-	Button,
-	Checkbox,
-	Chip,
-	Input,
-	Label,
-	Modal,
-	Spinner,
-	Table,
-	TextField,
-	toast,
-} from "@fluxify/components";
-import { TbPlus, TbTrash } from "react-icons/tb";
+import { Button, Spinner, toast } from "@fluxify/components";
+import { TbSearch, TbTrash } from "react-icons/tb";
 import { appConfigQuery } from "@/query/appConfigQuery";
 import { showErrorNotification } from "@/lib/errorNotifier";
 import { ConfirmDialog } from "@/components/common/ConfirmDialog";
-
-const ENCODINGS = ["plaintext", "base64", "hex"] as const;
+import { CreateConfigButton } from "@/components/appConfig/CreateConfigModal";
+import { EditConfigModal } from "@/components/appConfig/EditConfigModal";
+import { AppConfigTable } from "@/components/appConfig/AppConfigTable";
+import type { ConfigRow, SortBy } from "@/components/appConfig/types";
 
 export const Route = createFileRoute("/_authed/$projectId/app-config")({
 	component: AppConfigPage,
 });
 
-type ConfigRow = {
-	id: number;
-	keyName: string;
-	isEncrypted: boolean;
-	dataType: string;
-};
-
 function AppConfigPage() {
 	const { projectId } = Route.useParams();
 	const [page, setPage] = useState(1);
+	const [perPage, setPerPage] = useState(20);
+	const [searchInput, setSearchInput] = useState("");
+	const [debouncedSearch, setDebouncedSearch] = useState("");
+	const [sortBy, setSortBy] = useState<SortBy>("keyName");
+	const [sortOrder, setSortOrder] = useState<"asc" | "desc">("asc");
+	const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+
+	const [editingConfig, setEditingConfig] = useState<ConfigRow | null>(null);
+	const [pendingDelete, setPendingDelete] = useState<ConfigRow | null>(null);
+	const [pendingBulkDelete, setPendingBulkDelete] = useState(false);
+
+	// Debounce search input
+	useEffect(() => {
+		const timer = setTimeout(() => {
+			setDebouncedSearch(searchInput);
+			setPage(1);
+		}, 300);
+		return () => clearTimeout(timer);
+	}, [searchInput]);
+
 	const { data, isLoading, isError } = appConfigQuery.getAll.useQuery(projectId, {
 		page,
-		perPage: 20,
+		perPage,
+		search: debouncedSearch,
+		sortBy,
+		sort: sortOrder,
 	});
-	const remove = appConfigQuery.remove.mutation(projectId);
-	const [pendingDelete, setPendingDelete] = useState<ConfigRow | null>(null);
 
+	const remove = appConfigQuery.remove.mutation(projectId);
+	const deleteBulk = appConfigQuery.deleteBulk.mutation(projectId);
+
+	const items = (data?.data ?? []) as ConfigRow[];
 	const totalPages = data?.pagination?.totalPages ?? 1;
+
+	function handleSort(column: SortBy) {
+		if (sortBy === column) {
+			setSortOrder((prev) => (prev === "asc" ? "desc" : "asc"));
+		} else {
+			setSortBy(column);
+			setSortOrder("asc");
+		}
+	}
 
 	return (
 		<div className="flex flex-col gap-4">
-			<div className="flex items-center justify-between">
+			{/* Top Header */}
+			<div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
 				<div>
-					<h1 className="text-xl font-semibold tracking-tight">App config</h1>
+					<h1 className="text-xl font-semibold tracking-tight">App Config</h1>
 					<p className="text-sm text-muted">
-						Key-value settings available to your routes.
+						Key-value settings and secrets available across your project routes.
 					</p>
 				</div>
-				<CreateConfigButton projectId={projectId} />
+				<div className="flex items-center gap-2">
+					{selectedIds.size > 0 && (
+						<Button
+							variant="danger"
+							onPress={() => setPendingBulkDelete(true)}
+						>
+							<TbTrash size={16} /> Delete ({selectedIds.size})
+						</Button>
+					)}
+					<CreateConfigButton projectId={projectId} />
+				</div>
 			</div>
 
+			{/* Search & Toolbar */}
+			<div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+				<div className="relative w-full max-w-sm">
+					<TbSearch className="absolute left-3 top-1/2 -translate-y-1/2 text-muted" size={16} />
+					<input
+						type="text"
+						placeholder="Search config by key name..."
+						value={searchInput}
+						onChange={(e) => setSearchInput(e.target.value)}
+						className="w-full rounded-md border border-border bg-background pl-9 pr-3 py-1.5 text-sm placeholder:text-muted focus:outline-none focus:ring-2 focus:ring-primary/20"
+					/>
+				</div>
+				<div className="flex items-center gap-2 text-sm text-muted">
+					<span>Rows per page:</span>
+					<select
+						value={perPage}
+						onChange={(e) => {
+							setPerPage(Number(e.target.value));
+							setPage(1);
+						}}
+						className="rounded-md border border-border bg-background px-2 py-1 text-sm focus:outline-none"
+					>
+						<option value={10}>10</option>
+						<option value={20}>20</option>
+						<option value={50}>50</option>
+						<option value={100}>100</option>
+					</select>
+				</div>
+			</div>
+
+			{/* Table Content */}
 			{isLoading ? (
 				<div className="flex justify-center py-16">
 					<Spinner />
 				</div>
 			) : isError ? (
-				<p className="py-16 text-center text-muted">Couldn't load config.</p>
-			) : data && data.data.length === 0 ? (
-				<p className="py-16 text-center text-muted">No config keys yet.</p>
+				<p className="py-16 text-center text-muted">Couldn't load app config.</p>
+			) : items.length === 0 ? (
+				<p className="py-16 text-center text-muted">
+					{debouncedSearch ? `No configurations found matching "${debouncedSearch}"` : "No config keys yet."}
+				</p>
 			) : (
-				<Table>
-					<Table.Content aria-label="App config">
-						<Table.Header>
-							<Table.Column id="key" isRowHeader>Key</Table.Column>
-							<Table.Column id="type">Type</Table.Column>
-							<Table.Column id="encrypted">Encrypted</Table.Column>
-							<Table.Column id="actions" aria-label="Actions">{""}</Table.Column>
-						</Table.Header>
-						<Table.Body items={(data?.data ?? []) as ConfigRow[]}>
-							{(row: ConfigRow) => (
-								<Table.Row id={String(row.id)}>
-									<Table.Cell>
-										<span className="font-mono text-sm">{row.keyName}</span>
-									</Table.Cell>
-									<Table.Cell>{row.dataType}</Table.Cell>
-									<Table.Cell>
-										<Chip>{row.isEncrypted ? "Yes" : "No"}</Chip>
-									</Table.Cell>
-									<Table.Cell>
-										<div className="flex justify-end">
-											<Button
-												isIconOnly
-												variant="ghost"
-												aria-label="Delete config"
-												onPress={() => setPendingDelete(row)}
-											>
-												<TbTrash size={16} />
-											</Button>
-										</div>
-									</Table.Cell>
-								</Table.Row>
-							)}
-						</Table.Body>
-					</Table.Content>
-				</Table>
+				<AppConfigTable
+					items={items}
+					selectedIds={selectedIds}
+					onSelectionChange={setSelectedIds}
+					sortBy={sortBy}
+					sortOrder={sortOrder}
+					onSort={handleSort}
+					onEdit={setEditingConfig}
+					onDelete={setPendingDelete}
+				/>
 			)}
 
+			{/* Pagination Controls */}
 			{totalPages > 1 && (
-				<div className="flex items-center justify-end gap-3 text-sm text-muted">
-					<Button variant="outline" isDisabled={page <= 1} onPress={() => setPage((p) => p - 1)}>
-						Previous
-					</Button>
-					<span>Page {page} of {totalPages}</span>
-					<Button variant="outline" isDisabled={page >= totalPages} onPress={() => setPage((p) => p + 1)}>
-						Next
-					</Button>
+				<div className="flex items-center justify-between border-t border-border pt-4 text-sm text-muted">
+					<div>
+						Showing page <b>{page}</b> of <b>{totalPages}</b>
+					</div>
+					<div className="flex items-center gap-2">
+						<Button variant="outline" isDisabled={page <= 1} onPress={() => setPage((p) => p - 1)}>
+							Previous
+						</Button>
+						<Button variant="outline" isDisabled={page >= totalPages} onPress={() => setPage((p) => p + 1)}>
+							Next
+						</Button>
+					</div>
 				</div>
 			)}
 
+			{/* Edit Config Modal */}
+			{editingConfig && (
+				<EditConfigModal
+					projectId={projectId}
+					config={editingConfig}
+					onClose={() => setEditingConfig(null)}
+				/>
+			)}
+
+			{/* Single Delete Confirm Dialog */}
 			<ConfirmDialog
 				open={!!pendingDelete}
 				onOpenChange={(o) => !o && setPendingDelete(null)}
@@ -122,117 +174,46 @@ function AppConfigPage() {
 				onConfirm={() => {
 					if (!pendingDelete) return;
 					remove.mutate(pendingDelete.id, {
-						onSuccess: () => toast.success("Config deleted"),
+						onSuccess: () => {
+							toast.success("Config deleted");
+							setSelectedIds((prev) => {
+								const next = new Set(prev);
+								next.delete(pendingDelete.id);
+								return next;
+							});
+							setPendingDelete(null);
+						},
 						onError: (e) => showErrorNotification(e as Error),
 					});
-					setPendingDelete(null);
 				}}
 			>
-				Delete <b className="text-foreground">{pendingDelete?.keyName}</b>? This can't be undone.
+				Delete key <b className="text-foreground">{pendingDelete?.keyName}</b>? This cannot be undone.
+			</ConfirmDialog>
+
+			{/* Bulk Delete Confirm Dialog */}
+			<ConfirmDialog
+				open={pendingBulkDelete}
+				onOpenChange={(o) => !o && setPendingBulkDelete(false)}
+				title="Delete selected configs?"
+				danger
+				confirmText={`Delete ${selectedIds.size} items`}
+				pending={deleteBulk.isPending}
+				onConfirm={() => {
+					deleteBulk.mutate(
+						{ ids: Array.from(selectedIds) },
+						{
+							onSuccess: () => {
+								toast.success(`Deleted ${selectedIds.size} config items`);
+								setSelectedIds(new Set());
+								setPendingBulkDelete(false);
+							},
+							onError: (e) => showErrorNotification(e as Error),
+						},
+					);
+				}}
+			>
+				Are you sure you want to delete <b className="text-foreground">{selectedIds.size}</b> selected configuration key(s)? This action cannot be undone.
 			</ConfirmDialog>
 		</div>
-	);
-}
-
-function CreateConfigButton({ projectId }: { projectId: string }) {
-	const create = appConfigQuery.create.mutation(projectId);
-	const [open, setOpen] = useState(false);
-	const [keyName, setKeyName] = useState("");
-	const [description, setDescription] = useState("");
-	const [value, setValue] = useState("");
-	const [isEncrypted, setIsEncrypted] = useState(false);
-	const [encoding, setEncoding] = useState<(typeof ENCODINGS)[number]>("plaintext");
-
-	function reset() {
-		setKeyName("");
-		setDescription("");
-		setValue("");
-		setIsEncrypted(false);
-		setEncoding("plaintext");
-	}
-
-	function submit(e: React.FormEvent) {
-		e.preventDefault();
-		create.mutate(
-			{
-				keyName,
-				description,
-				value,
-				isEncrypted,
-				encodingType: encoding,
-				dataType: "string",
-			},
-			{
-				onSuccess: () => {
-					toast.success("Config created");
-					reset();
-					setOpen(false);
-				},
-				onError: (err) => showErrorNotification(err as Error),
-			},
-		);
-	}
-
-	return (
-		<Modal isOpen={open} onOpenChange={setOpen}>
-			<Modal.Trigger>
-				<Button variant="primary">
-					<TbPlus size={16} /> New key
-				</Button>
-			</Modal.Trigger>
-			<Modal.Backdrop>
-				<Modal.Container placement="center" size="sm">
-					<Modal.Dialog>
-						<Modal.Header>
-							<Modal.Heading>Add a config key</Modal.Heading>
-						</Modal.Header>
-						<form onSubmit={submit}>
-							<Modal.Body>
-								<div className="flex flex-col gap-4">
-									<TextField isRequired value={keyName} onChange={setKeyName}>
-										<Label>Key name</Label>
-										<Input placeholder="API_TIMEOUT" />
-									</TextField>
-									<TextField isRequired value={description} onChange={setDescription}>
-										<Label>Description</Label>
-										<Input placeholder="What this key controls" />
-									</TextField>
-									<TextField isRequired value={value} onChange={setValue}>
-										<Label>Value</Label>
-										<Input placeholder="Value" />
-									</TextField>
-									<div className="flex flex-col gap-1.5">
-										<Label>Encoding</Label>
-										<div className="flex gap-1.5">
-											{ENCODINGS.map((enc) => (
-												<Button
-													key={enc}
-													type="button"
-													variant={encoding === enc ? "primary" : "outline"}
-													onPress={() => setEncoding(enc)}
-												>
-													{enc}
-												</Button>
-											))}
-										</div>
-									</div>
-									<Checkbox isSelected={isEncrypted} onChange={setIsEncrypted}>
-										Encrypt this value
-									</Checkbox>
-								</div>
-							</Modal.Body>
-							<Modal.Footer>
-								<Button variant="ghost" onPress={() => setOpen(false)}>
-									Cancel
-								</Button>
-								<Button type="submit" variant="primary" isPending={create.isPending}>
-									Add key
-								</Button>
-							</Modal.Footer>
-						</form>
-					</Modal.Dialog>
-				</Modal.Container>
-			</Modal.Backdrop>
-		</Modal>
 	);
 }

--- a/apps/portal/src/routes/_authed/$projectId/integrations.tsx
+++ b/apps/portal/src/routes/_authed/$projectId/integrations.tsx
@@ -1,22 +1,25 @@
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { z } from "zod";
-import { Button, Input, Modal, Spinner, cn, toast } from "@fluxify/components";
-import { FaRobot, FaTableList, FaChevronRight } from "react-icons/fa6";
+import { Modal, Spinner, cn, toast } from "@fluxify/components";
+import { FaRobot, FaTableList } from "react-icons/fa6";
 import { LuServerCrash } from "react-icons/lu";
 import {
-	TbDatabase,
-	TbHeartRateMonitor,
-	TbPlugConnected,
-	TbFilter,
+	TbBolt,
+	TbBook,
 	TbChevronDown,
+	TbCloudCog,
+	TbDatabase,
+	TbDots,
+	TbExternalLink,
+	TbHeartRateMonitor,
+	TbLock,
+	TbPlugConnected,
+	TbTrash,
 } from "react-icons/tb";
-import {
-	getIntegrationsVariants,
-	humanReadableConnectorNames,
-} from "@fluxify/server/src/api/v1/integrations/helpers";
 import { integrationsQuery } from "@/query/integrationsQuery";
 import { showErrorNotification } from "@/lib/errorNotifier";
+import { ConfirmDialog } from "@/components/common/ConfirmDialog";
 import { integrationIcons } from "@/components/integrations/integrationIcons";
 import { IntegrationForm } from "@/components/integrations/IntegrationForm";
 import {
@@ -35,9 +38,9 @@ export const Route = createFileRoute("/_authed/$projectId/integrations")({
 
 const CONNECTORS: { name: string; type: IntegrationGroup; icon: ReactNode }[] = [
 	{ name: "Databases", type: "database", icon: <TbDatabase size={18} /> },
-	{ name: "KV", type: "kv", icon: <FaTableList size={18} /> },
-	{ name: "AI", type: "ai", icon: <FaRobot size={18} /> },
-	{ name: "BaaS", type: "baas", icon: <LuServerCrash size={18} /> },
+	{ name: "KV", type: "kv", icon: <FaTableList size={16} /> },
+	{ name: "AI", type: "ai", icon: <FaRobot size={16} /> },
+	{ name: "BaaS", type: "baas", icon: <LuServerCrash size={16} /> },
 	{ name: "Observability", type: "observability", icon: <TbHeartRateMonitor size={18} /> },
 ];
 
@@ -48,6 +51,21 @@ function IntegrationsPage() {
 	const { selectedMenu } = useIntegrationState();
 	const { setSelectedMenu } = useIntegrationActions();
 	const [connectOpen, setConnectOpen] = useState(false);
+
+	// Fetch count of integrations per category
+	const { data: dbData } = integrationsQuery.getAll.useQuery(projectId, "database");
+	const { data: kvData } = integrationsQuery.getAll.useQuery(projectId, "kv");
+	const { data: aiData } = integrationsQuery.getAll.useQuery(projectId, "ai");
+	const { data: baasData } = integrationsQuery.getAll.useQuery(projectId, "baas");
+	const { data: obsData } = integrationsQuery.getAll.useQuery(projectId, "observability");
+
+	const counts: Record<IntegrationGroup, number> = {
+		database: dbData?.length ?? 0,
+		kv: kvData?.length ?? 0,
+		ai: aiData?.length ?? 0,
+		baas: baasData?.length ?? 0,
+		observability: obsData?.length ?? 0,
+	};
 
 	// sync selected group from URL (deep-link support)
 	useEffect(() => {
@@ -60,57 +78,74 @@ function IntegrationsPage() {
 	}
 
 	return (
-		<div className="flex h-full flex-col gap-4 px-1 py-1">
+		<div className="flex flex-col gap-6">
+			{/* Header */}
 			<div className="flex items-center justify-between">
 				<div>
-					<h1 className="text-xl font-semibold tracking-tight">Integrations</h1>
-					<p className="text-sm text-muted">Connect &amp; Configure 3rd Party Services</p>
+					<h1 className="text-2xl font-bold tracking-tight text-white">Integrations</h1>
+					<p className="text-sm text-zinc-400">Connect &amp; Configure 3rd Party Services</p>
 				</div>
-				<Button variant="primary" onPress={() => setConnectOpen(true)}>
-					<TbPlugConnected size={16} /> Connect App/Service
-				</Button>
+				<button
+					type="button"
+					onClick={() => setConnectOpen(true)}
+					className="flex items-center gap-2 rounded-xl bg-[#D0F237] px-4 py-2 text-sm font-semibold text-black transition-colors hover:bg-[#bce028]"
+				>
+					<TbPlugConnected size={16} /> Connect App / Service
+				</button>
 			</div>
 
-			<div className="flex min-h-0 flex-1 gap-4">
-				{/* Left rail — available connectors */}
+			<div className="flex min-h-0 flex-1 gap-6">
+				{/* Column 1 — CATEGORIES Rail */}
 				<nav className="flex w-56 shrink-0 flex-col gap-1">
+					<div className="mb-2 px-3 text-[10px] font-bold uppercase tracking-widest text-zinc-500">
+						CATEGORIES
+					</div>
 					{CONNECTORS.map((c) => {
 						const active = selectedMenu === c.type;
+						const count = counts[c.type] ?? 0;
 						return (
 							<button
 								key={c.type}
 								type="button"
 								onClick={() => selectGroup(c.type)}
 								className={cn(
-									"flex items-center gap-2.5 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+									"flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-all",
 									active
-										? "bg-white/5 text-foreground"
-										: "text-muted hover:bg-white/5 hover:text-foreground",
+										? "border border-[#202533] bg-[#13151D] text-white shadow-sm"
+										: "text-zinc-400 hover:bg-white/[0.03] hover:text-zinc-200",
 								)}
 							>
-								<span className={cn(active && "text-accent")}>{c.icon}</span>
-								{c.name}
+								<span className={cn(active ? "text-[#D0F237]" : "text-zinc-400")}>{c.icon}</span>
+								<span>{c.name}</span>
+								<span
+									className={cn(
+										"ml-auto rounded-full px-2 py-0.5 text-xs font-semibold",
+										active ? "bg-[#202533] text-zinc-200" : "bg-[#161822] text-zinc-500",
+									)}
+								>
+									{count}
+								</span>
 							</button>
 						);
 					})}
 				</nav>
 
-				{/* Center — configured integrations list */}
+				{/* Column 2 — Center configured list or active creation/editing */}
 				<div className="min-w-0 flex-1 overflow-y-auto">
 					<IntegrationsList projectId={projectId} group={selectedMenu} />
 				</div>
 
-				{/* Right — filter */}
-				<FilterPanel group={selectedMenu} />
+				{/* Column 3 — Right Panel: Help, Connected Databases & Environment Notice */}
+				<RightHelpPanel projectId={projectId} activeGroup={selectedMenu} />
 			</div>
 
 			{/* Connect modal (create) */}
 			<Modal isOpen={connectOpen} onOpenChange={setConnectOpen}>
 				<Modal.Backdrop>
 					<Modal.Container placement="center" size="lg">
-						<Modal.Dialog>
+						<Modal.Dialog className="bg-[#0E1015] border border-[#1C202B]">
 							<Modal.Header>
-								<Modal.Heading>Connect a new App/Service</Modal.Heading>
+								<Modal.Heading className="text-white">Connect a new App/Service</Modal.Heading>
 							</Modal.Header>
 							<Modal.Body>
 								<IntegrationForm projectId={projectId} onSaved={() => setConnectOpen(false)} />
@@ -126,37 +161,25 @@ function IntegrationsPage() {
 function IntegrationsList({ projectId, group }: { projectId: string; group: string }) {
 	const { open } = Route.useSearch();
 	const navigate = useNavigate();
-	const { filterVariant, searchQuery } = useIntegrationState();
-	const { setFilterVariant, setSearchQuery } = useIntegrationActions();
 	const { data, isLoading, isError } = integrationsQuery.getAll.useQuery(projectId, group);
 	const remove = integrationsQuery.remove.mutation(projectId);
+	const test = integrationsQuery.testConnection.mutation(projectId);
 
-	// reset filters when group changes
-	useEffect(() => {
-		setFilterVariant("");
-		setSearchQuery("");
-	}, [group]);
-
-	const filtered = useMemo(() => {
-		if (!data) return [];
-		if (filterVariant) return data.filter((i) => i.variant === filterVariant);
-		if (searchQuery)
-			return data.filter((i) => i.name.toLowerCase().includes(searchQuery.toLowerCase()));
-		return data;
-	}, [data, filterVariant, searchQuery]);
+	const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
 
 	if (isLoading) return <div className="flex justify-center py-16"><Spinner /></div>;
 	if (isError) return <p className="py-16 text-center text-muted">Couldn't load integrations.</p>;
 
-	if (filtered.length === 0) {
+	if (!data || data.length === 0) {
 		return (
-			<div className="flex flex-col items-center gap-2 rounded-lg border border-border bg-background-secondary py-16 text-center">
-				<p className="text-lg font-medium">No integrations found.</p>
-				<p className="text-sm text-muted">
-					{filterVariant || searchQuery
-						? "No results found"
-						: "Try adding one now by clicking Connect App/Service"}
-				</p>
+			<div className="flex flex-col items-center gap-3 rounded-2xl border border-[#1C202B] bg-[#0E1015] p-8 text-center">
+				<TbCloudCog size={36} className="text-zinc-600" />
+				<div>
+					<p className="text-base font-semibold text-white">No integrations found</p>
+					<p className="mt-1 text-xs text-zinc-400">
+						No configured services in this category yet. Click "Connect App / Service" to add one.
+					</p>
+				</div>
 			</div>
 		);
 	}
@@ -165,101 +188,159 @@ function IntegrationsList({ projectId, group }: { projectId: string; group: stri
 		navigate({ to: ".", search: { group, open: open === id ? undefined : id } });
 	}
 
+	function handleTest(e: React.MouseEvent, integration: NonNullable<typeof data>[number]) {
+		e.stopPropagation();
+		test.mutate(
+			{ group: integration.group, variant: integration.variant, config: integration.config as Record<string, unknown> },
+			{
+				onSuccess: (res) =>
+					res?.success ? toast.success("Connection successful") : toast.danger(res?.error ?? "Connection failed"),
+				onError: (err) => showErrorNotification(err as Error),
+			},
+		);
+	}
+
+	function handleDelete(e: React.MouseEvent, id: string) {
+		e.stopPropagation();
+		setPendingDeleteId(id);
+	}
+
 	return (
-		<div className="flex flex-col gap-2">
-			{filtered.map((integration) => {
-				const isOpen = open === integration.id;
+		<div className="flex flex-col gap-4">
+			{data.map((integration) => {
+				const isOpen = open === integration.id || data.length === 1;
 				return (
-					<div key={integration.id} className="overflow-hidden rounded-lg border border-border bg-background-secondary">
-						<button
-							type="button"
+					<div
+						key={integration.id}
+						className="overflow-hidden rounded-2xl border border-[#1C202B] bg-[#0E1015] transition-all"
+					>
+						{/* Card Header Bar — Contains Title, ID, Test Connection, Delete, & Chevron */}
+						<div
+							role="button"
+							tabIndex={0}
 							onClick={() => toggle(integration.id)}
-							className="flex w-full items-center justify-between px-4 py-3 text-left hover:bg-white/5"
+							onKeyDown={(e) => e.key === "Enter" && toggle(integration.id)}
+							className="flex flex-wrap items-center justify-between gap-3 border-b border-[#1C202B] px-5 py-4 hover:bg-white/[0.02] cursor-pointer"
 						>
-							<span className="flex items-center gap-3">
-								<span className="text-muted">{integrationIcons[integration.variant]}</span>
-								<span className="font-medium">{integration.name}</span>
-							</span>
-							<TbChevronDown size={16} className={cn("text-muted transition-transform", isOpen && "rotate-180")} />
-						</button>
+							<div className="flex items-center gap-3">
+								<div className="flex size-9 items-center justify-center rounded-xl bg-[#161822] text-[#D0F237]">
+									{integrationIcons[integration.variant] ?? <TbDatabase size={18} />}
+								</div>
+								<div>
+									<div className="flex items-center gap-2">
+										<span className="font-semibold text-white">{integration.name}</span>
+									</div>
+									<div className="text-xs text-zinc-400">
+										{integration.variant} • {group}
+									</div>
+								</div>
+							</div>
+
+							{/* Right Actions Bar — Available even when accordion is closed */}
+							<div className="flex items-center gap-2" onClick={(e) => e.stopPropagation()}>
+								<span className="rounded-full border border-[#252A38] bg-[#191C26] px-2.5 py-1 text-[11px] font-mono text-zinc-400">
+									ID: {integration.id.slice(0, 8)}
+								</span>
+
+								{/* Test Connection Button */}
+								<button
+									type="button"
+									onClick={(e) => handleTest(e, integration)}
+									className="flex items-center gap-1.5 rounded-xl border border-[#252A38] bg-[#141720] px-3 py-1.5 text-xs font-medium text-zinc-200 transition-colors hover:bg-[#1C202B]"
+								>
+									<TbBolt size={14} className="text-[#D0F237]" />
+									<span>Test Connection</span>
+								</button>
+
+								{/* Delete Button */}
+								<button
+									type="button"
+									onClick={(e) => handleDelete(e, integration.id)}
+									className="flex items-center justify-center rounded-xl border border-red-900/30 bg-[#1C181B] p-2 text-red-400 transition-colors hover:bg-red-950/40"
+									aria-label="Delete integration"
+								>
+									<TbTrash size={15} />
+								</button>
+
+								{/* Chevron indicator */}
+								<button
+									type="button"
+									onClick={() => toggle(integration.id)}
+									className="p-1 text-zinc-400 hover:text-white"
+								>
+									<TbChevronDown
+										size={18}
+										className={cn("transition-transform", isOpen && "rotate-180")}
+									/>
+								</button>
+							</div>
+						</div>
+
+						{/* Form Content */}
 						{isOpen && (
-							<div className="border-t border-border px-4 py-4">
+							<div className="p-5">
 								<IntegrationForm
 									projectId={projectId}
 									id={integration.id}
 									lockGroupVariant
-									showDelete
-									deletePending={remove.isPending}
-									onDelete={() => {
-										// collapse first (drops ?open= and unmounts getById) so the
-										// broad invalidation below never refetches the deleted id.
-										navigate({ to: ".", search: { group } });
-										remove.mutate(integration.id, {
-											onSuccess: () => toast.success("Integration deleted"),
-											onError: (e) => showErrorNotification(e as Error),
-										});
-									}}
+									showDelete={false}
+									onSaved={() => navigate({ to: ".", search: { group } })}
 								/>
 							</div>
 						)}
 					</div>
 				);
 			})}
+
+			<ConfirmDialog
+				open={!!pendingDeleteId}
+				onOpenChange={(o) => !o && setPendingDeleteId(null)}
+				title="Delete integration?"
+				danger
+				confirmText="Delete"
+				pending={remove.isPending}
+				onConfirm={() => {
+					if (!pendingDeleteId) return;
+					const id = pendingDeleteId;
+					setPendingDeleteId(null);
+					navigate({ to: ".", search: { group } });
+					remove.mutate(id, {
+						onSuccess: () => toast.success("Integration deleted"),
+						onError: (e) => showErrorNotification(e as Error),
+					});
+				}}
+			>
+				You are about to delete this integration. This action is irreversible.
+			</ConfirmDialog>
 		</div>
 	);
 }
 
-function FilterPanel({ group }: { group: string }) {
-	const { filterVariant, searchQuery, filterHidden } = useIntegrationState();
-	const { setFilterVariant, setSearchQuery, toggleFilterVisibility } = useIntegrationActions();
-	const hasFilter = !!filterVariant || !!searchQuery;
-
-	if (filterHidden) {
-		return (
-			<div className="shrink-0 pt-1">
-				<button
-					type="button"
-					onClick={toggleFilterVisibility}
-					className="relative rounded-md p-2 text-muted hover:bg-white/5 hover:text-foreground"
-					aria-label="Show filters"
-				>
-					<TbFilter size={16} />
-					{hasFilter && <span className="absolute right-1 top-1 size-1.5 rounded-full bg-danger" />}
-				</button>
-			</div>
-		);
-	}
+function RightHelpPanel({ projectId, activeGroup }: { projectId: string; activeGroup: string }) {
+	const { data: dbData } = integrationsQuery.getAll.useQuery(projectId, "database");
 
 	return (
-		<div className="w-56 shrink-0">
-			<div className="flex flex-col gap-3 rounded-lg border border-border bg-background-secondary p-3">
-				<div className="flex items-center justify-between">
-					<span className="text-sm font-medium">Filter Integrations</span>
-					<button
-						type="button"
-						onClick={toggleFilterVisibility}
-						className="rounded-md p-1 text-muted hover:bg-white/5 hover:text-foreground"
-						aria-label="Hide filters"
-					>
-						<FaChevronRight size={13} />
-					</button>
+		<div className="flex w-64 shrink-0 flex-col gap-4">
+			{/* Card 1: Need Help */}
+			<div className="flex flex-col gap-3 rounded-2xl border border-[#1C202B] bg-[#0E1015] p-4">
+				<div className="flex items-center gap-2 font-semibold text-white text-sm">
+					<TbBook size={16} className="text-zinc-400" />
+					<span>Need help?</span>
 				</div>
-				<div className="flex flex-col gap-1">
-					<label className="text-xs text-muted">Search</label>
-					<Input value={searchQuery} onChange={(e) => setSearchQuery(e.currentTarget.value)} placeholder="Search..." />
-				</div>
-				<div className="flex flex-col gap-1">
-					<label className="text-xs text-muted">By type</label>
-					<select
-						value={filterVariant}
-						onChange={(e) => setFilterVariant(e.target.value)}
-						className="rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground outline-none"
-					>
-						<option value="">All types</option>
-						{getIntegrationsVariants(group as never).map((v) => (
-							<option key={v} value={v}>{v}</option>
-						))}
-					</select>
+				<p className="text-xs text-zinc-400 leading-relaxed">
+					Learn how to secure your Postgres integration with IP allowlists and read replicas.
+				</p>
+				<a
+					href="https://docs.fluxify.rest/integrations/databases.html"
+					target="_blank"
+					rel="noreferrer"
+					className="flex items-center gap-1 text-xs font-semibold text-[#D0F237] hover:underline"
+				>
+					View docs <TbExternalLink size={12} />
+				</a>
+				<div className="flex items-start gap-2.5 rounded-xl border border-[#202533] bg-[#12141C] p-3 text-xs text-zinc-400 leading-relaxed">
+					<TbLock size={16} className="shrink-0 text-zinc-400 mt-0.5" />
+					<span>Use a dedicated read-only role for Fluxify to limit blast radius.</span>
 				</div>
 			</div>
 		</div>

--- a/apps/portal/src/services/appConfig.ts
+++ b/apps/portal/src/services/appConfig.ts
@@ -4,12 +4,31 @@ import type {
 	requestBodySchema as createRequestBodySchema,
 	responseSchema as createResponseSchema,
 } from "@fluxify/server/src/api/v1/app-config/create/dto";
+import type {
+	requestBodySchema as updateRequestBodySchema,
+	responseSchema as updateResponseSchema,
+} from "@fluxify/server/src/api/v1/app-config/update/dto";
+import type { responseSchema as getOneResponseSchema } from "@fluxify/server/src/api/v1/app-config/get-by-id/dto";
+import type {
+	requestBodySchema as deleteBulkRequestBodySchema,
+	responseSchema as deleteBulkResponseSchema,
+} from "@fluxify/server/src/api/v1/app-config/delete-bulk/dto";
 import { httpClient } from "@/lib/http";
 
 const baseUrl = (projectId: string) => `/v1/${projectId}/app-config`;
 
-export type ListAppConfigQuery = { page?: number; perPage?: number };
+export type ListAppConfigQuery = {
+	page?: number;
+	perPage?: number;
+	search?: string;
+	sort?: "asc" | "desc";
+	sortBy?: "id" | "keyName" | "createdAt" | "updatedAt" | "isEncrypted" | "encodingType";
+};
+
 export type CreateAppConfigBody = z.infer<typeof createRequestBodySchema>;
+export type UpdateAppConfigBody = z.infer<typeof updateRequestBodySchema>;
+export type DeleteBulkAppConfigBody = z.infer<typeof deleteBulkRequestBodySchema>;
+export type AppConfigDetail = z.infer<typeof getOneResponseSchema>;
 
 export const appConfigService = {
 	async getAll(
@@ -17,9 +36,16 @@ export const appConfigService = {
 		query: ListAppConfigQuery,
 	): Promise<z.infer<typeof getAllResponseSchema>> {
 		const params = new URLSearchParams();
-		params.set("page", String(query.page ?? 1));
-		params.set("perPage", String(query.perPage ?? 20));
-		const result = await httpClient.get(`${baseUrl(projectId)}/list?${params}`);
+		if (query.page) params.set("page", String(query.page));
+		if (query.perPage) params.set("perPage", String(query.perPage));
+		if (query.search) params.set("search", query.search);
+		if (query.sortBy) params.set("sortBy", query.sortBy);
+		if (query.sort) params.set("sort", query.sort);
+		const result = await httpClient.get(`${baseUrl(projectId)}/list?${params.toString()}`);
+		return result.data;
+	},
+	async getById(projectId: string, id: number | string): Promise<AppConfigDetail> {
+		const result = await httpClient.get(`${baseUrl(projectId)}/${id}`);
 		return result.data;
 	},
 	async create(
@@ -29,13 +55,29 @@ export const appConfigService = {
 		const result = await httpClient.post(baseUrl(projectId), body);
 		return result.data;
 	},
-	async delete(projectId: string, id: number) {
+	async update(
+		projectId: string,
+		id: number | string,
+		body: UpdateAppConfigBody,
+	): Promise<z.infer<typeof updateResponseSchema>> {
+		const result = await httpClient.put(`${baseUrl(projectId)}/${id}`, body);
+		return result.data;
+	},
+	async delete(projectId: string, id: number | string) {
 		await httpClient.delete(`${baseUrl(projectId)}/${id}`);
+	},
+	async deleteBulk(
+		projectId: string,
+		body: DeleteBulkAppConfigBody,
+	): Promise<z.infer<typeof deleteBulkResponseSchema>> {
+		const result = await httpClient.post(`${baseUrl(projectId)}/delete-bulk`, body);
+		return result.data;
 	},
 	async getKeysList(projectId: string, search: string): Promise<string[]> {
 		const params = new URLSearchParams();
 		if (search) params.set("search", search);
-		const result = await httpClient.get(`${baseUrl(projectId)}/keys?${params}`);
+		const result = await httpClient.get(`${baseUrl(projectId)}/keys?${params.toString()}`);
 		return result.data;
 	},
 };
+

--- a/packages/components/src/styles.css
+++ b/packages/components/src/styles.css
@@ -17,7 +17,7 @@
    @layer base defaults. */
 :root {
 	/* Rounded like the mockup (cards ~12px, controls; buttons = radius*3). */
-	--radius: 12px;
+	--radius: 6px;
 	/* HeroUI leaves form fields borderless by default (width 0), so an unfocused
 	   input is invisible against a matching surface. Give it a resting border. */
 	--field-border-width: 1px;
@@ -34,21 +34,28 @@
 .light,
 [data-theme="light"],
 [data-theme="default"] {
-	--accent: oklch(0.9 0.19 122); /* lime green */
+	--accent: oklch(0.9 0.19 122);
+	/* lime green */
 }
 
 /* Dark theme (primary): layered near-black surfaces (mockup palette), lime accent. */
 .dark,
 [data-theme="dark"] {
-	--background: #050507; /* main canvas */
-	--background-secondary: #0a0a0b; /* sidebar / inset fields */
+	--background: #050507;
+	/* main canvas */
+	--background-secondary: #0a0a0b;
+	/* sidebar / inset fields */
 	--background-tertiary: #0e0e10;
-	--surface: #111113; /* cards */
+	--surface: #111113;
+	/* cards */
 	--surface-secondary: #151518;
-	--overlay: #141416; /* popovers / modals */
-	--border: #232326; /* subtle zinc hairline */
+	--overlay: #141416;
+	/* popovers / modals */
+	--border: #232326;
+	/* subtle zinc hairline */
 	--border-secondary: #1e1e20;
-	--accent: oklch(0.9 0.2 122); /* lime */
+	--accent: oklch(0.9 0.2 122);
+	/* lime */
 }
 
 @layer base {
@@ -63,19 +70,23 @@
 	scrollbar-width: thin;
 	scrollbar-color: var(--border) transparent;
 }
+
 ::-webkit-scrollbar {
 	width: 10px;
 	height: 10px;
 }
+
 ::-webkit-scrollbar-track {
 	background: transparent;
 }
+
 ::-webkit-scrollbar-thumb {
 	background-color: var(--border);
 	border: 2px solid transparent;
 	background-clip: content-box;
 	border-radius: 9999px;
 }
+
 ::-webkit-scrollbar-thumb:hover {
 	background-color: var(--muted);
 	background-clip: content-box;
@@ -88,9 +99,11 @@
 	padding: calc(var(--spacing) * 6);
 	gap: calc(var(--spacing) * 5);
 }
+
 .card__header {
 	gap: calc(var(--spacing) * 2);
 }
+
 .card__footer {
 	justify-content: flex-end;
 	gap: calc(var(--spacing) * 2);

--- a/packages/components/src/styles.css
+++ b/packages/components/src/styles.css
@@ -16,7 +16,7 @@
 /* Shared brand knobs (apply to both themes). Unlayered so they beat HeroUI's
    @layer base defaults. */
 :root {
-	/* Rounded like the mockup (cards ~12px, controls; buttons = radius*3). */
+	/* Rounded like the mockup (cards, controls, and buttons all share this radius). */
 	--radius: 6px;
 	/* HeroUI leaves form fields borderless by default (width 0), so an unfocused
 	   input is invisible against a matching surface. Give it a resting border. */
@@ -107,4 +107,10 @@
 .card__footer {
 	justify-content: flex-end;
 	gap: calc(var(--spacing) * 2);
+}
+
+/* Button refinement (unlayered so it wins over HeroUI's default pill shape):
+   match the standard 6px radius instead of rounded-3xl. */
+.button {
+	border-radius: var(--radius);
 }


### PR DESCRIPTION
## Why
Achieve full feature parity for **App Config** in `apps/portal` with backend API endpoints and existing desktop/web capabilities.

## What
- **API Services & Queries**: Extended `appConfigService` and `appConfigQuery` in portal to support `getById`, `update`, `deleteBulk`, and full `getAll` filtering params (`search`, `sortBy`, `sort`, `page`, `perPage`).
- **Portal UI Implementation**: Built end-to-end App Config management with debounced search bar, sortable table columns, multi-select checkboxes, bulk deletion modal, creation modal, edit modal, and pagination.
- **HeroUI v3 Checkbox Fixes**: Solved HeroUI v3 Checkbox rendering and press responder handling by properly wrapping `<Checkbox.Control>` and `<Checkbox.Indicator>` inside `<Checkbox.Content>` and binding Table `selectionMode`.
- **Code Modularization**: Refactored component structure into `AppConfigTable`, `CreateConfigModal`, and `EditConfigModal` to satisfy `fta-cli` complexity limits.