### PR TITLE
fix(harness): use zod v4 toJSONSchema so structured fallback prompts carry a real schema

### DIFF
--- a/apps/ai-gateway/package.json
+++ b/apps/ai-gateway/package.json
@@ -46,7 +46,6 @@
 		"hono": "^4.12.27",
 		"hono-openapi": "^1.3.0",
 		"socket.io": "^4.8.3",
-		"zod": "^4.4.3",
-		"zod-to-json-schema": "^3.25.2"
+		"zod": "^4.4.3"
 	}
 }

--- a/apps/ai-gateway/src/harness/models/base.spec.ts
+++ b/apps/ai-gateway/src/harness/models/base.spec.ts
@@ -6,6 +6,7 @@ import { BaseAgentWrapper } from "./base";
 import { OpenAIAgentWrapper } from "./openai";
 import { describeFailure } from "../index";
 import { AgentNode } from "../types";
+import { blockBuilderSchema } from "../agents/sub-agents/blockBuilder/schemas";
 
 const schema = z.object({ blocks: z.array(z.string()) });
 
@@ -160,6 +161,21 @@ describe("OpenAIAgentWrapper", () => {
 		expect(
 			new Probe("gpt-4o", "sk-test").usesNativeStructuredOutput(),
 		).toBe(true);
+	});
+});
+
+describe("fallbackStructuredOutput schema conversion", () => {
+	it("produces a real JSON schema for the block builder schema, not an empty one", () => {
+		// zod-to-json-schema (v3) reads zod v3 `_def` internals and silently emits
+		// `{"$schema": "..."}` against a zod v4 schema — the prompt then tells the
+		// model to match `{}` and it guesses field names. Guard against that regressing.
+		const jsonSchema = z.toJSONSchema(blockBuilderSchema, {
+			target: "draft-7",
+			io: "output",
+		}) as { properties?: Record<string, unknown> };
+
+		expect(jsonSchema.properties).toBeTruthy();
+		expect(Object.keys(jsonSchema.properties!).length).toBeGreaterThan(0);
 	});
 });
 

--- a/apps/ai-gateway/src/harness/models/base.ts
+++ b/apps/ai-gateway/src/harness/models/base.ts
@@ -10,7 +10,6 @@ import { Runnable, RunnableConfig } from "@langchain/core/runnables";
 import { dispatchCustomEvent } from "@langchain/core/callbacks/dispatch";
 import { StructuredTool } from "@langchain/core/tools";
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 import { logger } from "@fluxify/common";
 import { withRetry } from "../../lib/retry";
 import { UserInterruptError } from "../errors";
@@ -430,7 +429,10 @@ export abstract class BaseAgentWrapper {
 		config?: RunnableConfig,
 		agentNode?: string,
 	): Promise<T> {
-		const jsonSchema = zodToJsonSchema(schema as any);
+		// zod-to-json-schema (v3) reads zod v3 `_def` internals and silently emits
+		// an empty schema against a zod v4 schema — the model then gets "match
+		// this schema: {}" and guesses field names. zod v4 ships its own converter.
+		const jsonSchema = z.toJSONSchema(schema, { target: "draft-7", io: "output" });
 
 		const formatInstructions = `
 You must respond with ONLY a valid JSON object matching the following JSON schema. 

--- a/bun.lock
+++ b/bun.lock
@@ -60,7 +60,6 @@
         "hono-openapi": "^1.3.0",
         "socket.io": "^4.8.3",
         "zod": "^4.4.3",
-        "zod-to-json-schema": "^3.25.2",
       },
       "devDependencies": {
         "@types/bun": "latest",


### PR DESCRIPTION
## Why

`apps/ai-gateway/src/harness/models/base.ts` built the JSON schema for the prompt-fallback structured-output path with `zodToJsonSchema(schema)`. `zod-to-json-schema@3` reads zod **v3** `_def` internals, and this repo is on `zod@4` — so against every one of our schemas it silently emitted `{"$schema": "..."}` and nothing else.

Measured against the real `blockBuilderSchema`:

```
zodToJsonSchema(blockBuilderSchema)  ->   53 chars   {"$schema":"http://json-schema.org/draft-07/schema#"}
z.toJSONSchema(blockBuilderSchema)   -> 5578 chars   {...,"type":"object","properties":{...}}
```

The fallback prompt therefore literally told the model *"respond with ONLY a valid JSON object matching the following JSON schema: `{}`"*.

Downstream effects:

- The model has to guess field names. `blockBuilder` survived only because `promptHelpers.ts` hand-writes an Output Contract — `router`, `verifyUserQuery`, `planner`, `taskGenerator` and `routeConfig` have no Output Contract and were guessing blind.
- `schema.parse` then fails, so the self-correction loop burns all 3 `STRUCTURED_OUTPUT_ATTEMPTS`, resending the entire history plus the bad output plus the issue list each time.
- `describeSchemaError` corrections were the *only* schema information the model ever received — the harness was reverse-engineering the schema to the model one validation error at a time.

This fires on every OpenAI-compatible / Ollama provider (`supportsStructuredOutput()` returns false when `baseUrl` is set) and on any provider whenever native `withStructuredOutput` throws and falls through.

## What

- `models/base.ts` — use zod v4's own converter: `z.toJSONSchema(schema, { target: "draft-7", io: "output" })`, drop the `zodToJsonSchema` import.
- `models/base.spec.ts` — **regression test** asserting the converted `blockBuilderSchema` has a non-empty `properties`. The original failure was completely silent; nothing would have caught it. This is as much the point of the PR as the one-line change.
- `apps/ai-gateway/package.json` + `bun.lock` — drop `zod-to-json-schema`. Verified nothing else in the monorepo imports it.

Deliberately scoped tight: no changes to the retry loop, `cleanJsonOutput`/`parseJsonLoose`, or the surrounding structured-output flow. Those are tracked separately in #144 and #146.

## Testing

```
$ bun test        # apps/ai-gateway
 94 pass
 0 fail
 167 expect() calls
Ran 94 tests across 14 files.
```

Lint (`turbo run lint`, `tsgo --noEmit`): 8/8 packages passing.

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)
