### PR TITLE
feat(integrations): expose database schema metadata

### DIFF
--- a/apps/server/src/api/v1/integrations/get-metadata/dto.ts
+++ b/apps/server/src/api/v1/integrations/get-metadata/dto.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+
+export const requestRouteSchema = z.object({
+	projectId: z.string(),
+	integrationId: z.uuidv7(),
+});
+
+export const columnSchema = z.object({
+	name: z.string(),
+	type: z.string(),
+	/** table that owns the column — the referenced table for a foreign key, else the column's own table */
+	owner: z.string(),
+});
+
+export const tableSchema = z.object({
+	table: z.string(),
+	columns: z.array(columnSchema),
+});
+
+export const responseSchema = z.object({
+	id: z.string(),
+	name: z.string(),
+	group: z.string(),
+	variant: z.string(),
+	metadata: z.object({
+		tables: z.array(tableSchema),
+	}),
+});

--- a/apps/server/src/api/v1/integrations/get-metadata/route.ts
+++ b/apps/server/src/api/v1/integrations/get-metadata/route.ts
@@ -1,0 +1,58 @@
+import {
+	describeRoute,
+	DescribeRouteOptions,
+	resolver,
+	validator,
+} from "hono-openapi";
+import { requestRouteSchema, responseSchema } from "./dto";
+import handleRequest from "./service";
+import { errorSchema } from "../../../../errors/customError";
+import zodErrorCallbackParser from "../../../../middlewares/zodErrorCallbackParser";
+import { HonoServer } from "../../../../types";
+import { requireProjectAccess } from "../../../auth/middleware";
+
+const openapiRouteOptions: DescribeRouteOptions = {
+	description:
+		"Get the metadata of an integration. Databases return their tables and columns.",
+	operationId: "get-integration-metadata",
+	tags: ["Integrations"],
+	responses: {
+		200: {
+			description: "Successful",
+			content: {
+				"application/json": {
+					schema: resolver(responseSchema),
+				},
+			},
+		},
+		400: {
+			description: "Metadata unavailable for this integration",
+			content: {
+				"application/json": {
+					schema: resolver(errorSchema),
+				},
+			},
+		},
+		404: {
+			description: "Integration not found",
+			content: {
+				"application/json": {
+					schema: resolver(errorSchema),
+				},
+			},
+		},
+	},
+};
+
+export default function (app: HonoServer) {
+	app.get(
+		"/:integrationId/metadata",
+		describeRoute(openapiRouteOptions),
+		requireProjectAccess("creator", { key: "projectId", source: "param" }),
+		validator("param", requestRouteSchema, zodErrorCallbackParser),
+		async (c) => {
+			const params = c.req.valid("param");
+			return c.json(await handleRequest(params));
+		},
+	);
+}

--- a/apps/server/src/api/v1/integrations/get-metadata/service.ts
+++ b/apps/server/src/api/v1/integrations/get-metadata/service.ts
@@ -1,0 +1,103 @@
+import { z } from "zod";
+import { requestRouteSchema, responseSchema } from "./dto";
+import { getIntegrationByID } from "../get-by-id/repository";
+import { NotFoundError } from "../../../../errors/notFoundError";
+import { BadRequestError } from "../../../../errors/badRequestError";
+import { databaseVariantSchema } from "../schemas";
+import { getSchema } from "../helpers";
+import { getAppConfigKeysFromData } from "../create/service";
+import { decodeAppConfig } from "../test-connection/service";
+import { parsePostgresUrl } from "../../../../lib/parsers/postgres";
+import { parseMysqlUrl } from "../../../../lib/parsers/mysql";
+import { parseMongoUrl } from "../../../../lib/parsers/mongodb";
+import {
+	Connection,
+	DbType,
+	extractMongoConnectionInfo,
+	extractMysqlConnectionInfo,
+	extractPgConnectionInfo,
+	introspectConnection,
+} from "@fluxify/adapters";
+
+export default async function handleRequest(
+	params: z.infer<typeof requestRouteSchema>,
+): Promise<z.infer<typeof responseSchema>> {
+	const integration = await getIntegrationByID(
+		params.projectId,
+		params.integrationId,
+	);
+	if (!integration) {
+		throw new NotFoundError("Integration not found");
+	}
+	// ponytail: databases only; other groups get their own metadata shape when they need one.
+	if (integration.group !== "database") {
+		throw new BadRequestError(
+			"Metadata is only available for database integrations",
+		);
+	}
+
+	const schema = getSchema("database", integration.variant!);
+	const parsed = schema?.safeParse(integration.config);
+	if (!parsed?.success) {
+		throw new BadRequestError("Invalid configuration");
+	}
+
+	const appConfigs = await decodeAppConfig(
+		getAppConfigKeysFromData(parsed.data),
+		params.projectId,
+	);
+	const connection = buildConnection(
+		integration.variant!,
+		integration.config,
+		appConfigs,
+	);
+
+	let tables;
+	try {
+		tables = await introspectConnection(connection);
+	} catch (error) {
+		throw new BadRequestError(
+			`Failed to read schema: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+
+	return {
+		id: integration.id,
+		name: integration.name!,
+		group: integration.group!,
+		variant: integration.variant!,
+		metadata: { tables },
+	};
+}
+
+function buildConnection(
+	variant: string,
+	config: any,
+	appConfigs: Map<string, string>,
+): Connection {
+	switch (variant as z.infer<typeof databaseVariantSchema>) {
+		case "PostgreSQL": {
+			const cfg = extractPgConnectionInfo(config, appConfigs, parsePostgresUrl);
+			if (!cfg) break;
+			return {
+				...(cfg as Record<string, any>),
+				ssl: cfg.ssl == "true",
+				dbType: DbType.POSTGRES,
+			} as Connection;
+		}
+		case "MySQL": {
+			const cfg = extractMysqlConnectionInfo(config, appConfigs, parseMysqlUrl);
+			if (!cfg) break;
+			return { ...(cfg as Record<string, any>), dbType: DbType.MYSQL } as Connection;
+		}
+		case "MongoDB": {
+			const cfg = extractMongoConnectionInfo(config, appConfigs, parseMongoUrl);
+			if (!cfg) break;
+			return {
+				...(cfg as Record<string, any>),
+				dbType: DbType.MONGODB,
+			} as Connection;
+		}
+	}
+	throw new BadRequestError("Invalid configuration");
+}

--- a/apps/server/src/api/v1/integrations/register.ts
+++ b/apps/server/src/api/v1/integrations/register.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import registerGetAllRoute from "./get-all/route";
 import registerGetByIdRoute from "./get-by-id/route";
+import registerGetMetadataRoute from "./get-metadata/route";
 import registerCreateRoute from "./create/route";
 import registerUpdateRoute from "./update/route";
 import registerDeleteRoute from "./delete/route";
@@ -16,6 +17,7 @@ export default {
     registerGetBasicListRoute(router);
     registerGetAllRoute(router);
     registerGetByIdRoute(router);
+    registerGetMetadataRoute(router);
     registerCreateRoute(router);
     registerUpdateRoute(router);
     registerDeleteRoute(router);

--- a/apps/server/src/api/v1/integrations/test-connection/service.ts
+++ b/apps/server/src/api/v1/integrations/test-connection/service.ts
@@ -291,7 +291,7 @@ export async function testAiConnection(
 	}
 }
 
-async function decodeAppConfig(keys: string[], projectId: string) {
+export async function decodeAppConfig(keys: string[], projectId: string) {
 	const appConfigs = await getAppConfigs(keys, projectId);
 	const configMap = new Map<string, string>();
 	appConfigs.forEach((config) => {

--- a/packages/adapters/db/index.ts
+++ b/packages/adapters/db/index.ts
@@ -22,6 +22,40 @@ export type DBConditionType = z.infer<typeof whereConditionSchema>;
 export type { DBJoinType, QueryOptions } from "./jsonPath";
 import type { QueryOptions } from "./jsonPath";
 
+export type IntrospectedColumn = {
+	name: string;
+	type: string;
+	/** table that owns the column — the referenced table for a foreign key, else the column's own table */
+	owner: string;
+};
+
+export type IntrospectedTable = {
+	table: string;
+	columns: IntrospectedColumn[];
+};
+
+/** groups flat information_schema rows into the IntrospectedTable shape */
+export function groupIntrospectionRows(
+	rows: Array<{
+		table_name: string;
+		column_name: string;
+		data_type: string;
+		ref_table: string | null;
+	}>,
+): IntrospectedTable[] {
+	const byTable = new Map<string, IntrospectedTable>();
+	for (const r of rows) {
+		let entry = byTable.get(r.table_name);
+		if (!entry) byTable.set(r.table_name, (entry = { table: r.table_name, columns: [] }));
+		entry.columns.push({
+			name: r.column_name,
+			type: r.data_type,
+			owner: r.ref_table ?? r.table_name,
+		});
+	}
+	return [...byTable.values()];
+}
+
 export enum DbAdapterMode {
 	NORMAL = 1,
 	TRANSACTION = 2,
@@ -49,6 +83,8 @@ export interface IDbAdapter {
 		conditions: DBConditionType[],
 	): Promise<any>;
 	raw(query?: string | unknown, params?: any[]): Promise<any>;
+	/** optional — adapters that cannot describe their schema simply omit it */
+	introspect?(): Promise<IntrospectedTable[]>;
 	delete(table: string, conditions: DBConditionType[]): Promise<boolean>;
 	setMode(mode: DbAdapterMode): Promise<void>;
 	startTransaction(): Promise<void>;
@@ -171,6 +207,63 @@ export class DbFactory {
 
 		await Promise.allSettled([...proms, ...mongoProms]);
 	}
+}
+
+/**
+ * Opens a short-lived connection, describes the schema and closes it again.
+ * Design-time only — runtime queries go through DbFactory's pooled adapters.
+ */
+export async function introspectConnection(
+	cfg: Connection,
+): Promise<IntrospectedTable[]> {
+	const vm = {} as JsVM; // introspection never evaluates js conditions
+
+	if (cfg.dbType.toLowerCase() === DbType.POSTGRES.toLowerCase()) {
+		const sql = new SQL({
+			adapter: "postgres",
+			hostname: cfg.host,
+			port: Number(cfg.port),
+			username: cfg.username,
+			password: cfg.password,
+			database: cfg.database,
+			tls: cfg.ssl,
+			max: 2,
+		});
+		const db = PostgresAdapter.createKysely(sql);
+		try {
+			return await new PostgresAdapter(db, sql, vm).introspect();
+		} finally {
+			await sql.close();
+		}
+	}
+
+	if (cfg.dbType.toLowerCase() === DbType.MYSQL.toLowerCase()) {
+		const pool = MySqlAdapter.createPool(cfg);
+		try {
+			return await new MySqlAdapter(
+				MySqlAdapter.createKysely(pool),
+				pool,
+				vm,
+			).introspect();
+		} finally {
+			await pool.promise().end();
+		}
+	}
+
+	if (cfg.dbType.toLowerCase() === DbType.MONGODB.toLowerCase()) {
+		const { MongoClient } = require("mongodb");
+		const client = new MongoClient(buildMongoUrl(cfg), {
+			serverSelectionTimeoutMS: 5000,
+		});
+		try {
+			await client.connect();
+			return await new MongoAdapter(client, client.db(cfg.database), vm).introspect();
+		} finally {
+			await client.close();
+		}
+	}
+
+	throw new Error(`${cfg.dbType} introspection not implemented`);
 }
 
 export * from "./postgresAdapter";

--- a/packages/adapters/db/mongoDbAdapter.test.ts
+++ b/packages/adapters/db/mongoDbAdapter.test.ts
@@ -124,6 +124,30 @@ describe("MongoAdapter Integration Tests", () => {
 		expect(badRes.success).toBe(false);
 	});
 
+	test("introspect: infers fields from sampled documents", async () => {
+		const adapter = new MongoAdapter(client, db, vm);
+		const collectionName = "docs_" + faker.string.alphanumeric(8).toLowerCase();
+		await adapter.insertBulk(collectionName, [
+			{ name: "a", age: 1, tags: ["x"], joined: new Date() },
+			{ name: "b", age: 2, tags: [], joined: new Date(), extra: true },
+		]);
+
+		const schema = await adapter.introspect();
+		const coll = schema.find((t) => t.table === collectionName);
+		expect(coll).toBeDefined();
+
+		const types = Object.fromEntries(
+			coll!.columns.map((c) => [c.name, c.type]),
+		);
+		expect(types.id).toBe("objectId"); // _id is exposed as id
+		expect(types.name).toBe("string");
+		expect(types.age).toBe("number");
+		expect(types.tags).toBe("array");
+		expect(types.joined).toBe("date");
+		expect(types.extra).toBe("boolean"); // present in only one sampled doc
+		expect(coll!.columns.every((c) => c.owner === collectionName)).toBe(true);
+	});
+
 	test("CRUD: Single Record Lifecycle", async () => {
 		const adapter = new MongoAdapter(client, db, vm);
 		const collectionName = "users_" + faker.string.alphanumeric(8).toLowerCase();

--- a/packages/adapters/db/mongoDbAdapter.ts
+++ b/packages/adapters/db/mongoDbAdapter.ts
@@ -4,6 +4,7 @@ import {
 	DbAdapterMode,
 	DBConditionType,
 	IDbAdapter,
+	IntrospectedTable,
 	QueryOptions,
 } from ".";
 import { JsVM } from "@fluxify/lib";
@@ -42,6 +43,34 @@ export class MongoAdapter implements IDbAdapter {
 
 	async raw(): Promise<Db> {
 		return this.db;
+	}
+
+	// Mongo has no schema: infer field names/types from the first 5 documents.
+	// ponytail: top-level fields only; walk nested objects if the UI needs dotted paths.
+	async introspect(): Promise<IntrospectedTable[]> {
+		const collections = await this.db.listCollections().toArray();
+		const result: IntrospectedTable[] = [];
+
+		for (const { name } of collections) {
+			const docs = await this.db.collection(name).find({}).limit(5).toArray();
+			const types = new Map<string, Set<string>>();
+			for (const doc of docs) {
+				for (const [key, value] of Object.entries(doc)) {
+					const field = key === "_id" ? "id" : key;
+					if (!types.has(field)) types.set(field, new Set());
+					types.get(field)!.add(mongoTypeOf(value));
+				}
+			}
+			result.push({
+				table: name,
+				columns: [...types].map(([field, kinds]) => ({
+					name: field,
+					type: [...kinds].sort().join(" | "),
+					owner: name,
+				})),
+			});
+		}
+		return result;
 	}
 
 	// joins are ignored for Mongo (the join UI is hidden when Mongo is selected);
@@ -315,6 +344,14 @@ export class MongoAdapter implements IDbAdapter {
 		};
 		return map[operator] ?? "$eq";
 	}
+}
+
+function mongoTypeOf(value: unknown): string {
+	if (value === null || value === undefined) return "null";
+	if (value instanceof ObjectId) return "objectId";
+	if (value instanceof Date) return "date";
+	if (Array.isArray(value)) return "array";
+	return typeof value;
 }
 
 export function buildMongoUrl(connection: Connection): string {

--- a/packages/adapters/db/mySqlAdapter.test.ts
+++ b/packages/adapters/db/mySqlAdapter.test.ts
@@ -109,6 +109,33 @@ describe("MySqlAdapter Integration Tests", () => {
 		expect(badRes.success).toBe(false);
 	});
 
+	test("introspect: tables, column types and foreign key owners", async () => {
+		const adapter = new MySqlAdapter(db, pool, vm);
+		const suffix = faker.string.alphanumeric(8).toLowerCase();
+		const parent = `authors_${suffix}`;
+		const child = `books_${suffix}`;
+		await adapter.raw(
+			`CREATE TABLE ${parent} (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255) NOT NULL)`,
+		);
+		await adapter.raw(
+			`CREATE TABLE ${child} (id INT AUTO_INCREMENT PRIMARY KEY, title VARCHAR(255), author_id INT, FOREIGN KEY (author_id) REFERENCES ${parent}(id))`,
+		);
+
+		const schema = await adapter.introspect();
+		const books = schema.find((t) => t.table === child);
+		expect(books).toBeDefined();
+		expect(schema.some((t) => t.table === parent)).toBe(true);
+
+		const title = books!.columns.find((c) => c.name === "title");
+		expect(title?.type).toBe("varchar(255)");
+		// a plain column is owned by its own table
+		expect(title?.owner).toBe(child);
+		// a foreign key is owned by the table it references
+		expect(books!.columns.find((c) => c.name === "author_id")?.owner).toBe(
+			parent,
+		);
+	});
+
 	test("CRUD: Single Record Lifecycle", async () => {
 		const adapter = new MySqlAdapter(db, pool, vm);
 		const tableName = "users_" + faker.string.alphanumeric(8).toLowerCase();

--- a/packages/adapters/db/mySqlAdapter.ts
+++ b/packages/adapters/db/mySqlAdapter.ts
@@ -1,7 +1,14 @@
 import { CompiledQuery, Kysely, MysqlDialect } from "kysely";
 import { createPool, Pool } from "mysql2";
 import type { PoolConnection } from "mysql2/promise";
-import { Connection, DbAdapterMode, DBConditionType, IDbAdapter } from ".";
+import {
+	Connection,
+	DbAdapterMode,
+	DBConditionType,
+	groupIntrospectionRows,
+	IDbAdapter,
+	IntrospectedTable,
+} from ".";
 import { JsVM } from "@fluxify/lib";
 import {
 	applyColumns,
@@ -14,6 +21,19 @@ import {
 
 // A generic schema to satisfy Kysely's strict typing without using 'any'
 type FluxifyDatabase = Record<string, Record<string, any>>;
+
+const INTROSPECT_SQL = `
+	SELECT c.TABLE_NAME AS table_name, c.COLUMN_NAME AS column_name,
+	       c.COLUMN_TYPE AS data_type, k.REFERENCED_TABLE_NAME AS ref_table
+	FROM information_schema.COLUMNS c
+	LEFT JOIN information_schema.KEY_COLUMN_USAGE k
+	  ON k.TABLE_SCHEMA = c.TABLE_SCHEMA
+	 AND k.TABLE_NAME = c.TABLE_NAME
+	 AND k.COLUMN_NAME = c.COLUMN_NAME
+	 AND k.REFERENCED_TABLE_NAME IS NOT NULL
+	WHERE c.TABLE_SCHEMA = DATABASE()
+	ORDER BY c.TABLE_NAME, c.ORDINAL_POSITION
+`;
 
 export class MySqlAdapter implements IDbAdapter {
 	public static variant = "MySQL";
@@ -66,6 +86,11 @@ export class MySqlAdapter implements IDbAdapter {
 
 		const conn = this.getConnection();
 		return conn.executeQuery(CompiledQuery.raw(query, params ?? []));
+	}
+
+	async introspect(): Promise<IntrospectedTable[]> {
+		const result = await this.raw(INTROSPECT_SQL);
+		return groupIntrospectionRows(result.rows ?? result);
 	}
 
 	async getAll(

--- a/packages/adapters/db/postgresAdapter.test.ts
+++ b/packages/adapters/db/postgresAdapter.test.ts
@@ -105,6 +105,33 @@ describe("PostgresAdapter Integration Tests", () => {
 		expect(badRes.success).toBe(false);
 	});
 
+	test("introspect: tables, column types and foreign key owners", async () => {
+		const adapter = new PostgresAdapter(db, sql, vm);
+		const suffix = faker.string.alphanumeric(8).toLowerCase();
+		const parent = `authors_${suffix}`;
+		const child = `books_${suffix}`;
+		await adapter.raw(
+			`CREATE TABLE ${parent} (id SERIAL PRIMARY KEY, name VARCHAR(255) NOT NULL)`,
+		);
+		await adapter.raw(
+			`CREATE TABLE ${child} (id SERIAL PRIMARY KEY, title VARCHAR(255), author_id INT REFERENCES ${parent}(id))`,
+		);
+
+		const schema = await adapter.introspect();
+		const books = schema.find((t) => t.table === child);
+		expect(books).toBeDefined();
+		expect(schema.some((t) => t.table === parent)).toBe(true);
+
+		const title = books!.columns.find((c) => c.name === "title");
+		expect(title?.type).toBe("character varying");
+		// a plain column is owned by its own table
+		expect(title?.owner).toBe(child);
+		// a foreign key is owned by the table it references
+		expect(books!.columns.find((c) => c.name === "author_id")?.owner).toBe(
+			parent,
+		);
+	});
+
 	test("CRUD: Single Record Lifecycle", async () => {
 		const adapter = new PostgresAdapter(db, sql, vm);
 		const tableName = "users_" + faker.string.alphanumeric(8).toLowerCase();

--- a/packages/adapters/db/postgresAdapter.ts
+++ b/packages/adapters/db/postgresAdapter.ts
@@ -1,6 +1,13 @@
 import { SQL } from "bun";
 import { CompiledQuery, Kysely } from "kysely";
-import { Connection, DbAdapterMode, DBConditionType, IDbAdapter } from ".";
+import {
+	Connection,
+	DbAdapterMode,
+	DBConditionType,
+	groupIntrospectionRows,
+	IDbAdapter,
+	IntrospectedTable,
+} from ".";
 import { JsVM } from "@fluxify/lib";
 import { BunSqlPostgresDialect } from "./kyselySqlDialect";
 import {
@@ -13,6 +20,27 @@ import {
 } from "./jsonPath";
 
 export type FluxifyDatabase = Record<string, Record<string, any>>;
+
+const INTROSPECT_SQL = `
+	SELECT c.table_name, c.column_name, c.data_type, fk.ref_table
+	FROM information_schema.columns c
+	LEFT JOIN (
+		SELECT kcu.table_schema, kcu.table_name, kcu.column_name,
+		       ccu.table_name AS ref_table
+		FROM information_schema.table_constraints tc
+		JOIN information_schema.key_column_usage kcu
+		  ON kcu.constraint_name = tc.constraint_name
+		 AND kcu.constraint_schema = tc.constraint_schema
+		JOIN information_schema.constraint_column_usage ccu
+		  ON ccu.constraint_name = tc.constraint_name
+		 AND ccu.constraint_schema = tc.constraint_schema
+		WHERE tc.constraint_type = 'FOREIGN KEY'
+	) fk ON fk.table_schema = c.table_schema
+	    AND fk.table_name = c.table_name
+	    AND fk.column_name = c.column_name
+	WHERE c.table_schema NOT IN ('pg_catalog', 'information_schema')
+	ORDER BY c.table_name, c.ordinal_position
+`;
 
 export class PostgresAdapter implements IDbAdapter {
 	public static variant = "PostgreSQL";
@@ -63,6 +91,11 @@ export class PostgresAdapter implements IDbAdapter {
 
 		const conn = this.getConnection();
 		return conn.executeQuery(CompiledQuery.raw(query, params ?? []));
+	}
+
+	async introspect(): Promise<IntrospectedTable[]> {
+		const result = await this.raw(INTROSPECT_SQL);
+		return groupIntrospectionRows(result.rows ?? result);
 	}
 
 	async getAll(


### PR DESCRIPTION
## Why

Anywhere a block needs a table or column name, the user types it by hand — there is nothing telling them what the connected database actually contains, and a typo only surfaces at request time. The adapters already hold a live connection; they just never described what was on the other end of it.

This lands the backend half: schema introspection in the adapters, and one endpoint to read it. Wiring it into searchable table/column selectors in the canvas is a follow-up.

## What

**Adapters**

- `IDbAdapter.introspect?()` — optional, so an adapter that cannot describe itself simply omits it and callers feature-detect rather than being lied to.
- Returns `[{ table, columns: [{ name, type, owner }] }]`. `owner` is the **referenced** table for a foreign key and the column's own table otherwise, which is what a picker needs in order to follow a relation.
- **Postgres / MySQL** read `information_schema`, left-joined to foreign key metadata.
- **MongoDB** has no schema, so it samples the first 5 documents per collection and unions the field types it finds (`string`, `objectId`, `date`, `array`, or `string | number` where a field varies). `_id` surfaces as `id`, matching the rest of the adapter.
- `introspectConnection(connection)` opens a short-lived connection, describes the schema and closes it. Design-time only — it deliberately does not touch `DbFactory`'s pooled runtime adapters, so a metadata call cannot leave a connection behind in the request path.

**API**

`GET /:projectId/integrations/:integrationId/metadata` →

```json
{
  "id": "...", "name": "main-db", "group": "database", "variant": "PostgreSQL",
  "metadata": { "tables": [
    { "table": "books", "columns": [
      { "name": "title",     "type": "varchar(255)", "owner": "books" },
      { "name": "author_id", "type": "int",          "owner": "authors" }
    ]}
  ]}
}
```

Same `creator` project access as the other integration routes. Non-database groups get a 400 until they have a metadata shape of their own; a connection that cannot be read reports the driver's error rather than a 500.

## Known limits

- Mongo introspection is top-level fields only — nested objects are not walked into dotted paths yet (marked in-code).
- No caching. Introspection is a live query, so a very wide schema should not be re-fetched per keystroke once the UI consumes this.
- The DB user needs `information_schema` visibility; tables it cannot select will not appear.

## Testing

New introspection tests in each adapter suite, run against real Postgres, MySQL and Mongo containers — 30 pass. They assert column types, that a plain column is owned by its own table, and that a foreign key is owned by the table it references. `bun run lint` and the server unit + integration suites are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)