### PR TITLE
feat(harness): reliability fixes, plan review UI, and artifact tooling

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -80,6 +80,47 @@ When creating branches or Pull Requests via the `gh` CLI:
 1. Pass `slot="selection"` on any `<Checkbox>` rendered inside `<Table.Header>` or `<Table.Cell>` (e.g. `<Checkbox slot="selection" ... />`).
 2. Replace nested `<button>` elements inside `<Table.Column>` with clickable `<div>` or `<span>` elements (e.g. `<div role="button" tabIndex={0} onClick={...}>`).
 
+### Harness Structured Output — "JSON Parse error: Unexpected EOF" / silent parse failures
+**File:** `apps/ai-gateway/src/harness/models/base.ts` (`fallbackStructuredOutput`).
+**Symptoms & causes (all fixed, keep the fixes):**
+1. `Model response: .` (empty) — `response.content as string` assumed a plain string. Reasoning/multi-block models return an **array of content blocks**, or park text in `additional_kwargs.reasoning_content`. Use `extractText()`; never cast `.content` to string.
+2. Empty content also happens when a model burns its whole output budget on thinking. It throws a named error now — don't let it reach `JSON.parse`.
+3. Prose around the payload ("Here is the JSON: {...}") — `cleanJsonOutput` strips code fences AND slices from the first `{`/`[` to the last `}`/`]`.
+4. `"field": null` for an omitted optional field — zod `.optional()` **rejects null**. Two defenses: `JSON.parse` reviver drops nulls, and agent schemas use `.nullish()` instead of `.optional()`.
+**Rules:**
+- Prefer `.nullish()` over `.optional()` in any zod schema an LLM fills.
+- Give required arrays `.default([])` — a terminal block has no `connections`, a fresh canvas has no `canvasChanges`; making the model type `[]` is just an error surface.
+- Every agent prompt must include an **Output Contract** with the exact property names and a concrete JSON example. Field-name drift (`type` vs `blockType`) is a prompt bug, not a model bug.
+
+### Harness Retries — a blind retry makes the model repeat the same mistake
+`withRetry` re-sends an identical prompt, so schema violations recur every attempt. `fallbackStructuredOutput` retries internally instead: it appends the bad output as an `AIMessage` plus the compact zod issue list as a **`HumanMessage`** correction, then re-asks (3 attempts). The correction must be a human turn — see the `invalid_request_message_order` rules above.
+Also: native `withStructuredOutput` failures are caught and fall through to the prompt fallback rather than killing the run.
+
+### Harness "The operation timed out." / run hangs
+- Every model+tool call goes through `withSignal()`, which injects `MODEL_CALL_TIMEOUT_MS` (180s, override with `HARNESS_MODEL_TIMEOUT_MS`) so a stuck provider connection can't stall a run. `checkConnection` uses 30s.
+- The tool-execution loop's `model.invoke` must be wrapped in `withRetry` like every other model call — it was the one unretried call, so a single network blip killed the whole run.
+- `isUserInterrupt(error)` returns true for **any** `AbortError`, including provider-side timeouts. Only treat it as a user stop when `abortController.signal.aborted` is also true; otherwise a timeout gets recorded as `interrupted` instead of `failed`.
+
+### Harness Runs Marked `failed` With No Message / after correct output
+1. **No message:** `failRun` used to persist only `status: "failed"` with no `aiResponse`, so the UI showed a bare status. The graph catch now passes `describeFailure(error, lastNode)` — a categorized, user-readable markdown message (structured output / rate limit / auth / context length / timeout / generic) naming the node that failed via `labelForNode`. `lastNode` is tracked from `on_chain_start` events. Non-`Error` rejections go through `errorMessage()` so `{ code: 23 }` doesn't become `[object Object]`.
+2. **Failed right after producing correct output:** LangGraph's default `recursionLimit` is **25**. Each task level costs 3 supersteps (sub-agent → supervisor → orchestrator) plus ~5 for router/verify/planner/taskGenerator/orchestrator, so a 6–7 task sequential build throws `GraphRecursionError` at the very end. `streamConfig` sets `recursionLimit: 100`.
+
+### "OpenAI Compatible" Integration — "Missing credentials. Please pass an apiKey…"
+**Issue:** Selecting the *OpenAI Compatible* AI variant (Ollama, LM Studio, vLLM, LiteLLM) failed the pre-run connection probe with `Missing credentials…set the OPENAI_API_KEY environment variable`.
+**Cause:** That variant maps to provider `openai` (`models/projectConfig.ts`), and local servers need no API key — but the OpenAI SDK refuses to construct without one.
+**Real cause (the one that bites with a valid key too):** the wrapper passed **`openAIApiKey`**. In `@langchain/openai` v1.x, `ChatOpenAI` reads only `fields.apiKey`, `fields.configuration.apiKey`, or `$OPENAI_API_KEY` — `openAIApiKey` is a dead alias on chat models (it still works on `OpenAI()`/`OpenAIEmbeddings`), so the key was silently dropped for every OpenAI-family provider (DeepSeek, Poolside, etc.).
+**Field-name check per SDK (verified in node_modules, not guessed):** `ChatOpenAI` → `apiKey` only. `ChatAnthropic` → `apiKey` (`anthropicApiKey` still aliased; base URL is `anthropicApiUrl`, NOT `baseUrl`). `ChatGoogle`, `ChatMistralAI`, `ChatOpenRouter` → `apiKey`. When bumping a LangChain package, re-check these — the aliases die quietly with no type error.
+**Fix (`models/openai/index.ts`):**
+- `apiKey: this.apiKey || (this.baseUrl ? "not-required" : undefined)` — a placeholder only when a custom `baseUrl` is set; real OpenAI still requires a real key.
+- `supportsStructuredOutput()` returns `false` when `baseUrl` is set. Compatible servers usually reject the `json_schema` response format, so skip the native path and use the prompt fallback instead of burning 3 retries per call.
+
+### Harness Orchestrator — skipped/repeated task levels
+**Issue:** Sub-agents appeared to run twice (e.g. block builder inside block builder) and levels got skipped.
+**Cause:** The orchestrator popped `taskQueue` to pick the next level, so any re-entry into that node consumed a level it never verified. Worse, the supervisor only wrote statuses to `dispatchedTasks[i]`, relying on those being the *same object references* as entries in `tasks` — a fragile aliasing contract across graph state.
+**Fix:**
+- The orchestrator derives the ready level from task statuses + `dependsOnAgentId` (`status === "pending"` and every dependency settled). A `running` task is never dispatched again. `taskQueue` is now informational only.
+- The supervisor writes each verdict into the `tasks` entry **by id** (`setStatus`), not through reference aliasing. A lost write there stalls the build forever.
+
 ---
 
 ## Documentation Writing Rules

--- a/apps/ai-gateway/src/api/v1/harness-conversations/action/dto.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/action/dto.ts
@@ -14,16 +14,22 @@ export const conversationActionEnum = z.enum([
 	"hitl_approve", // no reviews
 	"hitl_review", // reviews required
 	"hitl_reject", // no reviews
+	"sub_artifact_applied", // sub_artifact required; safe to resend
 ]);
 
 export const hitlReviewSchema = z.object({
 	reviews: z.array(z.string()).optional(), // refine with if action is hitl_review
 });
 
+export const subArtifactSchema = z.object({
+	subArtifactId: z.string().min(1),
+});
+
 export const requestBodySchema = z
 	.object({
 		action: conversationActionEnum,
 		hitl_review: hitlReviewSchema.optional(),
+		sub_artifact: subArtifactSchema.optional(),
 	})
 	.refine(
 		(data) => {
@@ -35,6 +41,10 @@ export const requestBodySchema = z
 		{
 			message: "hitl_review is required when action is hitl_review",
 		},
+	)
+	.refine(
+		(data) => data.action !== "sub_artifact_applied" || !!data.sub_artifact,
+		{ message: "sub_artifact is required when action is sub_artifact_applied" },
 	);
 
 export type ConversationActionBody = z.infer<typeof requestBodySchema>;
@@ -44,6 +54,7 @@ export const responseSchema = z.object({
 	pinned: z.boolean().optional(),
 	archived: z.boolean().optional(),
 	updatedAt: z.union([z.string(), z.date()]).optional(),
+	appliedAt: z.union([z.string(), z.date()]).nullish(),
 });
 
 export type ConversationAction = z.infer<typeof conversationActionEnum>;

--- a/apps/ai-gateway/src/api/v1/harness-conversations/action/repository.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/action/repository.ts
@@ -1,5 +1,9 @@
-import { db, agentHarnessConversationsEntity } from "@fluxify/server";
-import { eq } from "drizzle-orm";
+import {
+	db,
+	agentHarnessConversationsEntity,
+	agentHarnessSubArtifactsEntity,
+} from "@fluxify/server";
+import { and, eq } from "drizzle-orm";
 
 export async function setConversationFlags(
 	conversationId: string,
@@ -14,6 +18,29 @@ export async function setConversationFlags(
 			pinned: agentHarnessConversationsEntity.pinned,
 			archived: agentHarnessConversationsEntity.archived,
 			updatedAt: agentHarnessConversationsEntity.updatedAt,
+		});
+	return result;
+}
+
+/** Marks one sub-artifact as applied to the project. Scoped to the conversation
+ *  so a client can't flip another chat's artifact. Idempotent — resending just
+ *  refreshes the timestamp. Returns undefined when the id isn't in this chat. */
+export async function markSubArtifactApplied(
+	conversationId: string,
+	subArtifactId: string,
+) {
+	const [result] = await db
+		.update(agentHarnessSubArtifactsEntity)
+		.set({ appliedAt: new Date() })
+		.where(
+			and(
+				eq(agentHarnessSubArtifactsEntity.id, subArtifactId),
+				eq(agentHarnessSubArtifactsEntity.conversationId, conversationId),
+			),
+		)
+		.returning({
+			id: agentHarnessSubArtifactsEntity.id,
+			appliedAt: agentHarnessSubArtifactsEntity.appliedAt,
 		});
 	return result;
 }

--- a/apps/ai-gateway/src/api/v1/harness-conversations/action/service.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/action/service.ts
@@ -1,5 +1,5 @@
-import { BadRequestError, ConflictError } from "@fluxify/server";
-import { setConversationFlags } from "./repository";
+import { BadRequestError, ConflictError, NotFoundError } from "@fluxify/server";
+import { markSubArtifactApplied, setConversationFlags } from "./repository";
 import { bumpListCacheVersion } from "../cacheVersion";
 import { requestInterrupt } from "../../../../harness/interrupt";
 import { enqueueHarnessContinue } from "../../../../harness/internal/enqueue";
@@ -75,6 +75,16 @@ export default async function handleRequest(
 		const flags = resolveFlags(action, conversation.archived);
 		const result = await setConversationFlags(conversationId, flags);
 		if (conversation.userId) await bumpListCacheVersion(conversation.userId);
+		return result;
+	}
+
+	// Applying a past output to the project is independent of the run lifecycle,
+	// so no status guard — and it can be resent any number of times.
+	if (action === "sub_artifact_applied") {
+		const subArtifactId = body.sub_artifact?.subArtifactId;
+		if (!subArtifactId) throw new BadRequestError("sub_artifact is required");
+		const result = await markSubArtifactApplied(conversationId, subArtifactId);
+		if (!result) throw new NotFoundError("Sub-artifact not found");
 		return result;
 	}
 

--- a/apps/ai-gateway/src/api/v1/harness-conversations/action/tests/action.spec.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/action/tests/action.spec.ts
@@ -7,6 +7,7 @@ import type { ConversationAction } from "../dto";
 
 mock.module("../repository", () => ({
 	setConversationFlags: mock(),
+	markSubArtifactApplied: mock(),
 }));
 
 mock.module("../../cacheVersion", () => ({
@@ -99,5 +100,34 @@ describe("Harness Conversation Action Service", () => {
 		expect(
 			handleRequest("conv1", body("hitl_approve"), conv({ status: "running" })),
 		).rejects.toThrow(serverModule.ConflictError);
+	});
+
+	it("marks a sub-artifact applied whatever the run status, as often as asked", async () => {
+		const markSpy = spyOn(repository, "markSubArtifactApplied").mockResolvedValue({
+			id: "sub1",
+			appliedAt: new Date(),
+		} as never);
+		const applyBody = {
+			action: "sub_artifact_applied" as const,
+			sub_artifact: { subArtifactId: "sub1" },
+		};
+
+		await handleRequest("conv1", applyBody, conv({ status: "running" }));
+		await handleRequest("conv1", applyBody, conv({ status: "running" }));
+
+		expect(markSpy).toHaveBeenCalledTimes(2);
+		expect(markSpy).toHaveBeenCalledWith("conv1", "sub1");
+	});
+
+	it("404s when the sub-artifact is not in this conversation", async () => {
+		spyOn(repository, "markSubArtifactApplied").mockResolvedValue(undefined as never);
+
+		expect(
+			handleRequest(
+				"conv1",
+				{ action: "sub_artifact_applied", sub_artifact: { subArtifactId: "other" } },
+				conv(),
+			),
+		).rejects.toThrow(serverModule.NotFoundError);
 	});
 });

--- a/apps/ai-gateway/src/harness/agents/discussion.ts
+++ b/apps/ai-gateway/src/harness/agents/discussion.ts
@@ -31,9 +31,25 @@ About Fluxify:
 Capabilities & Tools:
 1. "search_docs": Use this tool whenever the user asks about platform features, how a specific block works, or best practices. Pass a highly relevant keyword search query to retrieve documentation chunks.
 2. "get_route_details": Use this tool *only when necessary* if the user asks about the current route (the graph in canvas) they are viewing or working on. 
-3. "find_resource": Use this tool to find tables, databases, or API blocks within the workspace when the user queries about them.
+3. "find_resource": Use this tool to find tables, databases, or API blocks within the workspace when the user queries about them. It also returns a route's or custom block's current canvas (its live block graph) when you pass its id.
+4. "get_artifact": Use this tool whenever the user asks what you built, changed, or implemented in an earlier run of this conversation ("what did you do in that route?", "why did you add that block?"). It returns the exact stored output of a past build.
+
+WHERE ARTIFACT IDS COME FROM:
+Earlier assistant messages in this conversation are build summaries containing tokens like \`:route{type="add" sub_artifact_id="abc123"}\` and \`:canvasChanges{parent_type="route" parent="..." artifact_id="def456"}\`. The \`sub_artifact_id\` / \`artifact_id\` values are the ids to pass to \`get_artifact\`. Copy them verbatim; never invent one. If a summary has no token for the thing being asked about, use \`find_resource\` (route_canvas / custom_block_canvas) to read the workspace's current state instead.
+
+APPLIED VS PROPOSED:
+\`get_artifact\` reports whether an output is applied. That flag is internal — never print it, an id, or any tool field name. Let it shape the words only:
+- applied — it is live in the project; talk about it as something that exists. If the exact live config matters, confirm with \`find_resource\`, since it may have drifted.
+- not applied — it was only proposed. Never imply it exists; say it is still pending and the user applies it from the summary above.
+
+REFERENCING A RESOURCE:
+To point at something, end the sentence with one token instead of quoting ids in prose:
+- \`:resource{type="route|app_config|integration|custom_block" identifier="<db id from find_resource>"}\` — an existing workspace resource.
+- \`:route{type="add|delete|changes" sub_artifact_id="<id>"}\` — a route output from a past run.
+Those two are the only tokens you may write; \`:canvasChanges{...}\` belongs to build summaries, not to you. Format is exact: no space before \`{\`, attributes space-separated, every value double-quoted, ids copied verbatim from a tool result or an earlier summary — never invented. Put the token at the end of a line, at most one per reference, and only when you actually have the id.
 
 CRITICAL INSTRUCTIONS:
+- Prefer \`get_artifact\` over re-reading the summary prose when the user asks about a past change: the summary says what changed, the artifact says exactly how.
 - If the user's query requires knowledge you don't possess, you MUST use the \`search_docs\` tool. Do not hallucinate answers.
 - If the user's query lacks necessary context or details to provide a meaningful answer, fail early by politely asking the user to provide the missing information.
 - If the user asks for actions outside your capabilities (like actually building a route), politely inform them that you are the discussion agent and they should ask to build a route directly.
@@ -75,6 +91,7 @@ Q: "What can I access inside the script block?" -> a lead sentence, then a bulle
 			messages: this.state.messages,
 			userQuery: this.state.userQuery,
 			tools: tools,
+			agentNode: AgentNode.DISCUSSION,
 		});
 
 		let markdownContent =

--- a/apps/ai-gateway/src/harness/agents/orchestrator.spec.ts
+++ b/apps/ai-gateway/src/harness/agents/orchestrator.spec.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "bun:test";
+import { OrchestratorAgent } from "./orchestrator";
+import { AgentNode, type GlobalGraphState, type Task } from "../types";
+
+const task = (id: string, dependsOnAgentId: string[] = []): Task =>
+	({
+		id,
+		title: id,
+		description: id,
+		status: "pending",
+		assignedAgentNode: AgentNode.BLOCK_BUILDER,
+		dependsOnAgentId,
+	}) as Task;
+
+const stateWith = (tasks: Task[]) =>
+	({ orchestratorState: { tasks } }) as unknown as GlobalGraphState;
+
+const dispatch = async (tasks: Task[]) => {
+	const result = await new OrchestratorAgent(stateWith(tasks)).execute();
+	return result.orchestratorState?.dispatchedTasks ?? [];
+};
+
+describe("OrchestratorAgent", () => {
+	it("dispatches only tasks whose dependencies are settled", async () => {
+		const tasks = [task("a"), task("b", ["a"]), task("c")];
+		const dispatched = await dispatch(tasks);
+		expect(dispatched.map((t) => t.id)).toEqual(["a", "c"]);
+	});
+
+	it("dispatches dependents once their parent is done", async () => {
+		const a = task("a");
+		a.status = "completed";
+		const dispatched = await dispatch([a, task("b", ["a"])]);
+		expect(dispatched.map((t) => t.id)).toEqual(["b"]);
+	});
+
+	it("never re-dispatches a task that is already running", async () => {
+		const tasks = [task("a"), task("b")];
+		expect((await dispatch(tasks)).map((t) => t.id)).toEqual(["a", "b"]);
+		// Tasks are now `running`; a second pass must not fan them out again.
+		expect(await dispatch(tasks)).toEqual([]);
+	});
+
+	it("resumes the level whose results the supervisor settled", async () => {
+		const a = task("a");
+		const b = task("b", ["a"]);
+		await dispatch([a, b]); // a -> running
+		a.status = "completed"; // supervisor verdict
+		expect((await dispatch([a, b])).map((t) => t.id)).toEqual(["b"]);
+	});
+
+	it("ends the run when nothing is left to dispatch", async () => {
+		const done = task("a");
+		done.status = "completed";
+		const failed = task("b");
+		failed.status = "failed";
+
+		const result = await new OrchestratorAgent(
+			stateWith([done, failed]),
+		).execute();
+		expect(result.nextRoute).toBeUndefined();
+		expect(result.orchestratorState?.dispatchedTasks).toEqual([]);
+	});
+});

--- a/apps/ai-gateway/src/harness/agents/orchestrator.ts
+++ b/apps/ai-gateway/src/harness/agents/orchestrator.ts
@@ -21,10 +21,27 @@ export class OrchestratorAgent extends BaseAgent {
 			},
 		});
 
-		let tasks = this.state.orchestratorState?.tasks || [];
-		let taskQueue = this.state.orchestratorState?.taskQueue || [];
+		const tasks = this.state.orchestratorState?.tasks || [];
 
-		if (taskQueue.length === 0) {
+		// Readiness is derived from task statuses, never from popping a queue.
+		// A level with N tasks fans out to N sub-agents, so the graph runs N
+		// supervisors and N orchestrators in the following supersteps — a
+		// queue-shifting orchestrator consumed N levels per round, skipping tasks
+		// and dispatching overlapping levels concurrently. Deriving the next level
+		// makes those concurrent runs produce the identical result instead.
+		const byId = new Map(tasks.map((task) => [task.id, task]));
+		const isSettled = (task?: Task) =>
+			task ? task.status === "completed" || task.status === "failed" : true;
+
+		const readyTasks = tasks.filter(
+			(task) =>
+				task.status === "pending" &&
+				(task.dependsOnAgentId ?? []).every((depId) =>
+					isSettled(byId.get(depId)),
+				),
+		);
+
+		if (readyTasks.length === 0) {
 			await dispatchAgentEvent({
 				name: "agent_status",
 				data: {
@@ -38,25 +55,20 @@ export class OrchestratorAgent extends BaseAgent {
 				orchestratorState: {
 					...this.state.orchestratorState,
 					tasks,
-					taskQueue,
+					dispatchedTasks: [],
 				},
 			};
 		}
 
-		// Pop the next level of tasks
-		const nextTaskIds = taskQueue.shift() || [];
 		const nextRoutes: AgentNodeName[] = [];
 		const assignedTaskIds: string[] = [];
 		const dispatchedTasks: Task[] = [];
 
-		for (const nextTaskId of nextTaskIds) {
-			const nextTaskIndex = tasks.findIndex((t) => t.id === nextTaskId);
-			if (nextTaskIndex !== -1) {
-				tasks[nextTaskIndex].status = "running";
-				nextRoutes.push(tasks[nextTaskIndex].assignedAgentNode);
-				assignedTaskIds.push(nextTaskId);
-				dispatchedTasks.push(tasks[nextTaskIndex]);
-			}
+		for (const task of readyTasks) {
+			task.status = "running";
+			nextRoutes.push(task.assignedAgentNode);
+			assignedTaskIds.push(task.id);
+			dispatchedTasks.push(task);
 		}
 
 		let nextRoute: AgentNodeName | AgentNodeName[] | undefined = undefined;
@@ -83,7 +95,6 @@ export class OrchestratorAgent extends BaseAgent {
 			orchestratorState: {
 				...this.state.orchestratorState,
 				tasks,
-				taskQueue,
 				dispatchedTasks,
 			},
 		};

--- a/apps/ai-gateway/src/harness/agents/planner.ts
+++ b/apps/ai-gateway/src/harness/agents/planner.ts
@@ -5,6 +5,7 @@ import { blockAiDescriptions } from "@fluxify/blocks";
 import { z } from "zod";
 import { subAgents } from "./sub-agents";
 import { createFindResourceTool } from "../tools/findResource";
+import { createGetArtifactTool } from "../tools/getArtifact";
 
 function buildSubAgentsTable(): string {
 	if (subAgents.length === 0) {
@@ -38,7 +39,7 @@ const plannerSchema = z.object({
 		),
 	scratchpadNote: z
 		.string()
-		.optional()
+		.nullish()
 		.describe(
 			"Contextual notes, resource IDs, or warnings to pass to downstream sub-agents.",
 		),
@@ -99,9 +100,16 @@ Other blocks may require secrets from **app configs**.
 - If an integration/config is missing based on context, DO NOT reject the request. Instead, add a prominent warning in your \`markdownPlan\` stating that the user must create it.
 
 ## Available Tools
-You have access to the \`find_resource\` tool. You MUST use this tool to search the database for existing resources (e.g., routes, app configs, integrations, custom blocks) relevant to the user's request.
+**\`find_resource\`** — You MUST use this tool to search the database for existing resources (e.g., routes, app configs, integrations, custom blocks) relevant to the user's request.
 - Always search for the exact resource ID if you are modifying, updating, or deleting an existing resource.
 - Store the found resource IDs (e.g., \`routeId\`) and relevant details in the \`scratchpadNote\` so downstream agents have the exact IDs needed to perform their tasks. Do NOT guess IDs.
+
+**\`get_artifact\`** — Reads back what an earlier run in this conversation actually built. Use it whenever the user's request refers to previous work ("change what you just built", "add auth to that route", "undo the block you added") instead of guessing from the summary text.
+- The ids come from tokens inside earlier assistant messages: \`:route{type="add" sub_artifact_id="abc123"}\` and \`:canvasChanges{parent_type="route" parent="..." artifact_id="def456"}\`. Pass the \`sub_artifact_id\` / \`artifact_id\` values verbatim; never invent one. A parent artifact id returns every output of that run.
+- Each result reports \`applied=yes\` or \`applied=no\`. **This changes the plan:**
+  - \`applied=yes\` — the output is live in the project, so it also exists as a real record. Look it up with \`find_resource\` to get its real DB id, reference it with \`:resource{...}\`, and plan a modification of the existing resource.
+  - \`applied=no\` — it was only proposed and does NOT exist in the project. There is no DB id for it, so never emit a \`:resource{...}\` chip for it and never tell the user it already exists; plan it as work still to be created.
+- Put anything downstream agents need from the artifact (target ids, block names, decisions already made) into the \`scratchpadNote\`.
 
 ## Output Instructions
 1. **Markdown Plan (\`markdownPlan\`)**: Create a crystal clear, user-perspective markdown plan.
@@ -120,12 +128,20 @@ You have access to the \`find_resource\` tool. You MUST use this tool to search 
 2. **Scratchpad (\`scratchpadNote\`)**: Accumulate all resource lookup results (IDs, names), internal reasoning, and technical implementation details into the \`scratchpadNote\`. This is appended to the next agent's prompt so they don't have to re-search and know exactly what blocks to use.
 3. **Confidence Score (\`confidenceScore\`)**: 1-5 score indicating if sub-agents can build this without human reviews.
 4. **Implementation Complexity (\`implementationComplexity\`)**: 'high', 'mid', or 'low' based on how complex the system becomes if AI builds it without human reviews.
-5. **Handling Reviews**: If the user is reviewing a plan (check message history), address their concerns and regenerate the plan accordingly.
+5. **Explicit Review Requests**: If the user's own words ask you to draft/propose/show a plan first and NOT build it automatically (e.g. "just give me a plan", "don't implement yet", "let me review it first", "propose a plan for approval"), that request always forces a review — regardless of how simple the task actually is. Set \`confidenceScore\` to 1-2 and \`implementationComplexity\` to at least 'mid' so it halts for human review, even if you'd otherwise be confident enough to build it straight away.
+6. **Handling Reviews**: Check message history for a prior plan and the user's response to it.
+   - **Approval, in any words**: If the user's response is an approval — "approve", "looks good", "start", "go ahead", "do it", or any other phrasing that means "proceed" — treat the existing plan as accepted. Re-emit the same (or only trivially reformatted) \`markdownPlan\` and set \`confidenceScore\` to 5 so it proceeds straight to implementation. Do NOT ask for review again on an already-approved plan.
+   - **Small, simple feedback**: If the feedback is minor (e.g. renaming a field, tweaking a value, a one-line clarification) and does not change the plan's overall complexity or risk, apply it directly, then raise \`confidenceScore\` accordingly — don't keep bouncing a nearly-finished plan back for review over trivial changes.
+   - **Substantial feedback**: If the feedback changes scope, architecture, or introduces real ambiguity, revise the plan fully and score confidence honestly — it's fine to require another review in that case.
 
 Plan carefully, thoroughly, and output excellent English craft for the user's plan.${scratchPadText}`;
 
 		const tools = [
 			createFindResourceTool(
+				this.state.internal.dbService,
+				this.state.internal.metadata || {},
+			),
+			createGetArtifactTool(
 				this.state.internal.dbService,
 				this.state.internal.metadata || {},
 			),
@@ -137,6 +153,7 @@ Plan carefully, thoroughly, and output excellent English craft for the user's pl
 			tools,
 			messages: this.state.messages,
 			userQuery: this.state.userQuery,
+			agentNode: AgentNode.PLANNER,
 		})) as z.infer<typeof plannerSchema>;
 
 		const requiresHITL =

--- a/apps/ai-gateway/src/harness/agents/router.ts
+++ b/apps/ai-gateway/src/harness/agents/router.ts
@@ -56,6 +56,7 @@ CRITICAL INSTRUCTIONS:
 			systemPrompt,
 			messages: this.state.messages,
 			userQuery: this.state.userQuery,
+			agentNode: AgentNode.ROUTER,
 		})) as z.infer<typeof routerSchema>;
 
 		await dispatchAgentEvent({

--- a/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/agent.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/agent.ts
@@ -108,6 +108,7 @@ export class BlockBuilderAgent extends BaseAgent {
 			tools,
 			messages: [],
 			userQuery,
+			agentNode: AgentNode.BLOCK_BUILDER,
 		})) as z.infer<typeof blockBuilderSchema>;
 
 		const shortIdMap = new Map(

--- a/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/promptHelpers.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/promptHelpers.ts
@@ -89,6 +89,33 @@ ${customBlocksTable}
 
 8. **Tools**: Use the 'search_docs' tool to understand specific block capabilities and how to write Javascript expressions. Use 'find_resource' to lookup integrations and existing route/custom block canvas (metadata.isNewRoute=true for new routes). Use 'get_block_schemas' to fetch configuration schemas for any blocks you plan to use. Use 'get_agent_output' to fetch the configuration of a newly created route or custom block from a previous agent's output if it's not yet saved in the DB (the task description will provide the task IDs).
 
+### Output Contract
+
+Use these exact property names — do not rename or omit them:
+
+\`\`\`json
+{
+  "status": "success",
+  "targetType": "route",
+  "targetId": "<route or custom block id>",
+  "blocks": [
+    {
+      "id": "block_1",
+      "blockType": "entrypoint",
+      "blockName": "Entrypoint",
+      "position": { "x": 0, "y": 0 },
+      "data": {},
+      "connections": [{ "blockId": "block_2", "handle": "source" }]
+    }
+  ],
+  "canvasChanges": []
+}
+\`\`\`
+
+- The block's type goes in \`blockType\` (NOT \`type\`).
+- \`connections\` and \`canvasChanges\` are always present — use \`[]\` when empty.
+- Set \`status\` to 'impossible' (with a short \`reasoning\`) only when the canvas genuinely cannot be built.
+
 The orchestrator will apply the configuration after supervisor approval. Keep your reasoning concise.`;
 }
 

--- a/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/schemas.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/schemas.ts
@@ -18,15 +18,15 @@ export const BlockSchema = z.object({
 		.describe("The type/category of the block (e.g., 'http_request')."),
 	blockName: z
 		.string()
-		.optional()
+		.nullish()
 		.describe("Human-readable name for the block instance."),
 	blockDescription: z
 		.string()
-		.optional()
+		.nullish()
 		.describe("Brief description of what this block instance does."),
 	data: z
 		.record(z.string(), z.unknown())
-		.optional()
+		.nullish()
 		.describe("Configuration payload specific to the block type."),
 	position: z
 		.object({
@@ -36,7 +36,10 @@ export const BlockSchema = z.object({
 		.describe("Visual position of the block."),
 	connections: z
 		.array(ConnectionSchema)
-		.describe("List of downstream connections from this block."),
+		.default([])
+		.describe(
+			"List of downstream connections from this block (empty for terminal blocks).",
+		),
 });
 
 export const CanvasChangeSchema = z.discriminatedUnion("type", [
@@ -85,11 +88,16 @@ export const CanvasChangeSchema = z.discriminatedUnion("type", [
 export const blockBuilderSchema = z.object({
 	reasoning: z
 		.string()
-		.optional()
+		.nullish()
 		.describe(
 			"Provide a short reasoning ONLY when status is 'impossible' to explain why construction is impossible. Do not provide reasoning when status is 'success'.",
 		),
-	status: z.enum(["success", "impossible"]),
+	status: z
+		.enum(["success", "impossible"])
+		.default("success")
+		.describe(
+			"'success' when the canvas was built, 'impossible' when it cannot be built.",
+		),
 	targetType: z
 		.enum(["route", "custom_block"])
 		.describe("Whether this canvas belongs to a route or custom block"),
@@ -98,8 +106,14 @@ export const blockBuilderSchema = z.object({
 		.describe("The ID of the route or custom block this canvas belongs to"),
 	canvasChanges: z
 		.array(CanvasChangeSchema)
-		.describe("List of changes for existing canvas items"),
-	blocks: z.array(BlockSchema).describe("New blocks to add to the canvas"),
+		.default([])
+		.describe(
+			"List of changes for existing canvas items (empty when nothing existing changes)",
+		),
+	blocks: z
+		.array(BlockSchema)
+		.default([])
+		.describe("New blocks to add to the canvas"),
 });
 
 export type BlockBuilderResult = z.infer<typeof blockBuilderSchema>;

--- a/apps/ai-gateway/src/harness/agents/sub-agents/routeConfig.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/routeConfig.ts
@@ -12,17 +12,17 @@ const routeConfigSchema = z.object({
 		.describe("The operation to perform"),
 	routeId: z
 		.string()
-		.optional()
+		.nullish()
 		.describe("The UUID of the route. Leave empty for create action."),
 	data: z
 		.object({
-			method: z.string().optional(),
-			path: z.string().optional(),
-			bodySchema: z.any().optional(),
-			paramsSchema: z.any().optional(),
-			querySchema: z.any().optional(),
+			method: z.string().nullish(),
+			path: z.string().nullish(),
+			bodySchema: z.any().nullish(),
+			paramsSchema: z.any().nullish(),
+			querySchema: z.any().nullish(),
 		})
-		.optional()
+		.nullish()
 		.describe("The configuration of the route"),
 });
 
@@ -151,6 +151,7 @@ Determine the exact route configuration intent. Use your tools if you need more 
 			tools,
 			messages: [],
 			userQuery: userQuery,
+			agentNode: AgentNode.ROUTE_CONFIG_AGENT,
 		})) as z.infer<typeof routeConfigSchema>;
 
 		if (response.action === "create" && !response.routeId) {

--- a/apps/ai-gateway/src/harness/agents/summarizer.ts
+++ b/apps/ai-gateway/src/harness/agents/summarizer.ts
@@ -194,6 +194,7 @@ ${hintsText}`;
 			systemPrompt,
 			messages: [],
 			userQuery,
+			agentNode: AgentNode.SUMMARIZER,
 		});
 
 		let markdown =

--- a/apps/ai-gateway/src/harness/agents/supervisor.ts
+++ b/apps/ai-gateway/src/harness/agents/supervisor.ts
@@ -1,5 +1,5 @@
 import { BaseAgent } from "./base";
-import { type GlobalGraphState, AgentNode } from "../types";
+import { type GlobalGraphState, AgentNode, type Task } from "../types";
 import { dispatchAgentEvent } from "../callbacks";
 import { validateAgentOutput as validateRouteConfig } from "./sub-agents/routeConfig";
 import { validateBlockBuilderOutput } from "./sub-agents/blockBuilder";
@@ -25,6 +25,15 @@ export class SupervisorAgent extends BaseAgent {
 
 		let hasErrors = false;
 
+		// Statuses are written to the `tasks` entry by id, not left to the fact that
+		// dispatchedTasks happens to hold the same object references — the
+		// orchestrator only advances when a task's status in `tasks` is settled, so
+		// a lost write here stalls the whole build.
+		const setStatus = (taskId: string, status: Task["status"]) => {
+			const entry = tasks.find((t) => t.id === taskId);
+			if (entry) entry.status = status;
+		};
+
 		for (let i = 0; i < dispatchedTasks.length; i++) {
 			const task = dispatchedTasks[i];
 			// Only verify tasks that are currently running
@@ -34,6 +43,7 @@ export class SupervisorAgent extends BaseAgent {
 
 			if (!result) {
 				dispatchedTasks[i].status = "failed";
+				setStatus(task.id, "failed");
 				scratchpad.push(
 					`[Supervisor Error - Task ${task.id}]: No result provided by agent.`,
 				);
@@ -56,12 +66,14 @@ export class SupervisorAgent extends BaseAgent {
 
 			if (error) {
 				dispatchedTasks[i].status = "failed";
+				setStatus(task.id, "failed");
 				scratchpad.push(
 					`[Supervisor Error - Task ${task.id} (${task.assignedAgentNode})]: ${error}`,
 				);
 				hasErrors = true;
 			} else {
 				dispatchedTasks[i].status = "completed";
+				setStatus(task.id, "completed");
 			}
 		}
 

--- a/apps/ai-gateway/src/harness/agents/taskGenerator.ts
+++ b/apps/ai-gateway/src/harness/agents/taskGenerator.ts
@@ -151,6 +151,7 @@ ${scratchPadText}`;
 			systemPrompt,
 			messages: [], // We only pass the plan to keep it strictly focused
 			userQuery: planText,
+			agentNode: AgentNode.TASK_GENERATOR,
 		})) as z.infer<typeof taskSchema>;
 
 		// Map to our internal state type

--- a/apps/ai-gateway/src/harness/agents/verifyUserQuery.ts
+++ b/apps/ai-gateway/src/harness/agents/verifyUserQuery.ts
@@ -22,13 +22,13 @@ const verifySchema = z.object({
 		),
 	rejectReason: z
 		.string()
-		.optional()
+		.nullish()
 		.describe(
 			"Human-readable reason if rejected. Must be provided if capable is false.",
 		),
 	scratchpad: z
 		.string()
-		.optional()
+		.nullish()
 		.describe(
 			"A scratchpad note for descendant AI agents. Use this to pass important context, warnings, or missing integration info. Fill only if required.",
 		),
@@ -93,6 +93,7 @@ Analyze the request internally. Instead of raw reasoning, provide a 'scratchpad'
 			systemPrompt,
 			messages: this.state.messages,
 			userQuery: this.state.userQuery,
+			agentNode: AgentNode.VERIFY_USER_QUERY,
 		})) as z.infer<typeof verifySchema>;
 
 		await dispatchAgentEvent({
@@ -111,7 +112,7 @@ Analyze the request internally. Instead of raw reasoning, provide a 'scratchpad'
 			nextRoute: response.capable ? AgentNode.PLANNER : undefined,
 			verifyUserQueryState: {
 				capable: response.capable,
-				rejectReason: response.rejectReason,
+				rejectReason: response.rejectReason ?? undefined,
 			},
 			scratchpad: response.scratchpad ? [response.scratchpad] : [],
 		};

--- a/apps/ai-gateway/src/harness/callbacks.ts
+++ b/apps/ai-gateway/src/harness/callbacks.ts
@@ -13,12 +13,15 @@ import {
 	type HarnessPhase,
 	levelForNode,
 	runStatusForNode,
+	labelForNode,
 	buildTasksByLevel,
 	activeLevelIndex,
 } from "./streamTypes";
 import type { HarnessService } from "./internal/harnessService";
 import type { RedisService } from "./internal/redisService";
 import { publishHarnessEvent } from "./notifications";
+import { explainErrorReason } from "./errors";
+import type { RetryWarningInfo } from "./models/base";
 
 export async function dispatchAgentEvent(event: AgentCustomEvent): Promise<void> {
 	await dispatchCustomEvent(event.name, event.data);
@@ -281,5 +284,20 @@ export class HarnessCallbacks {
 				}),
 			);
 		}
+	}
+
+	/** A model call inside an agent hit a retryable error (bad structured
+	 *  output, transient network blip) and is re-asking rather than failing the
+	 *  run outright. Surfaced live so the UI doesn't just look stuck — wired in
+	 *  from `BaseAgentWrapper.setRetryWarningSink` in `FluxifyHarness.executeGraph`. */
+	public emitRetryWarning(info: RetryWarningInfo): void {
+		const node = (info.agentNode as AgentNodeName) ?? AgentNode.ROUTER;
+		if (!GRAPH_NODES.has(node)) return;
+		const reason = explainErrorReason(info.rawError);
+		const status = `${labelForNode(node)} hit a hiccup and is retrying (attempt ${info.attempt}/${info.maxAttempts}) — ${reason}`;
+		this.emit({
+			...this.makeEvent(node, "warning", status),
+			warning: { attempt: info.attempt, maxAttempts: info.maxAttempts },
+		});
 	}
 }

--- a/apps/ai-gateway/src/harness/errors.ts
+++ b/apps/ai-gateway/src/harness/errors.ts
@@ -16,3 +16,55 @@ export function isUserInterrupt(error: unknown): boolean {
 	if (error instanceof UserInterruptError) return true;
 	return error instanceof Error && error.name === "AbortError";
 }
+
+/**
+ * Turns a raw error message into a human-readable explanation, shared by the
+ * terminal failure report (`describeFailure`) and the live retry-warning
+ * events (`HarnessCallbacks.emitRetryWarning`) — both need the same
+ * categorization, just with different framing around it.
+ */
+export function explainErrorReason(raw: string): string {
+	const lower = raw.toLowerCase();
+
+	if (
+		lower.includes("structured output") ||
+		lower.includes("json") ||
+		lower.includes("schema")
+	) {
+		return "the AI model did not return a valid, complete response in the required format. This usually means the model ran out of output space or is not reliable at structured output — try a larger or stronger model, or split the request into smaller steps.";
+	}
+	if (
+		lower.includes("rate limit") ||
+		lower.includes("429") ||
+		lower.includes("quota")
+	) {
+		return "the AI provider rejected the request due to rate limits or exhausted quota. Please wait a moment and try again, or check your provider plan.";
+	}
+	if (
+		lower.includes("401") ||
+		lower.includes("403") ||
+		lower.includes("unauthorized") ||
+		lower.includes("api key")
+	) {
+		return "the AI provider rejected the credentials for this integration. Please check the API key and model configured for this project.";
+	}
+	if (
+		lower.includes("context length") ||
+		lower.includes("too many tokens") ||
+		lower.includes("maximum context")
+	) {
+		return "the request grew larger than the model's context window. Try a model with a bigger context window, or a narrower request.";
+	}
+	if (
+		lower.includes("timeout") ||
+		lower.includes("timed out") ||
+		lower.includes("etimedout") ||
+		lower.includes("econnreset") ||
+		lower.includes("socket") ||
+		lower.includes("fetch failed") ||
+		lower.includes("network")
+	) {
+		return "the AI provider took too long to respond or could not be reached. This request involved a lot of back-and-forth with the model — try again, or use a faster model.";
+	}
+	return "an unexpected error occurred while processing this request.";
+}

--- a/apps/ai-gateway/src/harness/graph.ts
+++ b/apps/ai-gateway/src/harness/graph.ts
@@ -59,7 +59,21 @@ const workflow = new StateGraph(GraphState)
 		const agent = new SummarizerAgent(state);
 		return await agent.execute();
 	})
-	.addEdge(START, AgentNode.ROUTER)
+	// A HITL resume skips the parts of the cycle the decision already settled:
+	// `approve` needs no re-planning or re-verification — it goes straight to
+	// breaking the (already-approved) plan into tasks. `review` only needs a
+	// fresh capability check against the revised ask before planning again.
+	// `reject` never reaches here — the harness short-circuits it before
+	// invoking the graph at all (see FluxifyHarness.continue).
+	.addConditionalEdges(START, (state: GlobalGraphState) => {
+		if (state.action?.type === "approve") {
+			return AgentNode.TASK_GENERATOR;
+		}
+		if (state.action?.type === "review") {
+			return AgentNode.VERIFY_USER_QUERY;
+		}
+		return AgentNode.ROUTER;
+	})
 	.addConditionalEdges(AgentNode.ROUTER, (state: GlobalGraphState) => {
 		if (state.nextRoute === AgentNode.VERIFY_USER_QUERY) {
 			return AgentNode.VERIFY_USER_QUERY;

--- a/apps/ai-gateway/src/harness/harness-client-implementation-guide.md
+++ b/apps/ai-gateway/src/harness/harness-client-implementation-guide.md
@@ -113,8 +113,11 @@ These mirror the server types exactly. Treat them as the wire schema.
 /** Which tier produced the event. */
 type HarnessLevel = "harness" | "sub_agent";
 
-/** Lifecycle phase of a single event. */
-type HarnessPhase = "node_start" | "node_end" | "status" | "hitl_required";
+/** Lifecycle phase of a single event. `warning` is non-terminal: the agent
+ *  named in `node` hit a retryable error (bad structured output, a transient
+ *  network blip) and is re-asking the model — it does not fail the run, and
+ *  `runStatus` stays whatever that agent was already doing. */
+type HarnessPhase = "node_start" | "node_end" | "status" | "hitl_required" | "warning";
 
 /** Overall run status (mirrors the DB run status). */
 type HarnessRunStatus =
@@ -140,13 +143,14 @@ interface HarnessTaskView {
 interface HarnessStreamEvent {
   conversationId: string;
   runId: string;
-  stepId?: string;          // present for node_start/node_end; absent for most status events
+  stepId?: string;          // present for node_start/node_end; absent for most status/warning events
   level: HarnessLevel;
   phase: HarnessPhase;
   node: AgentNodeName;
   status: string;           // human-readable label, e.g. "Running planner"
   runStatus: HarnessRunStatus;
   payload?: HarnessNodePayload; // present mainly on node_end / hitl_required
+  warning?: { attempt: number; maxAttempts: number }; // present only on phase "warning"
   timestamp: number;        // epoch ms — USE THIS for ordering/merge (see §5)
 }
 
@@ -224,6 +228,45 @@ status     <node>          runStatus: completed        ← TERMINAL
 `event.runStatus ∈ { "completed", "failed", "awaiting_hitl" }`. After this, no
 more updates arrive for that run.
 
+**A `warning` event can appear between any `node_start`/`node_end` pair.** It
+means the agent named in `node` hit a retryable error (bad structured output,
+a transient network blip) and is re-asking the model — it is **not**
+terminal, does not change `runStatus`, and the same node's `node_end` still
+follows once the retry succeeds (or the run eventually fails if every retry
+is exhausted):
+
+```
+node_start planner        (planning)
+warning    planner        "Planner hit a hiccup and is retrying (attempt 1/3) — ..."
+warning    planner        "Planner hit a hiccup and is retrying (attempt 2/3) — ..."
+node_end   planner        payload.planner       (markdownPlan)
+```
+
+Render it as a transient inline notice on the step (e.g. "retrying…") — don't
+treat it as an error state for the step, and don't clear it only on the next
+`warning`; clear it on that step's `node_end` (or its absence entirely is the
+common case — most retries never need to be shown because they succeed within
+milliseconds).
+
+**HITL resume (`approve`/`review`) skips part of the cycle — see §4.1.**
+
+### 4.1 HITL resume shortcuts
+
+When the user responds to a paused plan, the resumed run does **not** always
+restart from `router`:
+
+| Decision | Entry point | What you'll see |
+| --- | --- | --- |
+| `hitl_approve` | `taskGenerator` | An immediate `status` event on `taskGenerator` (`runStatus: orchestrating`), then straight into the `taskGenerator` → `orchestrator` → sub-agents → `summarizer` sequence. No `router`/`verifyUserQuery`/`planner` events at all for this pass. |
+| `hitl_review` | `verifyUserQuery` | An immediate `status` event on `verifyUserQuery` (`runStatus: verifying`), then `verifyUserQuery` → `planner` → (park again, or continue) as usual. No `router` event. |
+| `hitl_reject` | *(none)* | The graph never runs. You get a single terminal `status` event with `runStatus: completed` and the run's `aiResponse` is a structured "Plan rejected" message — no `node_start`/`node_end` events precede it. |
+
+The explicit `status` event on resume exists specifically so you have a
+reliable "the run is moving again" signal even though the usual first
+`node_start` (router/verify) you'd wait for may never come for this pass —
+don't gate your "resumed" UI transition on seeing `router` or `verifyUserQuery`
+start; gate it on `runStatus` leaving `awaiting_hitl`/`paused_hitl`.
+
 - `stepId` is **stable across `node_start` → `node_end`** for the same step
   (it's an upsert). Use it to update a step in place.
 - Sub-agent steps (`level: "sub_agent"`, nodes `blockBuilder`/`routeConfig`) can run
@@ -249,6 +292,9 @@ interface ConversationUIState {
   plan?: string;                          // planner.markdownPlan
   summary?: string;                       // summarizer.markdown
   hitl?: { reason: string; markdownPlan?: string };
+  /** Transient — set on a `warning` event, cleared once that node's `node_end`
+   *  arrives (the retry succeeded) or a new node starts. */
+  warning?: { node: AgentNodeName; message: string; attempt: number; maxAttempts: number };
 }
 
 interface StepUIState {
@@ -281,7 +327,15 @@ function applyEvent(state: ConversationUIState, e: HarnessStreamEvent): Conversa
       (e.runStatus === "completed" || e.runStatus === "failed" || e.runStatus === "awaiting_hitl");
   }
 
-  // 2) Step upsert keyed by stepId (node_start/node_end share the stepId).
+  // 2) Warning: transient, keyed by node, cleared on that node's next
+  //    node_start/node_end (the retry resolved one way or the other).
+  if (e.phase === "warning" && e.warning) {
+    next.warning = { node: e.node, message: e.status, ...e.warning };
+  } else if ((e.phase === "node_start" || e.phase === "node_end") && next.warning?.node === e.node) {
+    next.warning = undefined;
+  }
+
+  // 3) Step upsert keyed by stepId (node_start/node_end share the stepId).
   if (e.stepId) {
     const prev = next.steps[e.stepId];
     // don't let an older node_start overwrite a newer node_end
@@ -301,7 +355,7 @@ function applyEvent(state: ConversationUIState, e: HarnessStreamEvent): Conversa
     }
   }
 
-  // 3) Payload-driven fields — REPLACE (tasksByLevel is a full recompute).
+  // 4) Payload-driven fields — REPLACE (tasksByLevel is a full recompute).
   switch (e.payload?.node) {
     case "taskGenerator":
     case "supervisor":
@@ -413,11 +467,14 @@ DAG. Merging arrays produces duplicate/stale tasks.
 
 ### 6.10 HITL is terminal-but-resumable
 `awaiting_hitl` ends the current run pass. The run resumes later as a **new job**
-(and may reuse the run id) — you'll receive fresh `node_start`s again after the
-user submits their decision via the REST API.
+(and may reuse the run id) — you'll receive fresh events again after the user
+submits their decision via the REST API, but **don't assume the first one is
+`router`** — `approve`/`review` skip ahead (§4.1); `reject` produces no
+`node_start` at all, only a terminal `status`.
 - **Fix:** render the `humanInTheLoop` payload (reason + `markdownPlan`) and
   treat `awaiting_hitl` as "paused, waiting on user", not "done". Clear the
-  `hitl` block when new non-HITL events arrive.
+  `hitl` block when new non-HITL events arrive. Gate your "resumed" transition
+  on `runStatus` changing, not on seeing a specific node start.
 
 ### 6.11 React StrictMode / effect cleanup double-connects
 In dev, `useEffect` runs twice; without cleanup you open two sockets and get
@@ -437,6 +494,23 @@ Within one connection socket.io preserves emit order. Across a
 disconnect/reconnect that guarantee is gone (see 6.3/6.4).
 - **Fix:** the `timestamp` guard in the reducer is the ordering source of truth,
   not arrival order.
+
+### 6.14 `warning` events are noise unless you render them deliberately
+A `phase: "warning"` event does not mean anything failed — the agent named in
+`node` is retrying a bad response and will very likely recover on its own
+within a second or two (§4). If you log every socket event to a raw feed,
+warnings will show up there; that's fine. But don't:
+- treat it as a step failure (the step's `StepUIState.status` stays `"running"`;
+  don't flip it to anything error-like),
+- toast/alert on every one (a model can legitimately retry 2-3 times on a
+  single step under normal load — that's not exceptional),
+- leave it showing forever if the step actually did fail — that's what the
+  step's `node_end` never arriving, plus the run's own terminal `failed`
+  status, is for. `warning` is "still working on it", not "here's the error".
+- **Fix:** render it as a small transient inline note next to the step (e.g.
+  "retrying…"), cleared by the reducer's own logic once `node_end` arrives for
+  the same node (§5 step 2). Most users will never see one — it only shows up
+  when a step needed more than one attempt.
 
 ---
 
@@ -488,4 +562,6 @@ the idempotent, timestamp-guarded `applyEvent` from §5.
 - [ ] `tasksByLevel` replaced wholesale.
 - [ ] Terminal runs persisted client-side (survive the 60s snapshot eviction).
 - [ ] Socket disconnected on unmount; single listener; functional dispatch.
+- [ ] `warning` events rendered as a transient per-step notice, not an error state (§6.14).
+- [ ] "Resumed" UI transition keyed off `runStatus`, not off a specific node starting (§4.1, §6.10).
 ```

--- a/apps/ai-gateway/src/harness/index.ts
+++ b/apps/ai-gateway/src/harness/index.ts
@@ -30,17 +30,76 @@ import { FluxifyOtelTracer } from "./telemetry/otel-tracer";
 import { HarnessCallbacks } from "./callbacks";
 import {
 	levelForNode,
+	labelForNode,
+	runStatusForNode,
 	type HarnessRunStatus,
 	type HarnessStreamEvent,
 } from "./streamTypes";
 import { publishHarnessEvent } from "./notifications";
-import { isUserInterrupt } from "./errors";
+import { isUserInterrupt, explainErrorReason } from "./errors";
 import {
 	registerRunController,
 	unregisterRunController,
 	requestInterrupt,
 } from "./interrupt";
 import type { HarnessJobData, HarnessJobMetadata } from "./queue";
+
+/**
+ * Best-effort message for anything thrown. Provider SDKs sometimes reject with
+ * plain objects (`{ code: 23, ... }`) whose `String()` is "[object Object]".
+ */
+function errorMessage(error: unknown): string {
+	if (error instanceof Error) return error.message || error.name;
+	if (typeof error === "string") return error;
+	if (error && typeof error === "object") {
+		const e = error as Record<string, any>;
+		const parts = [e.message, e.error?.message, e.code, e.name].filter(
+			(p) => typeof p === "string" && p.length > 0,
+		);
+		if (parts.length > 0) return parts.join(" ");
+		try {
+			return JSON.stringify(error).slice(0, 500);
+		} catch {
+			return "Unknown error";
+		}
+	}
+	return String(error ?? "Unknown error");
+}
+
+/**
+ * Turns a thrown error into a short, user-readable explanation of why the run
+ * failed. Persisted as the run's `aiResponse` so the UI shows something more
+ * useful than a bare `failed` status.
+ */
+export function describeFailure(error: unknown, node?: AgentNodeName): string {
+	const raw = errorMessage(error);
+	const where = labelForNode(node);
+	const reason = explainErrorReason(raw);
+
+	return `This request could not be completed — it failed at the **${where}** step because ${reason}\n\nDetails: ${raw.slice(0, 500)}`;
+}
+
+/** Turns a HITL decision into the human turn the router/planner actually read
+ *  ("check message history" per the planner prompt) — `state.action` itself is
+ *  never inspected by any graph node, so this is the only path review
+ *  comments have into the model. */
+function describeHitlAction(action: HitlPlanAction): string | undefined {
+	switch (action.type) {
+		case "approve":
+			return "I approve this plan. Proceed with implementation.";
+		case "reject":
+			return `I reject this plan.${action.message ? ` Reason: ${action.message}` : ""}`;
+		case "review": {
+			if (!action.comments?.length) return undefined;
+			const comments = action.comments.map((c) =>
+				typeof c === "string" ? c : c.text,
+			);
+			return `Please revise the plan based on my feedback:\n${comments.map((c) => `- ${c}`).join("\n")}`;
+		}
+		default:
+			return undefined;
+	}
+}
 
 /** Everything a single harness run needs — supplied by the worker from job data. */
 export interface HarnessRunContext {
@@ -75,8 +134,53 @@ export class FluxifyHarness {
 	}
 
 	public async continue(ctx: HarnessRunContext) {
+		// `reject` throws the plan away outright — there's nothing left for the
+		// graph to do, so skip it entirely instead of paying for a router/verify/
+		// planner cycle just to land back on the same rejected plan.
+		if (ctx.action?.type === "reject") {
+			return await this.rejectRun(ctx, ctx.action);
+		}
 		const state = await this.buildState(ctx, "continue");
 		return await this.executeGraph(ctx, state);
+	}
+
+	/** Persists a rejected HITL plan as a completed (non-implemented) run,
+	 *  without invoking the graph. */
+	private async rejectRun(
+		ctx: HarnessRunContext,
+		action: Extract<HitlPlanAction, { type: "reject" }>,
+	) {
+		const harnessService = new HarnessService(ctx.conversationId);
+		const userId = await harnessService.getOwnerUserId();
+		const aiResponse = `**Plan rejected.** ${
+			action.message
+				? `Reason: ${action.message}`
+				: "No reason was provided."
+		} This plan will not be implemented — send a new message to start over.`;
+
+		await harnessService.updateRun({
+			runId: ctx.runId,
+			status: "completed",
+			aiResponse,
+			completedAt: new Date(),
+		});
+		await harnessService.saveLiveState({
+			runId: ctx.runId,
+			conversationId: ctx.conversationId,
+			currentState: "completed",
+			workingMemory: {},
+		});
+		await harnessService.updateConversationStatus("completed", null);
+		await this.redisService.clearActiveRun(ctx.conversationId);
+		await this.emitTerminal(
+			ctx,
+			userId,
+			"completed",
+			AgentNode.HUMAN_IN_THE_LOOP,
+			aiResponse,
+		);
+		await this.redisService.finalizeSnapshot(ctx.runId);
+		return undefined;
 	}
 
 	// Load previous messages from DB using HarnessService
@@ -96,13 +200,16 @@ export class FluxifyHarness {
 		const messages = await harnessService.getConversationMessageHistory();
 		if (ctx.query) {
 			messages.push(new HumanMessage(ctx.query));
+		} else if (mode === "continue" && ctx.action) {
+			const decision = describeHitlAction(ctx.action);
+			if (decision) messages.push(new HumanMessage(decision));
 		}
 
 		// On resume, rehydrate the serializable working-memory slices persisted
 		// when the run parked at HITL.
 		const workingMemory =
 			mode === "continue"
-				? (await harnessService.loadWorkingMemory(ctx.runId)) ?? {}
+				? ((await harnessService.loadWorkingMemory(ctx.runId)) ?? {})
 				: {};
 
 		return {
@@ -162,6 +269,12 @@ export class FluxifyHarness {
 		// aborting it raises UserInterruptError out of the graph (caught below).
 		const abortController = new AbortController();
 		state.agentWrapper?.setAbortSignal(abortController.signal);
+		// Surfaces retryable model errors (bad structured output, transient
+		// network issues) as live "warning" events instead of only finding out
+		// when the run eventually finishes or fails.
+		state.agentWrapper?.setRetryWarningSink((info) =>
+			callbacks.emitRetryWarning(info),
+		);
 		registerRunController(ctx.conversationId, abortController);
 
 		// Attach the OTEL tracer as a run callback (app.invoke used to pass this;
@@ -170,11 +283,42 @@ export class FluxifyHarness {
 			version: "v2",
 			callbacks: [new FluxifyOtelTracer()],
 			signal: abortController.signal,
+			// Each task level costs 3 supersteps (sub-agent -> supervisor ->
+			// orchestrator), so LangGraph's default of 25 fails a perfectly healthy
+			// multi-task build right after it produced correct output.
+			recursionLimit: 100,
 		};
 		let finalState: Partial<GlobalGraphState> | undefined;
+		// Last node the graph entered — the one to blame if the run throws.
+		let lastNode: AgentNodeName | undefined;
 
 		try {
-			await harnessService.updateRun({ runId: ctx.runId, status: "routing" }, true);
+			await harnessService.updateRun(
+				{ runId: ctx.runId, status: "routing" },
+				true,
+			);
+			await harnessService.updateConversationStatus("running", ctx.runId);
+
+			// A HITL `approve`/`review` resume enters the graph past the router (and
+			// past verify, for `approve`) — see graph.ts's conditional START edge. The
+			// WS client's first signal that the run is moving would otherwise be
+			// whatever node it happens to land on, which is easy to lose (a single
+			// event racing the client's resubscribe right after it submitted the
+			// review). Emit an explicit status event for the actual entry node right
+			// away so the UI can't miss the resume.
+			if (state.action?.type === "approve" || state.action?.type === "review") {
+				const entryNode =
+					state.action.type === "approve"
+						? AgentNode.TASK_GENERATOR
+						: AgentNode.VERIFY_USER_QUERY;
+				await this.emitTerminal(
+					ctx,
+					userId,
+					runStatusForNode(entryNode),
+					entryNode,
+					`Resuming — ${labelForNode(entryNode)}`,
+				);
+			}
 
 			await withFluxifyContext(
 				{
@@ -197,12 +341,16 @@ export class FluxifyHarness {
 							event.event === "on_chain_start" &&
 							event.name !== "LangGraph"
 						) {
+							lastNode = event.name as AgentNodeName;
 							await callbacks.onBefore(event.name as AgentNodeName, event.data);
 						} else if (event.event === "on_chain_end") {
 							if (event.name === "LangGraph") {
 								finalState = event.data.output as Partial<GlobalGraphState>;
 							} else {
-								await callbacks.onAfter(event.name as AgentNodeName, event.data);
+								await callbacks.onAfter(
+									event.name as AgentNodeName,
+									event.data,
+								);
 							}
 						}
 					}
@@ -216,7 +364,10 @@ export class FluxifyHarness {
 
 			// User interrupt is a clean terminal, not a failure — finalize as
 			// `interrupted` and don't rethrow (so BullMQ doesn't retry the job).
-			if (isUserInterrupt(error)) {
+			// A bare AbortError only means "interrupted" if this run's controller
+			// actually fired — provider-side timeouts abort too, and those are
+			// failures, not user stops.
+			if (isUserInterrupt(error) && abortController.signal.aborted) {
 				logger.info("[FluxifyHarness] Run interrupted by user", {
 					conversationId: ctx.conversationId,
 					runId: ctx.runId,
@@ -232,7 +383,14 @@ export class FluxifyHarness {
 			});
 			// Raw dump so the underlying stack is visible in foreground runs.
 			logger.error("Graph error", "FluxifyHarness", { error });
-			await this.failRun(ctx, harnessService, userId, error);
+			await this.failRun(
+				ctx,
+				harnessService,
+				userId,
+				error,
+				describeFailure(error, lastNode),
+				lastNode,
+			);
 			throw error;
 		} finally {
 			unregisterRunController(ctx.conversationId);
@@ -272,7 +430,12 @@ export class FluxifyHarness {
 				graphState: finalState,
 			});
 			await harnessService.updateConversationStatus("paused_hitl", ctx.runId);
-			await this.emitTerminal(ctx, userId, "awaiting_hitl", AgentNode.HUMAN_IN_THE_LOOP);
+			await this.emitTerminal(
+				ctx,
+				userId,
+				"awaiting_hitl",
+				AgentNode.HUMAN_IN_THE_LOOP,
+			);
 			// HITL is terminal for this run pass — evict its live-state snapshot soon.
 			await this.redisService.finalizeSnapshot(ctx.runId);
 			logger.info("[FluxifyHarness] Run parked for HITL", {
@@ -333,6 +496,7 @@ export class FluxifyHarness {
 		userId: string | null,
 		error?: unknown,
 		aiResponse?: string,
+		node: AgentNodeName = AgentNode.ROUTER,
 	) {
 		const message =
 			error instanceof Error ? error.message : error ? String(error) : "failed";
@@ -350,7 +514,7 @@ export class FluxifyHarness {
 			});
 			await harnessService.updateConversationStatus("failed", null);
 			await this.redisService.clearActiveRun(ctx.conversationId);
-			await this.emitTerminal(ctx, userId, "failed", AgentNode.ROUTER, message);
+			await this.emitTerminal(ctx, userId, "failed", node, message);
 			await this.redisService.finalizeSnapshot(ctx.runId);
 		} catch (e) {
 			logger.error("[FluxifyHarness] Error persisting run failure", {
@@ -376,7 +540,8 @@ export class FluxifyHarness {
 		harnessService: HarnessService,
 		userId: string | null,
 	) {
-		const message = "This run was stopped by the user before it finished.";
+		const message =
+			"Conversation was interrupted by the user before it finished.";
 		try {
 			await harnessService.updateRun({
 				runId: ctx.runId,
@@ -392,7 +557,13 @@ export class FluxifyHarness {
 			});
 			await harnessService.updateConversationStatus("interrupted", null);
 			await this.redisService.clearActiveRun(ctx.conversationId);
-			await this.emitTerminal(ctx, userId, "interrupted", AgentNode.ROUTER, message);
+			await this.emitTerminal(
+				ctx,
+				userId,
+				"interrupted",
+				AgentNode.ROUTER,
+				message,
+			);
 			await this.redisService.finalizeSnapshot(ctx.runId);
 		} catch (e) {
 			logger.error("[FluxifyHarness] Error persisting run interrupt", {

--- a/apps/ai-gateway/src/harness/internal/dbService.ts
+++ b/apps/ai-gateway/src/harness/internal/dbService.ts
@@ -7,6 +7,7 @@ import {
 	blocksEntity,
 	edgesEntity,
 	customBlockGraphsEntity,
+	agentHarnessSubArtifactsEntity,
 } from "@fluxify/server";
 import { eq, ilike, or, and, sql, inArray, type SQL } from "drizzle-orm";
 import { logger } from "@fluxify/common";
@@ -17,6 +18,18 @@ import { FindResourceResult } from "../types";
  * agent can pass multiple terms in one call instead of retrying per keyword.
  */
 export type SearchInput = string | string[];
+
+export interface SubArtifactRecord {
+	id: string;
+	artifactId: string;
+	runId: string;
+	kind: string;
+	action: string | null;
+	/** Null until the user applies this output to the project. */
+	appliedAt: Date | null;
+	payload: Record<string, any>;
+	createdAt: Date;
+}
 
 export class DbService {
 	constructor() {}
@@ -274,6 +287,49 @@ export class DbService {
 				error: e,
 			});
 			return null;
+		}
+	}
+
+	/**
+	 * Fetches persisted sub-agent outputs (sub-artifacts) from past runs.
+	 * `ids` may be sub-artifact ids (the ones embedded in summary tokens) or a
+	 * parent artifact id, in which case all its children are returned. Always
+	 * scoped to the conversation so one chat can never read another's artifacts.
+	 */
+	async getSubArtifacts(
+		conversationId: string,
+		ids: string[],
+	): Promise<SubArtifactRecord[]> {
+		try {
+			const clean = this.normalizeKeywords(ids);
+			// No conversation scope => never widen the query, just return nothing.
+			if (!conversationId || clean.length === 0) return [];
+
+			return await db
+				.select({
+					id: agentHarnessSubArtifactsEntity.id,
+					artifactId: agentHarnessSubArtifactsEntity.artifactId,
+					runId: agentHarnessSubArtifactsEntity.runId,
+					kind: agentHarnessSubArtifactsEntity.kind,
+					action: agentHarnessSubArtifactsEntity.action,
+					appliedAt: agentHarnessSubArtifactsEntity.appliedAt,
+					payload: agentHarnessSubArtifactsEntity.payload,
+					createdAt: agentHarnessSubArtifactsEntity.createdAt,
+				})
+				.from(agentHarnessSubArtifactsEntity)
+				.where(
+					and(
+						eq(agentHarnessSubArtifactsEntity.conversationId, conversationId),
+						or(
+							inArray(agentHarnessSubArtifactsEntity.id, clean),
+							inArray(agentHarnessSubArtifactsEntity.artifactId, clean),
+						),
+					),
+				)
+				.limit(20);
+		} catch (e) {
+			logger.error("[DbService] Error getting sub-artifacts", { error: e });
+			return [];
 		}
 	}
 

--- a/apps/ai-gateway/src/harness/models/anthropic/index.ts
+++ b/apps/ai-gateway/src/harness/models/anthropic/index.ts
@@ -19,7 +19,8 @@ export class AnthropicAgentWrapper extends BaseAgentWrapper {
 	protected getModel(): BaseChatModel {
 		return new ChatAnthropic({
 			model: this.modelName,
-			anthropicApiKey: this.apiKey,
+			// `apiKey` is the canonical field; `anthropicApiKey` is a legacy alias.
+			apiKey: this.apiKey,
 			anthropicApiUrl: this.baseUrl,
 			clientOptions: {
 				defaultHeaders: this.additionalHeaders,

--- a/apps/ai-gateway/src/harness/models/base.spec.ts
+++ b/apps/ai-gateway/src/harness/models/base.spec.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "bun:test";
+import { z } from "zod";
+import { BaseChatModel } from "@langchain/core/language_models/chat_models";
+import type { BaseMessage } from "@langchain/core/messages";
+import { BaseAgentWrapper } from "./base";
+import { OpenAIAgentWrapper } from "./openai";
+import { describeFailure } from "../index";
+import { AgentNode } from "../types";
+
+const schema = z.object({ blocks: z.array(z.string()) });
+
+/** Exposes the protected fallback path and lets a test supply a canned response. */
+class TestWrapper extends BaseAgentWrapper {
+	protected getModel(): BaseChatModel {
+		throw new Error("not used");
+	}
+
+	parse(content: unknown, additional_kwargs: Record<string, any> = {}) {
+		const model = { invoke: async () => ({ content, additional_kwargs }) } as any;
+		return this.fallbackStructuredOutput(model, [], schema);
+	}
+
+	/** Replays `responses` one per attempt, recording what each attempt was sent. */
+	parseSequence(responses: string[]) {
+		const seen: BaseMessage[][] = [];
+		let i = 0;
+		const model = {
+			invoke: async (messages: BaseMessage[]) => {
+				seen.push(messages);
+				return { content: responses[Math.min(i++, responses.length - 1)] };
+			},
+		} as any;
+		return { result: this.fallbackStructuredOutput(model, [], schema), seen };
+	}
+}
+
+describe("fallbackStructuredOutput", () => {
+	const wrapper = new TestWrapper("test-model");
+
+	it("parses fenced JSON with surrounding prose", async () => {
+		const result = await wrapper.parse(
+			'Sure! Here is the plan:\n```json\n{"blocks":["a"]}\n```\nHope that helps.',
+		);
+		expect(result).toEqual({ blocks: ["a"] });
+	});
+
+	it("parses JSON wrapped in prose without a code fence", async () => {
+		const result = await wrapper.parse('Here you go: {"blocks":["a","b"]} done.');
+		expect(result).toEqual({ blocks: ["a", "b"] });
+	});
+
+	it("flattens array content blocks", async () => {
+		const result = await wrapper.parse([
+			{ type: "thinking", thinking: "hmm" },
+			{ type: "text", text: '{"blocks":[]}' },
+		]);
+		expect(result).toEqual({ blocks: [] });
+	});
+
+	it("reports empty responses instead of crashing on JSON.parse", async () => {
+		expect(wrapper.parse("")).rejects.toThrow(/empty response/i);
+	});
+
+	it("re-asks with the validation error and accepts the corrected answer", async () => {
+		const { result, seen } = wrapper.parseSequence([
+			'{"blocks":[{"wrong":1}]}',
+			'{"blocks":["a"]}',
+		]);
+		expect(await result).toEqual({ blocks: ["a"] });
+
+		// Second attempt carries the correction, and ends on a human turn so
+		// providers like Mistral don't reject the request.
+		const retryMessages = seen[1];
+		expect(retryMessages.length).toBeGreaterThan(seen[0].length);
+		expect(retryMessages.at(-1)!.getType()).toBe("human");
+		expect(retryMessages.at(-1)!.content).toContain("blocks.0");
+	});
+
+	it("gives up after the attempt budget with the last validation error", async () => {
+		const { result, seen } = wrapper.parseSequence(['{"blocks":[1]}']);
+		expect(result).rejects.toThrow(/after 3 attempts/);
+		await result.catch(() => {});
+		expect(seen.length).toBe(3);
+	});
+});
+
+describe("OpenAIAgentWrapper", () => {
+	class Probe extends OpenAIAgentWrapper {
+		build() {
+			return this.getModel();
+		}
+		usesNativeStructuredOutput() {
+			return this.supportsStructuredOutput();
+		}
+	}
+
+	it("passes the API key through to the client", () => {
+		// ChatOpenAI reads `apiKey` only — the `openAIApiKey` alias is dropped on
+		// chat models, which silently produced "Missing credentials".
+		const model = new Probe("deepseek-chat", "sk-live", undefined, "https://api.deepseek.com").build();
+		expect((model as any).apiKey).toBe("sk-live");
+	});
+
+	it("builds against a keyless OpenAI-compatible endpoint", () => {
+		const wrapper = new Probe(
+			"llama3",
+			undefined,
+			undefined,
+			"http://localhost:11434/v1",
+		);
+		expect(() => wrapper.build()).not.toThrow();
+		expect(wrapper.usesNativeStructuredOutput()).toBe(false);
+	});
+
+	it("still uses native structured output for OpenAI itself", () => {
+		expect(
+			new Probe("gpt-4o", "sk-test").usesNativeStructuredOutput(),
+		).toBe(true);
+	});
+});
+
+describe("describeFailure", () => {
+	it("names the failing node and explains structured-output failures", () => {
+		const msg = describeFailure(
+			new Error("Failed to parse structured output. Model response: ."),
+			AgentNode.BLOCK_BUILDER,
+		);
+		expect(msg).toContain("block builder");
+		expect(msg).toContain("required format");
+	});
+
+	it("explains provider timeouts", () => {
+		const msg = describeFailure(
+			new DOMException("The operation timed out.", "TimeoutError"),
+			AgentNode.BLOCK_BUILDER,
+		);
+		expect(msg).toContain("took too long");
+	});
+
+	it("reads a message out of non-Error rejections", () => {
+		expect(describeFailure({ code: "ETIMEDOUT" })).toContain("ETIMEDOUT");
+	});
+
+	it("falls back to a generic explanation", () => {
+		expect(describeFailure(new Error("boom"))).toContain("unexpected error");
+	});
+});

--- a/apps/ai-gateway/src/harness/models/base.ts
+++ b/apps/ai-gateway/src/harness/models/base.ts
@@ -10,8 +10,16 @@ import { Runnable, RunnableConfig } from "@langchain/core/runnables";
 import { StructuredTool } from "@langchain/core/tools";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
+import { logger } from "@fluxify/common";
 import { withRetry } from "../../lib/retry";
 import { UserInterruptError } from "../errors";
+
+/** Upper bound for a single model/tool call. Long enough for big reasoning
+ *  responses, short enough that a dead connection doesn't stall a run. */
+export const MODEL_CALL_TIMEOUT_MS = 180_000; // 3 minutes
+
+/** How many times the prompt-based structured-output path re-asks the model. */
+const STRUCTURED_OUTPUT_ATTEMPTS = 3;
 
 export interface AgentInvokeOptions {
 	zodSchema?: z.ZodType<any>;
@@ -21,6 +29,19 @@ export interface AgentInvokeOptions {
 	tools?: StructuredTool[];
 	config?: RunnableConfig;
 	maxToolIterations?: number;
+	/** Which graph node is calling (e.g. `AgentNode.PLANNER`) — plain string so
+	 *  this provider-agnostic layer doesn't depend on the graph's node enum.
+	 *  Threaded into retry-warning events so the UI can attribute them. */
+	agentNode?: string;
+}
+
+/** A retryable error a caller may want to surface live (e.g. as a socket
+ *  event) instead of only finding out once the run finishes or fails. */
+export interface RetryWarningInfo {
+	agentNode?: string;
+	attempt: number;
+	maxAttempts: number;
+	rawError: string;
 }
 
 export abstract class BaseAgentWrapper {
@@ -31,15 +52,45 @@ export abstract class BaseAgentWrapper {
 	/** Set per run by the harness; when aborted, every model call is cancelled and
 	 *  a UserInterruptError is raised. */
 	protected signal?: AbortSignal;
+	/** Set per run by the harness — lets retryable errors (bad structured output,
+	 *  transient network issues) be surfaced live instead of only on failure. */
+	private retryWarningSink?: (info: RetryWarningInfo) => void;
 
 	/** Wires the run's interrupt signal into this agent (called once per run). */
 	public setAbortSignal(signal: AbortSignal): void {
 		this.signal = signal;
 	}
 
-	/** Merges the run's abort signal into a model-invoke config. */
+	/** Wires a live retry-warning sink into this agent (called once per run). */
+	public setRetryWarningSink(sink: (info: RetryWarningInfo) => void): void {
+		this.retryWarningSink = sink;
+	}
+
+	private emitRetryWarning(
+		agentNode: string | undefined,
+		attempt: number,
+		maxAttempts: number,
+		error: unknown,
+	): void {
+		this.retryWarningSink?.({
+			agentNode,
+			attempt,
+			maxAttempts,
+			rawError: error instanceof Error ? error.message : String(error),
+		});
+	}
+
+	/**
+	 * Merges the run's abort signal and a per-call timeout into an invoke config.
+	 * Without an explicit timeout a stuck provider connection hangs the whole run
+	 * until some outer layer gives up; bounded here so withRetry can retry it.
+	 */
 	private withSignal(config?: RunnableConfig): RunnableConfig {
-		return this.signal ? { ...config, signal: this.signal } : (config ?? {});
+		return {
+			timeout: MODEL_CALL_TIMEOUT_MS,
+			...config,
+			...(this.signal ? { signal: this.signal } : {}),
+		};
 	}
 
 	/** Raises a UserInterruptError if the run has been interrupted. */
@@ -69,7 +120,9 @@ export abstract class BaseAgentWrapper {
 	 * failure so callers can bail early with a meaningful message.
 	 */
 	public async checkConnection(): Promise<void> {
-		await this.getModel().invoke([new HumanMessage("ping")]);
+		await this.getModel().invoke([new HumanMessage("ping")], {
+			timeout: 30_000,
+		});
 	}
 
 	// Subclasses can override this if they don't natively support withStructuredOutput.
@@ -101,6 +154,7 @@ export abstract class BaseAgentWrapper {
 			messages = [],
 			tools,
 			config,
+			agentNode,
 		} = options;
 
 		let finalMessages: BaseMessage[] = [...messages];
@@ -122,12 +176,20 @@ export abstract class BaseAgentWrapper {
 			}
 
 			// Tool execution loop
-			const maxIterations = options.maxToolIterations ?? this.maxToolIterations ?? 15;
+			const maxIterations =
+				options.maxToolIterations ?? this.maxToolIterations ?? 15;
 			for (let i = 0; i < maxIterations; i++) {
 				this.throwIfInterrupted();
-				const response = (await model.invoke(
-					finalMessages,
-					this.withSignal(config),
+				// Retried like every other model call — a single network timeout
+				// mid-loop used to kill the whole run.
+				const response = (await withRetry(
+					() => model.invoke(finalMessages, this.withSignal(config)),
+					{
+						maxRetries: 2,
+						signal: this.signal,
+						onRetry: (attempt, max, err) =>
+							this.emitRetryWarning(agentNode, attempt, max, err),
+					},
 				)) as AIMessage;
 				finalMessages.push(response);
 
@@ -136,7 +198,10 @@ export abstract class BaseAgentWrapper {
 						const tool = tools.find((t) => t.name === tc.name);
 						if (tool) {
 							try {
-								const toolResult = await tool.invoke(tc.args, this.withSignal(config));
+								const toolResult = await tool.invoke(
+									tc.args,
+									this.withSignal(config),
+								);
 								finalMessages.push(
 									new ToolMessage({
 										tool_call_id: tc.id!,
@@ -185,40 +250,70 @@ export abstract class BaseAgentWrapper {
 
 		if (zodSchema) {
 			let result: any;
-			if (this.supportsStructuredOutput() && originalModel.withStructuredOutput) {
+			if (
+				this.supportsStructuredOutput() &&
+				originalModel.withStructuredOutput
+			) {
 				const structuredModel = originalModel.withStructuredOutput(zodSchema);
-				// By using invoke with config, it automatically logs to LangSmith/Langfuse
-				result = await withRetry(
-					() =>
-						structuredModel.invoke(finalMessages, this.withSignal(config)) as Promise<T>,
-					{ maxRetries: 3, signal: this.signal },
-				);
+				try {
+					// By using invoke with config, it automatically logs to LangSmith/Langfuse
+					result = await withRetry(
+						() =>
+							structuredModel.invoke(
+								finalMessages,
+								this.withSignal(config),
+							) as Promise<T>,
+						{
+							maxRetries: 3,
+							signal: this.signal,
+							onRetry: (attempt, max, err) =>
+								this.emitRetryWarning(agentNode, attempt, max, err),
+						},
+					);
+				} catch (e) {
+					// Native structured output can fail outright (unsupported schema
+					// features, provider quirks). Fall through to the prompt-based
+					// fallback below rather than killing the run.
+					this.throwIfInterrupted();
+					logger.warn(
+						"[BaseAgentWrapper] Native structured output failed, using prompt fallback",
+						{
+							model: this.modelName,
+							error: e instanceof Error ? e.message : String(e),
+						},
+					);
+				}
 			}
 
 			if (!result) {
 				// Fallback implementation for models that don't support withStructuredOutput natively,
-				// or if the native method failed silently (common with some model wrappers on complex inputs)
-				result = await withRetry(
-					() =>
-						this.fallbackStructuredOutput(
-							originalModel,
-							finalMessages,
-							zodSchema,
-							this.withSignal(config),
-						) as Promise<T>,
-					{ maxRetries: 3, signal: this.signal },
-				);
+				// or if the native method failed silently (common with some model wrappers on complex inputs).
+				// It retries internally, feeding the validation error back to the model.
+				result = (await this.fallbackStructuredOutput(
+					originalModel,
+					finalMessages,
+					zodSchema,
+					this.withSignal(config),
+					agentNode,
+				)) as T;
 			}
 
 			if (!result) {
-				throw new Error("Failed to get structured output from the model (it may have exceeded tool call limits without producing a JSON result).");
+				throw new Error(
+					"Failed to get structured output from the model (it may have exceeded tool call limits without producing a JSON result).",
+				);
 			}
 			return result;
 		}
 
 		return await withRetry(
 			() => originalModel.invoke(finalMessages, this.withSignal(config)),
-			{ maxRetries: 3, signal: this.signal },
+			{
+				maxRetries: 3,
+				signal: this.signal,
+				onRetry: (attempt, max, err) =>
+					this.emitRetryWarning(agentNode, attempt, max, err),
+			},
 		);
 	}
 
@@ -227,6 +322,7 @@ export abstract class BaseAgentWrapper {
 		messages: BaseMessage[],
 		schema: z.ZodType<any>,
 		config?: RunnableConfig,
+		agentNode?: string,
 	): Promise<T> {
 		const jsonSchema = zodToJsonSchema(schema as any);
 
@@ -253,19 +349,115 @@ ${JSON.stringify(jsonSchema, null, 2)}
 			modifiedMessages.unshift(new SystemMessage(formatInstructions));
 		}
 
-		const response = await model.invoke(modifiedMessages, config);
-		let content = response.content as string;
+		// Self-correcting loop: a blind retry just makes the model repeat the same
+		// mistake, so each attempt shows it what it got back and what was wrong.
+		// The correction is a human turn — a trailing system/assistant message makes
+		// providers like Mistral reject the request outright.
+		let lastError: unknown;
 
-		content = this.cleanJsonOutput(content);
+		for (let attempt = 0; attempt < STRUCTURED_OUTPUT_ATTEMPTS; attempt++) {
+			this.throwIfInterrupted();
 
-		try {
-			const parsed = JSON.parse(content);
-			return schema.parse(parsed);
-		} catch (error) {
-			throw new Error(
-				`Failed to parse structured output. Model response: ${content}. Error: ${error}`,
-			);
+			let content = "";
+			try {
+				const response = await model.invoke(modifiedMessages, config);
+				content = this.cleanJsonOutput(this.extractText(response));
+
+				if (!content) {
+					// Common with reasoning models that burn the whole output budget
+					// on thinking, or answer with a tool call the unbound model can't place.
+					throw new Error(
+						"The model returned an empty response instead of the required JSON (it may have exhausted its output token budget).",
+					);
+				}
+
+				// `"field": null` for an omitted optional field is the single most
+				// common drift; drop nulls so optional() accepts them.
+				return schema.parse(
+					JSON.parse(content, (_key, value) =>
+						value === null ? undefined : value,
+					),
+				);
+			} catch (error) {
+				if (this.signal?.aborted) throw error;
+				lastError = error;
+				if (attempt === STRUCTURED_OUTPUT_ATTEMPTS - 1) break;
+
+				logger.warn("[BaseAgentWrapper] Structured output invalid, re-asking", {
+					model: this.modelName,
+					attempt: attempt + 1,
+					error: error instanceof Error ? error.message : String(error),
+				});
+				this.emitRetryWarning(
+					agentNode,
+					attempt + 1,
+					STRUCTURED_OUTPUT_ATTEMPTS,
+					error,
+				);
+
+				modifiedMessages = [
+					...modifiedMessages,
+					new AIMessage(content || "(empty response)"),
+					new HumanMessage(
+						`Your previous response did not satisfy the required JSON schema.
+
+Problem:
+${this.describeSchemaError(error)}
+
+Respond again with ONLY the corrected JSON object. Use the exact property names from the schema (do not rename or omit them), and include every required property — use an empty array for required arrays you have nothing to put in.`,
+					),
+				];
+			}
 		}
+
+		throw new Error(
+			`Failed to parse structured output after ${STRUCTURED_OUTPUT_ATTEMPTS} attempts. Error: ${this.describeSchemaError(lastError)}`,
+		);
+	}
+
+	/** Compact, model-readable description of a zod or JSON parse failure. */
+	private describeSchemaError(error: unknown): string {
+		const issues = (error as any)?.issues;
+		if (Array.isArray(issues)) {
+			return issues
+				.slice(0, 20)
+				.map(
+					(i: any) => `- ${(i.path ?? []).join(".") || "(root)"}: ${i.message}`,
+				)
+				.join("\n");
+		}
+		const message = error instanceof Error ? error.message : String(error);
+		return message.slice(0, 500);
+	}
+
+	/**
+	 * Flattens a model response to plain text. Content can be a string, an array
+	 * of content blocks (Anthropic/Google/reasoning models), or empty with the
+	 * real text parked in a provider-specific `reasoning_content` field.
+	 */
+	protected extractText(response: {
+		content: unknown;
+		additional_kwargs?: Record<string, any>;
+	}): string {
+		const { content } = response;
+		let text = "";
+
+		if (typeof content === "string") {
+			text = content;
+		} else if (Array.isArray(content)) {
+			text = content
+				.map((block: any) =>
+					typeof block === "string" ? block : (block?.text ?? ""),
+				)
+				.join("");
+		}
+
+		if (!text.trim()) {
+			const reasoning = response.additional_kwargs?.reasoning_content;
+			if (typeof reasoning === "string") text = reasoning;
+		}
+
+		return text;
 	}
 
 	protected cleanJsonOutput(content: string): string {
@@ -276,6 +468,15 @@ ${JSON.stringify(jsonSchema, null, 2)}
 		const codeBlockMatch = content.match(/```(?:json)?\s*([\s\S]*?)```/);
 		if (codeBlockMatch && codeBlockMatch[1]) {
 			content = codeBlockMatch[1];
+		}
+
+		content = content.trim();
+
+		// Strip any prose wrapped around the payload (e.g. "Here is the JSON: {...}").
+		const start = content.search(/[{[]/);
+		if (start > 0) {
+			const end = Math.max(content.lastIndexOf("}"), content.lastIndexOf("]"));
+			if (end > start) content = content.slice(start, end + 1);
 		}
 
 		return content.trim();

--- a/apps/ai-gateway/src/harness/models/openai/index.ts
+++ b/apps/ai-gateway/src/harness/models/openai/index.ts
@@ -19,11 +19,25 @@ export class OpenAIAgentWrapper extends BaseAgentWrapper {
 	protected getModel(): BaseChatModel {
 		return new ChatOpenAI({
 			model: this.modelName,
-			openAIApiKey: this.apiKey,
+			// Must be `apiKey`. ChatOpenAI reads only `fields.apiKey`,
+			// `configuration.apiKey`, or $OPENAI_API_KEY — `openAIApiKey` is a dead
+			// alias on chat models (it still works on OpenAI() / OpenAIEmbeddings),
+			// so passing it silently dropped the key and every request failed with
+			// "Missing credentials".
+			// The fallback covers keyless local servers (Ollama, LM Studio, vLLM),
+			// which reject nothing but still need the SDK to construct.
+			apiKey: this.apiKey || (this.baseUrl ? "not-required" : undefined),
 			configuration: {
 				baseURL: this.baseUrl,
 				defaultHeaders: this.additionalHeaders,
 			},
 		});
+	}
+
+	// A custom baseUrl means an OpenAI-compatible server, not OpenAI. Most of them
+	// (Ollama, LM Studio, llama.cpp) reject the `json_schema` response format, so
+	// go straight to the prompt-based fallback instead of burning retries on it.
+	protected supportsStructuredOutput(): boolean {
+		return !this.baseUrl;
 	}
 }

--- a/apps/ai-gateway/src/harness/streamTypes.ts
+++ b/apps/ai-gateway/src/harness/streamTypes.ts
@@ -21,8 +21,15 @@ import {
 /** Which tier of the harness produced the event. */
 export type HarnessLevel = "harness" | "sub_agent";
 
-/** Lifecycle phase of the event. */
-export type HarnessPhase = "node_start" | "node_end" | "status" | "hitl_required";
+/** Lifecycle phase of the event. `warning` is non-terminal — the agent hit a
+ *  retryable error (e.g. bad structured output) and is re-asking the model; it
+ *  never changes `runStatus` away from what the agent was already doing. */
+export type HarnessPhase =
+	| "node_start"
+	| "node_end"
+	| "status"
+	| "hitl_required"
+	| "warning";
 
 /** Mirrors agentHarnessRunStatusEnum in the DB schema. */
 export type HarnessRunStatus =
@@ -98,6 +105,10 @@ export interface HarnessStreamEvent {
 	status: string;
 	runStatus: HarnessRunStatus;
 	payload?: HarnessNodePayload;
+	/** Present only on `phase: "warning"` — `status` already carries the full
+	 *  human-readable sentence; this is for UIs that want to render retry
+	 *  progress (e.g. "2/3") without parsing text. */
+	warning?: { attempt: number; maxAttempts: number };
 	timestamp: number;
 }
 
@@ -124,6 +135,26 @@ const SUB_AGENT_NODES: ReadonlySet<AgentNodeName> = new Set<AgentNodeName>([
 
 export function levelForNode(node: AgentNodeName): HarnessLevel {
 	return SUB_AGENT_NODES.has(node) ? "sub_agent" : "harness";
+}
+
+/** Human-readable node names for user-facing messages (e.g. failure reports). */
+const NODE_LABELS: Record<string, string> = {
+	[AgentNode.ROUTER]: "request router",
+	[AgentNode.CLASSIFIER]: "request classifier",
+	[AgentNode.VERIFY_USER_QUERY]: "request verification",
+	[AgentNode.PLANNER]: "planner",
+	[AgentNode.TASK_GENERATOR]: "task generator",
+	[AgentNode.DISCUSSION]: "discussion agent",
+	[AgentNode.BLOCK_BUILDER]: "block builder",
+	[AgentNode.ORCHESTRATOR]: "orchestrator",
+	[AgentNode.HUMAN_IN_THE_LOOP]: "plan review",
+	[AgentNode.ROUTE_CONFIG_AGENT]: "route configurator",
+	[AgentNode.SUPERVISOR]: "supervisor",
+	[AgentNode.SUMMARIZER]: "summarizer",
+};
+
+export function labelForNode(node?: AgentNodeName): string {
+	return (node && NODE_LABELS[node]) || "AI harness";
 }
 
 /** Maps a node to the run status it represents while executing. */

--- a/apps/ai-gateway/src/harness/tools/getArtifact.spec.ts
+++ b/apps/ai-gateway/src/harness/tools/getArtifact.spec.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "bun:test";
+import { createGetArtifactTool } from "./getArtifact";
+import type { DbService, SubArtifactRecord } from "../internal/dbService";
+import type { WorkflowMetadata } from "../types";
+
+const metadata = { conversationId: "conv-1" } as WorkflowMetadata;
+
+const record = (over: Partial<SubArtifactRecord> = {}): SubArtifactRecord => ({
+	id: "sub-1",
+	artifactId: "art-1",
+	runId: "run-1",
+	kind: "route",
+	action: "add",
+	appliedAt: null,
+	payload: { data: { method: "GET", path: "/users" } },
+	createdAt: new Date("2026-01-01T00:00:00.000Z"),
+	...over,
+});
+
+const toolWith = (rows: SubArtifactRecord[], spy?: (args: any[]) => void) =>
+	createGetArtifactTool(
+		{
+			getSubArtifacts: async (...args: any[]) => {
+				spy?.(args);
+				return rows;
+			},
+		} as unknown as DbService,
+		metadata,
+	);
+
+describe("get_artifact", () => {
+	it("scopes the lookup to the conversation and renders the payload", async () => {
+		const calls: any[][] = [];
+		const out = await toolWith([record()], (a) => calls.push(a)).invoke({
+			artifactIds: ["sub-1"],
+		});
+
+		expect(calls[0]).toEqual(["conv-1", ["sub-1"]]);
+		expect(out).toContain("kind=route, action=add");
+		expect(out).toContain('"path": "/users"');
+	});
+
+	it("tells the agent whether the output is already applied", async () => {
+		const notApplied = await toolWith([record()]).invoke({ artifactIds: ["sub-1"] });
+		expect(notApplied).toContain("applied=no");
+
+		const applied = await toolWith([
+			record({ appliedAt: new Date("2026-02-02T00:00:00.000Z") }),
+		]).invoke({ artifactIds: ["sub-1"] });
+		expect(applied).toContain("applied=yes, at 2026-02-02T00:00:00.000Z");
+	});
+
+	it("reports nothing found instead of returning empty output", async () => {
+		const out = await toolWith([]).invoke({ artifactIds: ["nope"] });
+		expect(out).toContain("No artifacts found");
+	});
+
+	it("truncates oversized payloads so the context window survives", async () => {
+		const fat = record({ payload: { blocks: "x".repeat(20000) } });
+		const out = await toolWith([fat]).invoke({ artifactIds: ["sub-1"] });
+		expect(out).toContain("[truncated —");
+		expect(out.length).toBeLessThan(13000);
+	});
+});

--- a/apps/ai-gateway/src/harness/tools/getArtifact.ts
+++ b/apps/ai-gateway/src/harness/tools/getArtifact.ts
@@ -1,0 +1,59 @@
+import { tool } from "@langchain/core/tools";
+import { z } from "zod";
+import { logger } from "@fluxify/common";
+import type { WorkflowMetadata } from "../types";
+import type { DbService } from "../internal/dbService";
+
+// ponytail: flat char cap so one fat canvas payload can't blow the context
+// window. If this starts truncating things users need, page per sub-artifact.
+const MAX_CHARS = 12000;
+
+/**
+ * Reads back what previous runs actually built. The summary markdown of a past
+ * run embeds sub-artifact ids in its tokens (`:route{... sub_artifact_id="..."}`,
+ * `:canvasChanges{... artifact_id="..."}`), so the discussion agent can pull the
+ * exact stored output instead of guessing from the summary prose.
+ */
+export const createGetArtifactTool = (
+	dbService: DbService,
+	metadata: WorkflowMetadata,
+) => {
+	return tool(
+		async ({ artifactIds }) => {
+			logger.info(
+				`[Tools] Fetching artifacts ${artifactIds.join(", ")} for conversation ${metadata.conversationId}`,
+			);
+
+			const rows = await dbService.getSubArtifacts(
+				metadata.conversationId,
+				artifactIds,
+			);
+			if (rows.length === 0) {
+				return "No artifacts found for those ids in this conversation.";
+			}
+
+			const body = rows
+				.map(
+					(r) =>
+						`## artifact ${r.id} (kind=${r.kind}, action=${r.action ?? "n/a"}, applied=${r.appliedAt ? `yes, at ${new Date(r.appliedAt).toISOString()}` : "no"}, run=${r.runId}, created=${new Date(r.createdAt).toISOString()})\n${JSON.stringify(r.payload, null, 2)}`,
+				)
+				.join("\n\n");
+
+			return body.length > MAX_CHARS
+				? `${body.slice(0, MAX_CHARS)}\n\n[truncated — ${body.length - MAX_CHARS} more characters. Re-run with fewer ids to see the rest.]`
+				: body;
+		},
+		{
+			name: "get_artifact",
+			description:
+				"Fetch what a previous run in this conversation actually built: the stored route configuration or canvas (block graph) output. Pass the ids found in earlier summary tokens (sub_artifact_id / artifact_id), or a parent artifact id to get every output of that run. Each result reports `applied=yes/no`: applied means the user already pushed that output into the project (it is live), applied=no means it was only proposed and does not exist in the project yet. This flag is internal — use it to shape your wording, never echo it to the user.",
+			schema: z.object({
+				artifactIds: z
+					.array(z.string())
+					.describe(
+						"Sub-artifact ids taken verbatim from earlier summary tokens, or a parent artifact id. Pass several at once instead of calling repeatedly.",
+					),
+			}),
+		},
+	);
+};

--- a/apps/ai-gateway/src/harness/tools/index.ts
+++ b/apps/ai-gateway/src/harness/tools/index.ts
@@ -3,6 +3,7 @@ import type { DbService } from "../internal/dbService";
 import { searchDocsTool } from "./searchDocs";
 import { createGetRouteDetailsTool } from "./getRouteDetails";
 import { createFindResourceTool } from "./findResource";
+import { createGetArtifactTool } from "./getArtifact";
 
 export function createHarnessTools(
 	dbService: DbService,
@@ -12,5 +13,6 @@ export function createHarnessTools(
 		searchDocsTool,
 		createGetRouteDetailsTool(dbService, metadata),
 		createFindResourceTool(dbService, metadata),
+		createGetArtifactTool(dbService, metadata),
 	];
 }

--- a/apps/ai-gateway/src/harness/types.ts
+++ b/apps/ai-gateway/src/harness/types.ts
@@ -1,7 +1,7 @@
 import { Annotation, MessagesAnnotation } from "@langchain/langgraph";
 import type { BaseAgentWrapper } from "./models/base";
 import type { DbService } from "./internal/dbService";
-import type { HarnessService } from "./internal/harnessService";
+import type { HarnessService, HitlPlanAction } from "./internal/harnessService";
 
 export enum AgentNode {
 	ROUTER = "router",
@@ -142,7 +142,10 @@ export type AgentOutputValidator = (
 
 export interface OrchestratorState {
 	tasks?: Task[];
-	taskQueue?: string[][]; // Topologically sorted task IDs grouped by independent execution levels
+	/** Topologically sorted task IDs grouped by level, produced by the task
+	 *  generator. Informational only — the orchestrator derives the next level
+	 *  from task statuses + dependencies so re-entry can't skip or repeat one. */
+	taskQueue?: string[][];
 	dispatchedTasks?: Task[]; // Tasks dispatched in the current tick
 	subAgentResults?: Record<string, SubAgentResult>;
 }
@@ -168,8 +171,7 @@ export const GraphState = Annotation.Root({
 		reducer: (oldState, newState) => newState ?? oldState,
 		default: () => undefined,
 	}),
-	action: Annotation<unknown>({
-		// TODO: implement core details of action (e.g. HITL, approvals) later
+	action: Annotation<HitlPlanAction | undefined>({
 		reducer: (oldState, newState) => newState ?? oldState,
 		default: () => undefined,
 	}),

--- a/apps/ai-gateway/src/lib/retry.ts
+++ b/apps/ai-gateway/src/lib/retry.ts
@@ -7,6 +7,9 @@ export interface RetryOptions {
   factor?: number;
   /** When aborted, the operation is not retried — the error propagates at once. */
   signal?: AbortSignal;
+  /** Called right before each retry sleep — lets a caller surface the retry
+   *  (e.g. as a live event) without changing the retry/backoff behavior. */
+  onRetry?: (attempt: number, maxRetries: number, error: unknown) => void;
 }
 
 export async function withRetry<T>(
@@ -43,7 +46,8 @@ export async function withRetry<T>(
       const delay = Math.min(baseDelayMs * Math.pow(factor, attempt - 1), maxDelayMs);
       const errorMessage = error instanceof Error ? error.message : String(error);
       logger.warn(`[Retry] Operation failed (attempt ${attempt}/${maxRetries}). Retrying in ${delay}ms...`, { error: errorMessage });
-      
+      options.onRetry?.(attempt, maxRetries, error);
+
       await new Promise(resolve => setTimeout(resolve, delay));
     }
   }

--- a/apps/portal/src/components/ai/AgentTaskStatus.tsx
+++ b/apps/portal/src/components/ai/AgentTaskStatus.tsx
@@ -1,0 +1,146 @@
+import { useState, useEffect } from "react";
+import { useConversationRun } from "@/store/aiHarness";
+import { TbCheck, TbLoader, TbX, TbClock, TbChevronRight, TbChevronDown, TbTool } from "react-icons/tb";
+
+function getHumanFriendlyName(name: string) {
+	return name
+		.replace(/([A-Z])/g, " $1")
+		.replace(/^./, (str) => str.toUpperCase())
+		.trim();
+}
+
+export function AgentTaskStatus({ conversationId }: { conversationId: string }) {
+	const run = useConversationRun(conversationId);
+	const tasksByLevel = run?.tasksByLevel;
+	const [expandedTasks, setExpandedTasks] = useState<Set<string>>(new Set());
+
+	// Expand tasks that are currently running
+	useEffect(() => {
+		if (tasksByLevel) {
+			const runningTasks = tasksByLevel.flat().filter(t => t.status === "running").map(t => t.id);
+			if (runningTasks.length > 0) {
+				setExpandedTasks(prev => {
+					const next = new Set(prev);
+					runningTasks.forEach(id => next.add(id));
+					return next;
+				});
+			}
+		}
+	}, [tasksByLevel]);
+
+	if (!tasksByLevel || tasksByLevel.length === 0) return null;
+
+	const allTasks = tasksByLevel.flat();
+	const isTerminal = run?.isTerminal;
+
+	const toggleTask = (taskId: string) => {
+		setExpandedTasks(prev => {
+			const next = new Set(prev);
+			if (next.has(taskId)) next.delete(taskId);
+			else next.add(taskId);
+			return next;
+		});
+	};
+
+	return (
+		<div
+			className={`flex w-full flex-col gap-2 transition-all duration-700 ease-in-out overflow-hidden ${
+				isTerminal ? "max-h-0 opacity-0 my-0 py-0" : "max-h-[2000px] opacity-100 py-2"
+			}`}
+		>
+			<div className="text-[11px] font-semibold uppercase tracking-wider text-muted px-2 mb-1">
+				Builder Execution Plan
+			</div>
+			<div className="flex flex-col gap-1 px-1">
+				{allTasks.map((task) => {
+					const isCompleted = task.status === "completed";
+					const isRunning = task.status === "running";
+					const isFailed = task.status === "failed";
+					const isExpanded = expandedTasks.has(task.id);
+					
+					const statusIcon = isCompleted ? (
+						<TbCheck className="text-success shrink-0" size={14} />
+					) : isRunning ? (
+						<TbLoader className="text-accent animate-spin shrink-0" size={14} />
+					) : isFailed ? (
+						<TbX className="text-danger shrink-0" size={14} />
+					) : (
+						<TbClock className="text-muted shrink-0" size={14} />
+					);
+
+					const humanName = getHumanFriendlyName(task.assignedAgentNode);
+					const steps = Object.values(run?.steps || {})
+						.filter(step => {
+							if (step.node === task.assignedAgentNode) return true;
+							const isSubAgentTask = task.assignedAgentNode === "blockBuilder" || task.assignedAgentNode === "routeConfig";
+							if (isSubAgentTask && step.level === "sub_agent") {
+								return step.node !== "blockBuilder" && step.node !== "routeConfig";
+							}
+							return false;
+						})
+						.sort((a, b) => a.timestamp - b.timestamp);
+
+					return (
+						<div key={task.id} className="flex flex-col">
+							<button
+								onClick={() => toggleTask(task.id)}
+								className="flex items-center gap-2 rounded-md hover:bg-surface/50 px-2 py-1.5 text-left transition-colors cursor-pointer group"
+							>
+								{statusIcon}
+								<div className="flex items-center gap-2 flex-1 min-w-0">
+									<span className="font-medium text-foreground text-[13px] truncate">
+										{humanName}
+									</span>
+								</div>
+								
+								<div className="flex items-center gap-2 shrink-0">
+									<span className="text-[11px] text-muted capitalize">
+										{task.status}
+									</span>
+									<div className="w-4 flex justify-center">
+										{isExpanded ? (
+											<TbChevronDown className="text-muted" size={14} />
+										) : (
+											<TbChevronRight className="text-muted" size={14} />
+										)}
+									</div>
+								</div>
+							</button>
+
+							{/* Events Accordion */}
+							<div
+								className={`overflow-hidden transition-all duration-300 ease-in-out ${
+									isExpanded ? "max-h-[500px] opacity-100 mt-1 mb-2" : "max-h-0 opacity-0"
+								}`}
+							>
+								<div className="flex flex-col gap-1.5 pl-7 pr-2 border-l border-border/50 ml-3.5 relative py-1">
+									{steps.map((step, idx) => {
+										let icon = <span className="w-[5px] h-[5px] rounded-full bg-border shrink-0 absolute -left-[3px] top-[7px]" />;
+										let label = step.label;
+										
+										if (label.toLowerCase().includes("tool")) {
+											icon = <TbTool size={11} className="text-muted absolute -left-[6px] top-[4px]" />;
+											label = label.replace(/calling tool:?\s*/i, "Tool: ");
+										}
+
+										return (
+											<div key={step.stepId || idx} className="flex items-start gap-2 relative">
+												{icon}
+												<span className="text-[12px] text-muted leading-tight">
+													{label}
+												</span>
+											</div>
+										);
+									})}
+									{steps.length === 0 && (
+										<div className="text-[12px] text-muted/50 italic">No events recorded yet.</div>
+									)}
+								</div>
+							</div>
+						</div>
+					);
+				})}
+			</div>
+		</div>
+	);
+}

--- a/apps/portal/src/components/ai/ConversationPage.tsx
+++ b/apps/portal/src/components/ai/ConversationPage.tsx
@@ -6,13 +6,17 @@ import { PromptEditor } from "./PromptEditor";
 import { useAiModels } from "./useAiModels";
 import { harnessConversationsQuery } from "@/query/harnessConversationsQuery";
 import { showErrorNotification } from "@/lib/errorNotifier";
-import { useIsRunning, useConversationRun } from "@/store/aiHarness";
+import { useIsRunning, useConversationRun, useAiHarnessStore } from "@/store/aiHarness";
 import { UserMessage } from "./UserMessage";
 import { AiMessage } from "./AiMessage";
 import { useScrollToBottom } from "./useScrollToBottom";
 import { ScrollToBottomButton } from "./ScrollToBottomButton";
 import { ChatTitleEditor } from "./ChatTitleEditor";
+import { AgentTaskStatus } from "./AgentTaskStatus";
 import type { HarnessConversation } from "./types";
+import { PlanReviewModal } from "./PlanReviewModal";
+import { Button } from "@fluxify/components";
+import { TbListSearch } from "react-icons/tb";
 
 export function ConversationPage() {
 	const { projectId, conversationId } = useParams({
@@ -33,6 +37,26 @@ export function ConversationPage() {
 	const prevIsRunning = useRef(isRunning);
 	const bottomRef = useRef<HTMLDivElement>(null);
 	const [optimisticQuery, setOptimisticQuery] = useState<string | null>(null);
+	const [isPlanReviewModalOpen, setIsPlanReviewModalOpen] = useState(false);
+
+	// Check active conversation from sidebar cache reactively
+	const [activeConversation, setActiveConversation] = useState<HarnessConversation | null>(null);
+	const isArchived = activeConversation?.archived ?? false;
+
+	// Once a live run exists, its socket-driven runStatus is authoritative — the
+	// REST `activeConversation.status` is only a fallback for before any socket
+	// event has arrived (it has no live-update path, so it can't be trusted once
+	// a run is already streaming: it'd freeze the review UI open forever after
+	// the run resumes).
+	const isTransitioning = !!optimisticQuery || actionMutation.isPending;
+
+	const isPausedForHitl = !isTransitioning && (
+		activeRun?.runStatus === "awaiting_hitl" || 
+		(activeRun?.runStatus as string) === "paused_hitl" || 
+		(!activeRun && activeConversation?.status === "paused_hitl")
+	);
+
+	const isPlanReviewMode = isPausedForHitl;
 
 	const { data: messagesData, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } = harnessConversationsQuery.messages.useInfiniteQuery(
 		projectId,
@@ -44,9 +68,7 @@ export function ConversationPage() {
 	const topRef = useRef<HTMLDivElement>(null);
 	const { isAtBottom, scrollToBottom } = useScrollToBottom(bottomRef, 250);
 
-	// Check active conversation from sidebar cache reactively
-	const [activeConversation, setActiveConversation] = useState<HarnessConversation | null>(null);
-	const isArchived = activeConversation?.archived ?? false;
+	const planText = activeRun?.hitl?.markdownPlan || (isPlanReviewMode && messages.length > 0 ? messages[0].aiResponse : null);
 
 	useEffect(() => {
 		const checkConversation = () => {
@@ -89,9 +111,11 @@ export function ConversationPage() {
 	// Auto-scroll
 	useEffect(() => {
 		if (optimisticQuery || isAtBottom) {
-			scrollToBottom();
+			// Use instant scroll for streams to prevent animation buildup/fighting
+			scrollToBottom(optimisticQuery ? "smooth" : "auto");
 		}
-	}, [messages.length, optimisticQuery, isAtBottom, scrollToBottom]);
+	// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [messages.length, optimisticQuery, activeRun?.lastTimestamp]);
 
 	// Invalidate messages on run completion
 	useEffect(() => {
@@ -116,6 +140,7 @@ export function ConversationPage() {
 			reqPayload.integrationId = model;
 		}
 
+		useAiHarnessStore.getState().clearRun(conversationId);
 		setOptimisticQuery(q);
 
 		sendMessage.mutate(reqPayload, {
@@ -152,6 +177,9 @@ export function ConversationPage() {
 							<UserMessage query={optimisticQuery} />
 						</div>
 					)}
+					<AgentTaskStatus conversationId={conversationId} />
+					
+
 
 					{isLoading ? (
 						<div className="flex w-full flex-col gap-8 animate-pulse pt-8 opacity-60">
@@ -167,19 +195,90 @@ export function ConversationPage() {
 							</div>
 						</div>
 					) : messages.length === 0 && !optimisticQuery ? (
-						<div className="text-center pt-8">
-							<p className="text-sm text-muted">Conversation</p>
-							<p className="font-mono text-xs text-muted">{conversationId}</p>
-						</div>
+						isPlanReviewMode && planText ? (
+							<div className="flex w-full flex-col gap-4 mt-2">
+								<div className="w-full rounded-2xl border border-primary/20 bg-primary/5 p-6 flex flex-col gap-4">
+									<div className="flex items-start gap-4">
+										<div className="bg-primary/20 p-3 rounded-xl text-primary shrink-0">
+											<TbListSearch size={24} />
+										</div>
+										<div className="flex-1">
+											<h3 className="text-lg font-semibold text-foreground">Implementation Plan Ready</h3>
+											<p className="text-sm text-muted mt-1 leading-relaxed">
+												The AI has proposed an implementation plan. Please review the blocks, provide feedback, or approve it to proceed.
+											</p>
+										</div>
+									</div>
+									<Button 
+										variant="primary" 
+										className="w-full font-medium"
+										onPress={() => setIsPlanReviewModalOpen(true)}
+									>
+										Review Plan
+									</Button>
+								</div>
+							</div>
+						) : (
+							<div className="text-center pt-8">
+								<p className="text-sm text-muted">Conversation</p>
+								<p className="font-mono text-xs text-muted">{conversationId}</p>
+							</div>
+						)
 					) : (
 						messages.map((msg, idx) => {
 							const isLatest = idx === 0;
 							const displayStatus = (isLatest && activeRun && !activeRun.isTerminal) ? activeRun.runStatus : msg.status;
 							
+							const looksLikePlan = msg.aiResponse && (
+								msg.aiResponse === planText || 
+								(msg.aiResponse.includes("Plan:") && msg.aiResponse.includes("Task 1:")) ||
+								msg.aiResponse.includes("Implementation Plan")
+							);
+							
+							const isActionablePlan = isPlanReviewMode && isLatest && looksLikePlan;
+							const isHistoricalPlan = !isActionablePlan && looksLikePlan;
+							
 							return (
 								<div key={msg.id} className="flex w-full flex-col gap-4">
 									{msg.userQuery && <UserMessage query={msg.userQuery} />}
-									<AiMessage response={msg.aiResponse} status={displayStatus} />
+									{isActionablePlan && planText ? (
+										<div className="w-full rounded-2xl border border-primary/20 bg-primary/5 p-6 flex flex-col gap-4">
+											<div className="flex items-start gap-4">
+												<div className="bg-primary/20 p-3 rounded-xl text-primary shrink-0">
+													<TbListSearch size={24} />
+												</div>
+												<div className="flex-1">
+													<h3 className="text-lg font-semibold text-foreground">Implementation Plan Ready</h3>
+													<p className="text-sm text-muted mt-1 leading-relaxed">
+														The AI has proposed an implementation plan. Please review the blocks, provide feedback, or approve it to proceed.
+													</p>
+												</div>
+											</div>
+											<Button 
+												variant="primary" 
+												className="w-full font-medium"
+												onPress={() => setIsPlanReviewModalOpen(true)}
+											>
+												Review Plan
+											</Button>
+										</div>
+									) : isHistoricalPlan ? (
+										<div className="w-full rounded-2xl border border-white/10 bg-white/5 p-4 flex flex-col gap-3 opacity-70">
+											<div className="flex items-center gap-4">
+												<div className="bg-white/10 p-2.5 rounded-xl text-foreground shrink-0">
+													<TbListSearch size={20} />
+												</div>
+												<div className="flex-1">
+													<h3 className="text-base font-medium text-foreground">Implementation Plan</h3>
+													<p className="text-xs text-muted mt-0.5">
+														{displayStatus === "running" ? "Plan is currently being executed." : "Plan was reviewed and approved."}
+													</p>
+												</div>
+											</div>
+										</div>
+									) : (
+										<AiMessage response={msg.aiResponse} status={displayStatus} />
+									)}
 								</div>
 							);
 						})
@@ -202,7 +301,7 @@ export function ConversationPage() {
 			</div>
 
 			<div className="sticky bottom-0 px-4 pb-2 pt-4 bg-background relative">
-				<ScrollToBottomButton isVisible={!isAtBottom} onClick={scrollToBottom} />
+				<ScrollToBottomButton isVisible={!isAtBottom} onClick={() => scrollToBottom("smooth")} />
 				<div className="mx-auto w-full max-w-[65%]">
 					{isArchived ? (
 						<div className="w-full rounded-2xl border border-border bg-surface p-4 text-center text-sm text-muted">
@@ -221,10 +320,20 @@ export function ConversationPage() {
 							placeholder="Reply to AI..."
 							isRunning={isRunning}
 							onStop={stop}
+							isDisabled={isPlanReviewMode}
 						/>
 					)}
 				</div>
 			</div>
+			{isPlanReviewMode && planText && (
+				<PlanReviewModal
+					isOpen={isPlanReviewModalOpen}
+					onOpenChange={setIsPlanReviewModalOpen}
+					plan={planText}
+					projectId={projectId}
+					conversationId={conversationId}
+				/>
+			)}
 		</div>
 	);
 }

--- a/apps/portal/src/components/ai/MarkdownViewer.tsx
+++ b/apps/portal/src/components/ai/MarkdownViewer.tsx
@@ -1,5 +1,7 @@
+import React from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { Typography, Table } from "@fluxify/components";
 
 interface MarkdownViewerProps {
 	content: string;
@@ -7,8 +9,63 @@ interface MarkdownViewerProps {
 
 export function MarkdownViewer({ content }: MarkdownViewerProps) {
 	return (
-		<div className="w-full text-left text-sm [&>p]:mb-4 [&>h1]:text-2xl [&>h1]:font-bold [&>h1]:mb-4 [&>h2]:text-xl [&>h2]:font-bold [&>h2]:mb-3 [&>h3]:text-lg [&>h3]:font-semibold [&>h3]:mb-2 [&>ul]:list-disc [&>ul]:ml-6 [&>ul]:mb-4 [&>ol]:list-decimal [&>ol]:ml-6 [&>ol]:mb-4 [&>li]:mb-1 [&>pre]:bg-black/20 [&>pre]:p-4 [&>pre]:rounded-xl [&>pre]:mb-4 [&>pre]:overflow-x-auto [&>code]:bg-black/20 [&>code]:px-1.5 [&>code]:py-0.5 [&>code]:rounded-md [&>blockquote]:border-l-4 [&>blockquote]:border-white/20 [&>blockquote]:pl-4 [&>blockquote]:italic [&>blockquote]:mb-4 text-foreground/80 leading-loose">
-			<ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+		<div className="w-full text-left text-sm text-foreground/80 leading-loose">
+			<ReactMarkdown
+				remarkPlugins={[remarkGfm]}
+				components={{
+					h1: ({ children }) => <Typography.Heading level={1} className="text-2xl font-bold mb-4">{children}</Typography.Heading>,
+					h2: ({ children }) => <Typography.Heading level={2} className="text-xl font-bold mb-3">{children}</Typography.Heading>,
+					h3: ({ children }) => <Typography.Heading level={3} className="text-lg font-semibold mb-2">{children}</Typography.Heading>,
+					h4: ({ children }) => <Typography.Heading level={4} className="text-base font-semibold mb-2">{children}</Typography.Heading>,
+					h5: ({ children }) => <Typography.Heading level={5} className="text-sm font-semibold mb-1">{children}</Typography.Heading>,
+					h6: ({ children }) => <Typography.Heading level={6} className="text-sm font-semibold mb-1 text-foreground/80">{children}</Typography.Heading>,
+					p: ({ children }) => <Typography.Paragraph className="mb-4">{children}</Typography.Paragraph>,
+					ul: ({ children }) => <ul className="list-disc ml-6 mb-4">{children}</ul>,
+					ol: ({ children }) => <ol className="list-decimal ml-6 mb-4">{children}</ol>,
+					li: ({ children }) => <li className="mb-1">{children}</li>,
+					blockquote: ({ children }) => (
+						<blockquote className="border-l-4 border-white/20 pl-4 italic mb-4">
+							{children}
+						</blockquote>
+					),
+					pre: ({ children }) => (
+						<pre className="bg-black/20 p-4 rounded-xl mb-4 overflow-x-auto text-sm">
+							{children}
+						</pre>
+					),
+					code: ({ children, className }) => {
+						const isInline = !className;
+						if (isInline) {
+							return <Typography.Code className="bg-black/20 px-1.5 py-0.5 rounded-md">{children}</Typography.Code>;
+						}
+						return <code className={className}>{children}</code>;
+					},
+					table: ({ children }) => (
+						<div className="mb-4">
+							<Table>
+								<Table.ScrollContainer>
+									<Table.Content>{children}</Table.Content>
+								</Table.ScrollContainer>
+							</Table>
+						</div>
+					),
+					thead: ({ children }) => {
+						let cols = children;
+						const elements = React.Children.toArray(children).filter(React.isValidElement);
+						if (elements.length === 1) {
+							// @ts-ignore - props.children exists on elements
+							cols = elements[0].props.children;
+						}
+						return <Table.Header>{cols}</Table.Header>;
+					},
+					tbody: ({ children }) => <Table.Body>{children}</Table.Body>,
+					tr: ({ children }) => <Table.Row>{children}</Table.Row>,
+					th: ({ children }) => <Table.Column>{children}</Table.Column>,
+					td: ({ children }) => <Table.Cell>{children}</Table.Cell>,
+				}}
+			>
+				{content}
+			</ReactMarkdown>
 		</div>
 	);
 }

--- a/apps/portal/src/components/ai/PlanReviewModal.tsx
+++ b/apps/portal/src/components/ai/PlanReviewModal.tsx
@@ -1,0 +1,332 @@
+import { useState, useEffect, useRef } from "react";
+import { Modal, Button, Popover, PopoverTrigger, PopoverContent } from "@fluxify/components";
+import { TbMessageCirclePlus, TbCheck, TbX, TbEdit } from "react-icons/tb";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { useQueryClient } from "@tanstack/react-query";
+import { harnessConversationsQuery } from "@/query/harnessConversationsQuery";
+import { MarkdownViewer } from "./MarkdownViewer";
+import { useAiHarnessStore } from "@/store/aiHarness";
+
+interface PlanReviewModalProps {
+	isOpen: boolean;
+	onOpenChange: (open: boolean) => void;
+	plan: string;
+	projectId: string;
+	conversationId: string;
+}
+
+const HoverableBlock = ({
+	children,
+	blockId,
+	existingReview,
+	onSaveReview,
+	isSelected,
+	onClick,
+}: {
+	children: React.ReactNode;
+	blockId: string;
+	existingReview?: string;
+	onSaveReview: (id: string, text: string) => void;
+	isSelected?: boolean;
+	onClick?: () => void;
+}) => {
+	const [hovered, setHovered] = useState(false);
+	const [popoverOpened, setPopoverOpened] = useState(false);
+	const [reviewText, setReviewText] = useState(existingReview || "");
+	const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+	useEffect(() => {
+		if (popoverOpened && textareaRef.current) {
+			const timeout = setTimeout(() => {
+				textareaRef.current?.focus();
+			}, 50);
+			return () => clearTimeout(timeout);
+		}
+	}, [popoverOpened]);
+
+	const handleSave = () => {
+		onSaveReview(blockId, reviewText);
+		setPopoverOpened(false);
+	};
+
+	const hasReview = !!existingReview;
+
+	return (
+		<div
+			id={blockId}
+			onMouseEnter={() => setHovered(true)}
+			onMouseLeave={() => setHovered(false)}
+			className={`relative px-3 py-1 pr-12 my-1 rounded-lg transition-all duration-200 border-l-2 ${
+				isSelected || hasReview
+					? "bg-primary/20 border-primary"
+					: hovered
+						? "bg-white/5 border-transparent"
+						: "border-transparent"
+			}`}
+		>
+			{children}
+
+			{(hovered || popoverOpened || hasReview) && (
+				<div className="absolute top-1 right-2 z-10">
+					{/* @ts-expect-error placement is valid */}
+					<Popover placement="left-start" isOpen={popoverOpened} onOpenChange={setPopoverOpened}>
+						<PopoverTrigger>
+							<Button
+								isIconOnly
+								size="sm"
+								variant={hasReview ? "primary" : "secondary"}
+								className={`rounded-full h-7 w-7 shadow-md ${!hasReview && "bg-[#2a2a2b] hover:bg-[#3a3a3b] text-white"}`}
+							>
+								{hasReview ? <TbEdit size={14} /> : <TbMessageCirclePlus size={14} />}
+							</Button>
+						</PopoverTrigger>
+						<PopoverContent className="w-64 rounded-xl border border-white/10 bg-[#1e1e20] p-4 shadow-xl">
+							<div className="flex w-full flex-col gap-3">
+								<span className="text-sm font-medium">
+									{hasReview ? "Edit Review" : "Add Review"}
+								</span>
+								<textarea
+									ref={textareaRef}
+									placeholder="What needs to be changed?"
+									value={reviewText}
+									onChange={(e) => setReviewText(e.target.value)}
+									className="w-full min-h-[60px] rounded-lg bg-black/20 p-2 text-sm text-foreground outline-none placeholder:text-muted resize-y border border-white/10 focus:border-primary/50"
+								/>
+								<div className="flex justify-end gap-2 pt-1">
+									<Button size="sm" variant="ghost" className="h-7 text-xs px-3" onPress={() => setPopoverOpened(false)}>
+										Cancel
+									</Button>
+									<Button size="sm" variant="primary" className="h-7 text-xs px-3" onPress={handleSave}>
+										Save
+									</Button>
+								</div>
+							</div>
+						</PopoverContent>
+					</Popover>
+				</div>
+			)}
+		</div>
+	);
+};
+
+export function PlanReviewModal({ isOpen, onOpenChange, plan, projectId, conversationId }: PlanReviewModalProps) {
+	const [reviews, setReviews] = useState<Record<string, string>>({});
+	const [rejectPopoverOpened, setRejectPopoverOpened] = useState(false);
+	const [rejectReason, setRejectReason] = useState("");
+	const [selectedBlockId, setSelectedBlockId] = useState<string | null>(null);
+	const rejectTextareaRef = useRef<HTMLTextAreaElement>(null);
+
+	useEffect(() => {
+		if (rejectPopoverOpened && rejectTextareaRef.current) {
+			const timeout = setTimeout(() => {
+				rejectTextareaRef.current?.focus();
+			}, 50);
+			return () => clearTimeout(timeout);
+		}
+	}, [rejectPopoverOpened]);
+
+	const actionMutation = harnessConversationsQuery.action.mutation(projectId, conversationId);
+
+	useEffect(() => {
+		if (selectedBlockId) {
+			const timeout = setTimeout(() => setSelectedBlockId(null), 5000);
+			return () => clearTimeout(timeout);
+		}
+	}, [selectedBlockId]);
+
+	const handleReviewClick = (id: string) => {
+		setSelectedBlockId(id);
+		const element = document.getElementById(id);
+		if (element) {
+			element.scrollIntoView({ behavior: "smooth", block: "center" });
+		}
+	};
+
+	const handleSaveReview = (id: string, text: string) => {
+		setReviews((prev) => {
+			const newReviews = { ...prev };
+			if (!text.trim()) delete newReviews[id];
+			else newReviews[id] = text;
+			return newReviews;
+		});
+	};
+
+	const hasReviews = Object.keys(reviews).length > 0;
+
+	const blockData = (() => {
+		const data: { content: string, lineNumber: number, id: string }[] = [];
+		let currentLineNumber = 1;
+		const rawBlocks = plan.split(/(\n\n+)/);
+		let index = 0;
+		for (let i = 0; i < rawBlocks.length; i++) {
+			if (i % 2 === 0) {
+				if (rawBlocks[i].trim().length > 0) {
+					data.push({
+						content: rawBlocks[i],
+						lineNumber: currentLineNumber,
+						id: "block-" + index,
+					});
+					index++;
+				}
+				currentLineNumber += (rawBlocks[i].match(/\n/g) || []).length;
+			} else {
+				currentLineNumber += (rawBlocks[i].match(/\n/g) || []).length;
+			}
+		}
+		return data;
+	})();
+
+	const handleAction = (action: "approve" | "reject" | "review") => {
+		const payload =
+			action === "review"
+				? {
+						action: "hitl_review" as const,
+						hitl_review: {
+							reviews: Object.entries(reviews).map(([id, text]) => {
+								const block = blockData.find((b) => b.id === id);
+								const lineNum = block ? block.lineNumber : 1;
+								return `(Line ${lineNum}): ${text}`;
+							}),
+						},
+					}
+				: { action: action === "approve" ? ("hitl_approve" as const) : ("hitl_reject" as const) };
+
+		actionMutation.mutate(payload, {
+			onSuccess: () => {
+				useAiHarnessStore.getState().optimisticResume(conversationId);
+				onOpenChange(false);
+				setReviews({});
+			},
+			onError: (err) => {
+				console.error("Action failed:", err);
+			}
+		});
+	};
+
+
+	return (
+		<Modal isOpen={isOpen} onOpenChange={onOpenChange}>
+			<Modal.Backdrop>
+				<Modal.Container placement="center" size="lg">
+					<Modal.Dialog className="max-w-6xl w-full">
+						<Modal.Header className="border-b border-white/10 px-6 py-3">
+							<h3 className="text-lg font-semibold">Review Proposed Plan</h3>
+						</Modal.Header>
+						<Modal.Body className="p-0 flex flex-row overflow-hidden" style={{ height: "calc(90vh - 140px)" }}>
+							{/* Left Panel: Markdown Content (60%) */}
+							<div className="flex-1 overflow-y-auto p-6 border-r border-white/10 bg-background/50">
+								<div className="mx-auto max-w-3xl">
+									{blockData.map((block) => {
+										return (
+											<HoverableBlock
+												key={block.id}
+												blockId={block.id}
+												existingReview={reviews[block.id]}
+												onSaveReview={handleSaveReview}
+												isSelected={selectedBlockId === block.id}
+												onClick={() => setSelectedBlockId(block.id)}
+											>
+												<MarkdownViewer content={block.content} />
+											</HoverableBlock>
+										);
+									})}
+								</div>
+							</div>
+
+							{/* Right Panel: Reviews (40%) */}
+							<div className="w-2/5 flex flex-col bg-surface overflow-hidden">
+								<div className="p-6 pb-4 border-b border-white/10 shrink-0">
+									<h4 className="text-lg font-semibold">Your Reviews</h4>
+								</div>
+								<div className="flex-1 overflow-y-auto p-6">
+									{hasReviews ? (
+										<div className="flex flex-col gap-3">
+											{Object.entries(reviews).map(([id, text]) => (
+												<div
+													key={id}
+													onClick={() => handleReviewClick(id)}
+													className={`group relative flex flex-col gap-2 rounded-xl border p-4 cursor-pointer transition-all duration-200 ${
+														selectedBlockId === id
+															? "border-primary bg-primary/10"
+															: "border-white/10 bg-white/5 hover:border-white/20"
+													}`}
+												>
+													<div className="flex justify-between items-start gap-2">
+														<p className="text-sm flex-1 whitespace-pre-wrap break-words m-0">
+															{text}
+														</p>
+														<Button
+															isIconOnly
+															size="sm"
+															variant="danger"
+															className="opacity-0 group-hover:opacity-100 h-6 w-6 rounded-full shrink-0"
+															onPress={(e) => {
+																handleSaveReview(id, "");
+															}}
+														>
+															<TbX size={14} />
+														</Button>
+													</div>
+												</div>
+											))}
+										</div>
+									) : (
+										<div className="flex h-full items-center justify-center text-center text-sm text-muted">
+											Hover over any line on the left to add a review.
+										</div>
+									)}
+								</div>
+
+								{/* Footer Actions */}
+								<div className="p-4 border-t border-white/10 bg-black/20 shrink-0 flex justify-end gap-3 items-center">
+									{/* @ts-expect-error placement is valid */}
+									<Popover placement="top-end" isOpen={rejectPopoverOpened} onOpenChange={setRejectPopoverOpened}>
+										<PopoverTrigger>
+											<Button variant="danger" size="sm" isPending={actionMutation.isPending}>
+												<TbX size={16} /> Reject
+											</Button>
+										</PopoverTrigger>
+										<PopoverContent className="w-72 rounded-xl border border-white/10 bg-[#1e1e20] p-4 shadow-xl">
+											<div className="flex flex-col gap-3 w-full">
+												<span className="text-sm font-medium">Rejection Reason (Optional)</span>
+												<textarea
+													ref={rejectTextareaRef}
+													placeholder="Why are you rejecting this plan?"
+													value={rejectReason}
+													onChange={(e) => setRejectReason(e.target.value)}
+													className="w-full min-h-[60px] rounded-lg bg-black/20 p-2 text-sm text-foreground outline-none border border-white/10 focus:border-danger/50"
+												/>
+												<div className="flex justify-end gap-2 pt-1">
+													<Button size="sm" variant="ghost" className="h-7 text-xs px-3" onPress={() => setRejectPopoverOpened(false)}>
+														Cancel
+													</Button>
+													<Button size="sm" variant="danger" className="h-7 text-xs px-3" onPress={() => {
+														setRejectPopoverOpened(false);
+														handleAction("reject");
+													}}>
+														Confirm Reject
+													</Button>
+												</div>
+											</div>
+										</PopoverContent>
+									</Popover>
+
+									<Button
+										variant={hasReviews ? "secondary" : "primary"}
+										size="sm"
+										onPress={() => handleAction(hasReviews ? "review" : "approve")}
+										isPending={actionMutation.isPending}
+									>
+										{hasReviews ? <TbEdit size={16} /> : <TbCheck size={16} />}
+										{hasReviews ? "Submit Review" : "Approve Plan"}
+									</Button>
+								</div>
+							</div>
+						</Modal.Body>
+					</Modal.Dialog>
+				</Modal.Container>
+			</Modal.Backdrop>
+		</Modal>
+	);
+}

--- a/apps/portal/src/components/ai/PromptEditor.tsx
+++ b/apps/portal/src/components/ai/PromptEditor.tsx
@@ -24,11 +24,12 @@ type Props = {
 	typewriter?: boolean;
 	isRunning?: boolean;
 	onStop?: () => void;
+	isDisabled?: boolean;
 };
 
 export function PromptEditor({ 
 	projectId, value, onChange, onSubmit, isPending, models, defaultModelId, minRows = 1, maxRows = 2,
-	placeholder = "Message AI...", typewriter = true, isRunning, onStop
+	placeholder = "Message AI...", typewriter = true, isRunning, onStop, isDisabled
 }: Props) {
 	const [model, setModel] = useState<string>(defaultModelId ?? (models[0]?.id || ""));
 	const [helpOpen, setHelpOpen] = useState(false);
@@ -74,7 +75,7 @@ export function PromptEditor({
 	}, [value]);
 
 	const trimmed = value.trim();
-	const canSend = trimmed.length > 0 && !isPending;
+	const canSend = trimmed.length > 0 && !isPending && !isDisabled;
 
 	const submit = () => {
 		if (!canSend) return;
@@ -84,7 +85,7 @@ export function PromptEditor({
 	};
 
 	return (
-		<div className="relative rounded-2xl border border-white/10 bg-[#161618] p-4 shadow-2xl transition-colors focus-within:border-[#ccff00]/50">
+		<div className={`relative rounded-2xl border border-white/10 bg-[#161618] p-4 shadow-2xl transition-colors focus-within:border-[#ccff00]/50 ${isDisabled ? 'opacity-50 pointer-events-none' : ''}`}>
 			<textarea
 				ref={textareaRef}
 				value={value}
@@ -95,13 +96,14 @@ export function PromptEditor({
 						submit();
 					}
 				}}
-				placeholder={typewriter ? twPlaceholder + (charIndex < PLACEHOLDERS[phIndex].length ? "|" : "") : placeholder}
+				disabled={isDisabled}
+				placeholder={isDisabled ? "Please review the implementation plan to continue..." : (typewriter ? twPlaceholder + (charIndex < PLACEHOLDERS[phIndex].length ? "|" : "") : placeholder)}
 				rows={minRows}
 				style={{
 					minHeight: minRows === 1 ? "24px" : `${minRows * 23}px`,
 					maxHeight: `${maxRows * 23}px`,
 				}}
-				className="w-full resize-none bg-transparent px-1 text-sm leading-relaxed text-foreground outline-none placeholder:text-muted"
+				className="w-full resize-none bg-transparent px-1 text-sm leading-relaxed text-foreground outline-none placeholder:text-muted disabled:cursor-not-allowed"
 			/>
 			
 			<div className="mt-2 flex items-end justify-between gap-3">

--- a/apps/portal/src/components/ai/UserMessage.tsx
+++ b/apps/portal/src/components/ai/UserMessage.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Card, Button } from "@fluxify/components";
+import { Card, Button, Typography } from "@fluxify/components";
 import { TbCopy, TbCheck } from "react-icons/tb";
 
 export function UserMessage({ query }: { query: string }) {
@@ -15,9 +15,9 @@ export function UserMessage({ query }: { query: string }) {
 		<div className="group flex w-full justify-end">
 			<div className="flex max-w-[70%] flex-col items-end gap-1">
 				<Card className="rounded-2xl rounded-br-sm border-none bg-default-100 !p-0 shadow-none">
-					<div className="whitespace-pre-wrap px-4 py-3 text-sm leading-relaxed text-foreground/80">
+					<Typography.Paragraph className="whitespace-pre-wrap px-4 py-3 text-sm leading-relaxed text-foreground/80 m-0">
 						{query}
-					</div>
+					</Typography.Paragraph>
 				</Card>
 
 				<div className="opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100">

--- a/apps/portal/src/components/ai/useScrollToBottom.ts
+++ b/apps/portal/src/components/ai/useScrollToBottom.ts
@@ -19,8 +19,8 @@ export function useScrollToBottom(bottomRef: RefObject<HTMLElement | null>, thre
 		return () => observer.disconnect();
 	}, [bottomRef, threshold]);
 
-	const scrollToBottom = useCallback(() => {
-		bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+	const scrollToBottom = useCallback((behavior: ScrollBehavior = "smooth") => {
+		bottomRef.current?.scrollIntoView({ behavior, block: "end" });
 	}, [bottomRef]);
 
 	return { isAtBottom, scrollToBottom };

--- a/apps/portal/src/store/aiHarness.ts
+++ b/apps/portal/src/store/aiHarness.ts
@@ -91,6 +91,8 @@ export interface AiHarnessActions {
 	setConversationList: (items: ConversationMeta[]) => void;
 	upsertConversation: (item: ConversationMeta) => void;
 	removeConversation: (conversationId: string) => void;
+	clearRun: (conversationId: string) => void;
+	optimisticResume: (conversationId: string) => void;
 	reset: () => void;
 }
 
@@ -256,6 +258,20 @@ export const useAiHarnessStore = create<AiHarnessState & AiHarnessActions>()(
 			set((state) => {
 				state.list = state.list.filter((c) => c.id !== conversationId);
 				delete state.runs[conversationId];
+			}),
+
+		clearRun: (conversationId) =>
+			set((state) => {
+				delete state.runs[conversationId];
+			}),
+
+		optimisticResume: (conversationId) =>
+			set((state) => {
+				const run = state.runs[conversationId];
+				if (run) {
+					run.runStatus = "executing";
+					run.isTerminal = false;
+				}
 			}),
 
 		// Only for logout / project switch. NOT called on disconnect — reconnects

--- a/apps/server/src/db/agent-harness-schema.ts
+++ b/apps/server/src/db/agent-harness-schema.ts
@@ -276,6 +276,10 @@ export const agentHarnessSubArtifactsEntity = pgTable(
 		kind: varchar("kind", { length: 50 }).notNull(),
 		// "add" | "delete" | "changes"
 		action: varchar("action", { length: 50 }),
+		/** Set when the user applies this output to the project. Null = never
+		 *  applied, so sub-agents can tell what is live and what is only proposed.
+		 *  Re-applying just refreshes the timestamp. */
+		appliedAt: timestamp("applied_at"),
 		payload: jsonb("payload").$type<Record<string, any>>().notNull(),
 		createdAt: timestamp("created_at").defaultNow().notNull(),
 	},

--- a/apps/server/src/db/migrations/0044_breezy_green_goblin.sql
+++ b/apps/server/src/db/migrations/0044_breezy_green_goblin.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "agent_harness_sub_artifacts" ADD COLUMN "applied_at" timestamp;

--- a/apps/server/src/db/migrations/meta/0044_snapshot.json
+++ b/apps/server/src/db/migrations/meta/0044_snapshot.json
@@ -1,0 +1,3204 @@
+{
+  "id": "a562a0ed-1c54-4ada-af9f-cfc6b8044644",
+  "prevId": "5f326bc4-298c-44c0-b178-1c68a22b4c3a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.access_control": {
+      "name": "access_control",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "access_control_roles",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_access_control_user_id": {
+          "name": "idx_access_control_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_access_control_project_id": {
+          "name": "idx_access_control_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "access_control_user_id_system_users_id_fk": {
+          "name": "access_control_user_id_system_users_id_fk",
+          "tableFrom": "access_control",
+          "tableTo": "system_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "access_control_project_id_projects_id_fk": {
+          "name": "access_control_project_id_projects_id_fk",
+          "tableFrom": "access_control",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_chat_conversations": {
+      "name": "ai_chat_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'New chat'"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ai_chat_conversation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'not_started'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_chat_conversations_user_id_system_users_id_fk": {
+          "name": "ai_chat_conversations_user_id_system_users_id_fk",
+          "tableFrom": "ai_chat_conversations",
+          "tableTo": "system_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_chat_conversations_project_id_projects_id_fk": {
+          "name": "ai_chat_conversations_project_id_projects_id_fk",
+          "tableFrom": "ai_chat_conversations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_chat_history": {
+      "name": "ai_chat_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ai_chat_conversation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'running'"
+        },
+        "user_query": {
+          "name": "user_query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "final_output": {
+          "name": "final_output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_execution_history": {
+          "name": "workflow_execution_history",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_chat_history_conversation_id_ai_chat_conversations_id_fk": {
+          "name": "ai_chat_history_conversation_id_ai_chat_conversations_id_fk",
+          "tableFrom": "ai_chat_history",
+          "tableTo": "ai_chat_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_workflow_builder_steps": {
+      "name": "ai_workflow_builder_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_history_id": {
+          "name": "chat_history_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_type": {
+          "name": "step_type",
+          "type": "ai_workflow_builder_step_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_status": {
+          "name": "step_status",
+          "type": "ai_workflow_builder_step_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "step_order": {
+          "name": "step_order",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_data": {
+          "name": "input_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_data": {
+          "name": "output_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ai_wf_steps_chat_history_id": {
+          "name": "idx_ai_wf_steps_chat_history_id",
+          "columns": [
+            {
+              "expression": "chat_history_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_wf_steps_conversation_id": {
+          "name": "idx_ai_wf_steps_conversation_id",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_wf_steps_step_type": {
+          "name": "idx_ai_wf_steps_step_type",
+          "columns": [
+            {
+              "expression": "step_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_wf_steps_step_status": {
+          "name": "idx_ai_wf_steps_step_status",
+          "columns": [
+            {
+              "expression": "step_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_workflow_builder_steps_chat_history_id_ai_chat_history_id_fk": {
+          "name": "ai_workflow_builder_steps_chat_history_id_ai_chat_history_id_fk",
+          "tableFrom": "ai_workflow_builder_steps",
+          "tableTo": "ai_chat_history",
+          "columnsFrom": [
+            "chat_history_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_workflow_builder_steps_conversation_id_ai_chat_conversations_id_fk": {
+          "name": "ai_workflow_builder_steps_conversation_id_ai_chat_conversations_id_fk",
+          "tableFrom": "ai_workflow_builder_steps",
+          "tableTo": "ai_chat_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_config": {
+      "name": "app_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key_name": {
+          "name": "key_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_encrypted": {
+          "name": "is_encrypted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "encoding_type": {
+          "name": "encoding_type",
+          "type": "encoding_types",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "app_config_data_types",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'string'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_app_config_key_name": {
+          "name": "idx_app_config_key_name",
+          "columns": [
+            {
+              "expression": "key_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_app_config_project_id": {
+          "name": "idx_app_config_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_app_config_is_encrypted": {
+          "name": "idx_app_config_is_encrypted",
+          "columns": [
+            {
+              "expression": "is_encrypted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_app_config_encoding_type": {
+          "name": "idx_app_config_encoding_type",
+          "columns": [
+            {
+              "expression": "encoding_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_app_config_key_name_fts": {
+          "name": "idx_app_config_key_name_fts",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', \"key_name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_app_config_desc_fts": {
+          "name": "idx_app_config_desc_fts",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', coalesce(\"description\", ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_config_project_id_projects_id_fk": {
+          "name": "app_config_project_id_projects_id_fk",
+          "tableFrom": "app_config",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocks": {
+      "name": "blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_id": {
+          "name": "route_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_blocks_route_id": {
+          "name": "idx_blocks_route_id",
+          "columns": [
+            {
+              "expression": "route_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blocks_route_id_routes_id_fk": {
+          "name": "blocks_route_id_routes_id_fk",
+          "tableFrom": "blocks",
+          "tableTo": "routes",
+          "columnsFrom": [
+            "route_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_block_graphs": {
+      "name": "custom_block_graphs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "custom_block_id": {
+          "name": "custom_block_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_block_id": {
+          "name": "next_block_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_custom_block_graphs_custom_block_id": {
+          "name": "idx_custom_block_graphs_custom_block_id",
+          "columns": [
+            {
+              "expression": "custom_block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "custom_block_graphs_custom_block_id_custom_blocks_list_id_fk": {
+          "name": "custom_block_graphs_custom_block_id_custom_blocks_list_id_fk",
+          "tableFrom": "custom_block_graphs",
+          "tableTo": "custom_blocks_list",
+          "columnsFrom": [
+            "custom_block_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_blocks_list": {
+      "name": "custom_blocks_list",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "custom_block_icon_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_params": {
+          "name": "input_params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "custom_block_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user-defined'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_custom_blocks_list_project_id": {
+          "name": "idx_custom_blocks_list_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_custom_blocks_list_name": {
+          "name": "idx_custom_blocks_list_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "custom_blocks_list_project_id_projects_id_fk": {
+          "name": "custom_blocks_list_project_id_projects_id_fk",
+          "tableFrom": "custom_blocks_list",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.edges": {
+      "name": "edges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "from": {
+          "name": "from",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to": {
+          "name": "to",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_handle": {
+          "name": "from_handle",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_handle": {
+          "name": "to_handle",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_id": {
+          "name": "route_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_edges_from": {
+          "name": "idx_edges_from",
+          "columns": [
+            {
+              "expression": "from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_edges_to": {
+          "name": "idx_edges_to",
+          "columns": [
+            {
+              "expression": "to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_edges_route_id": {
+          "name": "idx_edges_route_id",
+          "columns": [
+            {
+              "expression": "route_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "edges_from_blocks_id_fk": {
+          "name": "edges_from_blocks_id_fk",
+          "tableFrom": "edges",
+          "tableTo": "blocks",
+          "columnsFrom": [
+            "from"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edges_to_blocks_id_fk": {
+          "name": "edges_to_blocks_id_fk",
+          "tableFrom": "edges",
+          "tableTo": "blocks",
+          "columnsFrom": [
+            "to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edges_route_id_routes_id_fk": {
+          "name": "edges_route_id_routes_id_fk",
+          "tableFrom": "edges",
+          "tableTo": "routes",
+          "columnsFrom": [
+            "route_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instance_settings": {
+      "name": "instance_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "instance_setting_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "instance_settings_key_unique": {
+          "name": "instance_settings_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integrations": {
+      "name": "integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group": {
+          "name": "group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_integrations_name": {
+          "name": "idx_integrations_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integrations_group": {
+          "name": "idx_integrations_group",
+          "columns": [
+            {
+              "expression": "group",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integrations_variant": {
+          "name": "idx_integrations_variant",
+          "columns": [
+            {
+              "expression": "variant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integrations_tags": {
+          "name": "idx_integrations_tags",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integrations_project_id": {
+          "name": "idx_integrations_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integrations_name_fts": {
+          "name": "idx_integrations_name_fts",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', \"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integrations_project_id_projects_id_fk": {
+          "name": "integrations_project_id_projects_id_fk",
+          "tableFrom": "integrations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_settings": {
+      "name": "project_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_project_settings_project_id": {
+          "name": "idx_project_settings_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_settings_key": {
+          "name": "idx_project_settings_key",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_settings_project_id_projects_id_fk": {
+          "name": "project_settings_project_id_projects_id_fk",
+          "tableFrom": "project_settings",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_projects_id": {
+          "name": "idx_projects_id",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_projects_name": {
+          "name": "idx_projects_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_projects_updated_at": {
+          "name": "idx_projects_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.routes": {
+      "name": "routes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "NULL"
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_schema": {
+          "name": "body_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query_schema": {
+          "name": "query_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "params_schema": {
+          "name": "params_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_routes_project_id": {
+          "name": "idx_routes_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_routes_path": {
+          "name": "idx_routes_path",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_routes_name_fts": {
+          "name": "idx_routes_name_fts",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', \"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "routes_project_id_projects_id_fk": {
+          "name": "routes_project_id_projects_id_fk",
+          "tableFrom": "routes",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_suites": {
+      "name": "test_suites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_id": {
+          "name": "route_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "query_params": {
+          "name": "query_params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "route_params": {
+          "name": "route_params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "body": {
+          "name": "body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assertions": {
+          "name": "assertions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "integration_overrides": {
+          "name": "integration_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "app_config_overrides": {
+          "name": "app_config_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_suites_route_id_routes_id_fk": {
+          "name": "test_suites_route_id_routes_id_fk",
+          "tableFrom": "test_suites",
+          "tableTo": "routes",
+          "columnsFrom": [
+            "route_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_harness_artifacts": {
+      "name": "agent_harness_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_harness_artifacts_conv_id": {
+          "name": "idx_harness_artifacts_conv_id",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_harness_artifacts_run_id": {
+          "name": "idx_harness_artifacts_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_harness_artifacts_conversation_id_agent_harness_conversations_id_fk": {
+          "name": "agent_harness_artifacts_conversation_id_agent_harness_conversations_id_fk",
+          "tableFrom": "agent_harness_artifacts",
+          "tableTo": "agent_harness_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_harness_artifacts_run_id_agent_harness_runs_id_fk": {
+          "name": "agent_harness_artifacts_run_id_agent_harness_runs_id_fk",
+          "tableFrom": "agent_harness_artifacts",
+          "tableTo": "agent_harness_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_harness_conversations": {
+      "name": "agent_harness_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'New Chat'"
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_harness_conversation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "active_run_id": {
+          "name": "active_run_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_harness_conv_user_id": {
+          "name": "idx_harness_conv_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_harness_conv_project_id": {
+          "name": "idx_harness_conv_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_harness_conv_user_archived_pinned": {
+          "name": "idx_harness_conv_user_archived_pinned",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_harness_conversations_user_id_system_users_id_fk": {
+          "name": "agent_harness_conversations_user_id_system_users_id_fk",
+          "tableFrom": "agent_harness_conversations",
+          "tableTo": "system_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_harness_conversations_project_id_projects_id_fk": {
+          "name": "agent_harness_conversations_project_id_projects_id_fk",
+          "tableFrom": "agent_harness_conversations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_harness_hitl_actions": {
+      "name": "agent_harness_hitl_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_id": {
+          "name": "step_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "agent_harness_hitl_action_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_response": {
+          "name": "user_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_harness_hitl_run_id": {
+          "name": "idx_harness_hitl_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_harness_hitl_step_id": {
+          "name": "idx_harness_hitl_step_id",
+          "columns": [
+            {
+              "expression": "step_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_harness_hitl_actions_run_id_agent_harness_runs_id_fk": {
+          "name": "agent_harness_hitl_actions_run_id_agent_harness_runs_id_fk",
+          "tableFrom": "agent_harness_hitl_actions",
+          "tableTo": "agent_harness_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_harness_hitl_actions_step_id_agent_harness_steps_id_fk": {
+          "name": "agent_harness_hitl_actions_step_id_agent_harness_steps_id_fk",
+          "tableFrom": "agent_harness_hitl_actions",
+          "tableTo": "agent_harness_steps",
+          "columnsFrom": [
+            "step_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_harness_live_states": {
+      "name": "agent_harness_live_states",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_state": {
+          "name": "current_state",
+          "type": "agent_harness_live_state_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "active_step_id": {
+          "name": "active_step_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "working_memory": {
+          "name": "working_memory",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_harness_live_conv_id": {
+          "name": "idx_harness_live_conv_id",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_harness_live_states_run_id_agent_harness_runs_id_fk": {
+          "name": "agent_harness_live_states_run_id_agent_harness_runs_id_fk",
+          "tableFrom": "agent_harness_live_states",
+          "tableTo": "agent_harness_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_harness_live_states_conversation_id_agent_harness_conversations_id_fk": {
+          "name": "agent_harness_live_states_conversation_id_agent_harness_conversations_id_fk",
+          "tableFrom": "agent_harness_live_states",
+          "tableTo": "agent_harness_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_harness_runs": {
+      "name": "agent_harness_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_query": {
+          "name": "user_query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_response": {
+          "name": "ai_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_harness_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "interrupted_at": {
+          "name": "interrupted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_harness_runs_conv_id": {
+          "name": "idx_harness_runs_conv_id",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_harness_runs_status": {
+          "name": "idx_harness_runs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_harness_runs_integration_id": {
+          "name": "idx_harness_runs_integration_id",
+          "columns": [
+            {
+              "expression": "integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_harness_runs_conversation_id_agent_harness_conversations_id_fk": {
+          "name": "agent_harness_runs_conversation_id_agent_harness_conversations_id_fk",
+          "tableFrom": "agent_harness_runs",
+          "tableTo": "agent_harness_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_harness_runs_integration_id_integrations_id_fk": {
+          "name": "agent_harness_runs_integration_id_integrations_id_fk",
+          "tableFrom": "agent_harness_runs",
+          "tableTo": "integrations",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_harness_steps": {
+      "name": "agent_harness_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_type": {
+          "name": "step_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_order": {
+          "name": "step_order",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sub_agent_role": {
+          "name": "sub_agent_role",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sub_agent_id": {
+          "name": "sub_agent_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_harness_step_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_harness_steps_run_id": {
+          "name": "idx_harness_steps_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_harness_steps_sub_agent_id": {
+          "name": "idx_harness_steps_sub_agent_id",
+          "columns": [
+            {
+              "expression": "sub_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_harness_steps_run_sub_agent": {
+          "name": "uq_harness_steps_run_sub_agent",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sub_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_harness_steps_run_id_agent_harness_runs_id_fk": {
+          "name": "agent_harness_steps_run_id_agent_harness_runs_id_fk",
+          "tableFrom": "agent_harness_steps",
+          "tableTo": "agent_harness_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_harness_steps_conversation_id_agent_harness_conversations_id_fk": {
+          "name": "agent_harness_steps_conversation_id_agent_harness_conversations_id_fk",
+          "tableFrom": "agent_harness_steps",
+          "tableTo": "agent_harness_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_harness_sub_artifacts": {
+      "name": "agent_harness_sub_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sub_agent_id": {
+          "name": "sub_agent_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_harness_sub_artifacts_artifact_id": {
+          "name": "idx_harness_sub_artifacts_artifact_id",
+          "columns": [
+            {
+              "expression": "artifact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_harness_sub_artifacts_run_id": {
+          "name": "idx_harness_sub_artifacts_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_harness_sub_artifacts_artifact_id_agent_harness_artifacts_id_fk": {
+          "name": "agent_harness_sub_artifacts_artifact_id_agent_harness_artifacts_id_fk",
+          "tableFrom": "agent_harness_sub_artifacts",
+          "tableTo": "agent_harness_artifacts",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_harness_sub_artifacts_conversation_id_agent_harness_conversations_id_fk": {
+          "name": "agent_harness_sub_artifacts_conversation_id_agent_harness_conversations_id_fk",
+          "tableFrom": "agent_harness_sub_artifacts",
+          "tableTo": "agent_harness_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_harness_sub_artifacts_run_id_agent_harness_runs_id_fk": {
+          "name": "agent_harness_sub_artifacts_run_id_agent_harness_runs_id_fk",
+          "tableFrom": "agent_harness_sub_artifacts",
+          "tableTo": "agent_harness_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_users": {
+      "name": "system_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system_admin": {
+          "name": "is_system_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "system_users_email_unique": {
+          "name": "system_users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_id_system_users_id_fk": {
+          "name": "user_id_system_users_id_fk",
+          "tableFrom": "user",
+          "tableTo": "system_users",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.access_control_roles": {
+      "name": "access_control_roles",
+      "schema": "public",
+      "values": [
+        "viewer",
+        "creator",
+        "project_admin",
+        "system_admin"
+      ]
+    },
+    "public.ai_chat_conversation_status": {
+      "name": "ai_chat_conversation_status",
+      "schema": "public",
+      "values": [
+        "not_started",
+        "running",
+        "success",
+        "error",
+        "paused",
+        "plan_rejected"
+      ]
+    },
+    "public.ai_workflow_builder_step_status": {
+      "name": "ai_workflow_builder_step_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "completed",
+        "failed",
+        "paused",
+        "awaiting_review"
+      ]
+    },
+    "public.ai_workflow_builder_step_type": {
+      "name": "ai_workflow_builder_step_type",
+      "schema": "public",
+      "values": [
+        "verify",
+        "planner",
+        "orchestrator",
+        "sub_agent",
+        "evaluator"
+      ]
+    },
+    "public.app_config_data_types": {
+      "name": "app_config_data_types",
+      "schema": "public",
+      "values": [
+        "string",
+        "number",
+        "boolean"
+      ]
+    },
+    "public.custom_block_icon_type": {
+      "name": "custom_block_icon_type",
+      "schema": "public",
+      "values": [
+        "premade-list",
+        "custom"
+      ]
+    },
+    "public.custom_block_source_type": {
+      "name": "custom_block_source_type",
+      "schema": "public",
+      "values": [
+        "plugin",
+        "inhouse",
+        "user-defined"
+      ]
+    },
+    "public.encoding_types": {
+      "name": "encoding_types",
+      "schema": "public",
+      "values": [
+        "plaintext",
+        "base64",
+        "hex"
+      ]
+    },
+    "public.instance_setting_category": {
+      "name": "instance_setting_category",
+      "schema": "public",
+      "values": [
+        "auth"
+      ]
+    },
+    "public.agent_harness_conversation_status": {
+      "name": "agent_harness_conversation_status",
+      "schema": "public",
+      "values": [
+        "idle",
+        "running",
+        "paused_hitl",
+        "interrupted",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.agent_harness_hitl_action_type": {
+      "name": "agent_harness_hitl_action_type",
+      "schema": "public",
+      "values": [
+        "plan_approval",
+        "plan_rejection",
+        "user_input",
+        "confirmation",
+        "cancellation",
+        "custom"
+      ]
+    },
+    "public.agent_harness_live_state_status": {
+      "name": "agent_harness_live_state_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "paused_hitl",
+        "interrupted",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.agent_harness_run_status": {
+      "name": "agent_harness_run_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "routing",
+        "verifying",
+        "planning",
+        "orchestrating",
+        "executing",
+        "awaiting_hitl",
+        "completed",
+        "interrupted",
+        "failed"
+      ]
+    },
+    "public.agent_harness_step_status": {
+      "name": "agent_harness_step_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "interrupted"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/server/src/db/migrations/meta/_journal.json
+++ b/apps/server/src/db/migrations/meta/_journal.json
@@ -309,6 +309,13 @@
       "when": 1785020213579,
       "tag": "0043_bent_pepper_potts",
       "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "7",
+      "when": 1785195371771,
+      "tag": "0044_breezy_green_goblin",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/middlewares/zodErrorCallbackParser.ts
+++ b/apps/server/src/middlewares/zodErrorCallbackParser.ts
@@ -8,7 +8,7 @@ export default function (error: any, ctx: Context) {
 			type: "validation",
 			error: [],
 		};
-		for (let err of error?.error) {
+		for (let err of error?.error?.issues ?? []) {
 			errorsList.error.push({
 				field: err.path[0],
 				message: err.message,


### PR DESCRIPTION
## Why

Long harness runs were failing in ways that had nothing to do with the model getting the answer wrong: empty/multi-block responses crashed the JSON parse, blind retries re-sent the exact prompt that just failed, stuck provider connections hung a run forever, and runs that produced a perfectly good result still ended `failed` with a blank message. Separately, the plan review flow had no UI and applied sub-artifacts could be applied again.

## What

**Harness robustness**
- `fallbackStructuredOutput` now extracts text from multi-block/reasoning responses, strips prose around the JSON payload, drops `null`s for optional fields, and retries by appending the bad output plus the zod issue list as a **human turn** correction — so the model actually sees what it got wrong.
- Every model/tool call goes through `withSignal()` with a 180s timeout (`HARNESS_MODEL_TIMEOUT_MS`); the tool-loop `invoke` is retried like every other model call.
- Failures persist a categorized, user-readable message via `describeFailure()` naming the node that failed, instead of a bare `failed` status. `recursionLimit` raised to 100 — the default 25 killed 6–7 task builds at the finish line.
- The orchestrator derives the ready task level from task statuses + `dependsOnAgentId` rather than popping `taskQueue`, and the supervisor writes verdicts by task id instead of relying on object aliasing. This fixes skipped and double-dispatched levels.
- `ChatOpenAI` gets `apiKey` (the `openAIApiKey` alias is dead in `@langchain/openai` v1.x and was silently dropping keys for every OpenAI-family provider), and native structured output is skipped when a custom `baseUrl` is set, since OpenAI-compatible servers usually reject `json_schema`.

**Plan review + artifacts**
- New `sub_artifact_applied` conversation action with `appliedAt` tracking (migration `0044`) so an applied sub-artifact isn't applied twice.
- New `getArtifact` tool so agents can read artifacts produced earlier in the conversation.
- Portal: `PlanReviewModal` and `AgentTaskStatus` components, plus streaming, markdown rendering, and scroll-to-bottom refinements in the conversation view.

`AGENT.md` records each of these failure modes and its fix so they don't get reintroduced.

## Testing

- `bun test apps/ai-gateway` — 68 pass / 0 fail, including new specs for orchestrator dispatch ordering, the structured-output fallback, and `getArtifact`.
- Full monorepo typecheck and pre-commit analysis pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
