### PR TITLE
chore: accept the CLA by contributing instead of signing it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ docs/.vitepress/cache
 docs/.vitepress/dist
 apps/ai-gateway/src/harness/demo.ts
 apps/ai-gateway/src/test-trace.ts
+.claude/worktrees
+.issue-tracker/
+apps/ai-gateway/src/harness/IMPROVEMENTS.md

--- a/CLA.md
+++ b/CLA.md
@@ -16,19 +16,14 @@ Contributor License Agreement v2.0.
 
 ---
 
-## How to sign
+## How this is accepted
 
-You do not need to send anything by email or print anything.
+There is nothing to sign. No bot, no comment, no email, no paperwork.
 
-When you open your first pull request, a bot will comment with a link. Reply to
-that comment with:
-
-```
-I have read the CLA Document and I hereby sign the CLA
-```
-
-That's it. Your signature is recorded once and covers all your future
-contributions.
+**By submitting a contribution to this project, you agree to the terms below.**
+Opening a pull request, pushing a commit, or otherwise submitting work for
+inclusion is your acceptance. This applies to your first contribution and to
+every one after it.
 
 ---
 
@@ -63,6 +58,11 @@ perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
 copyright licence to reproduce, prepare derivative works of, publicly display,
 publicly perform, **sublicense**, and distribute Your Contributions and such
 derivative works.
+
+This grant expressly includes the right to use Your Contributions for
+**commercial purposes**, including selling, licensing for a fee, offering them
+as part of a paid or hosted service, and otherwise deriving revenue from them,
+without any obligation to account or pay royalties to You.
 
 > **What the sublicense right means in practice.** It allows the Project to
 > distribute your contribution under a different licence in future — for

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,8 +18,8 @@ know where to put your change, without having to ask anyone.
 > (`secretlint`), complexity analysis (`fta-cli`), and selective unit tests.
 
 > [!IMPORTANT]
-> **First-time contributors sign a CLA.** It's one comment on your first pull
-> request — a bot posts the link. You keep ownership of your work. See
+> **Contributing accepts our CLA.** There is nothing to sign — opening a pull
+> request is your acceptance. You keep ownership of your work. See
 > [Contributor License Agreement](#contributor-license-agreement) below.
 
 ---
@@ -353,22 +353,17 @@ gh pr create --repo Fluxify-rest/Fluxify --base main
 
 ### What a good PR looks like
 
-Also make sure you've signed the CLA — see below. A bot will prompt you on your
-first PR, so there's nothing to do in advance.
+Opening a PR also accepts our CLA — see below. There's nothing to do in advance.
 
 ## Contributor License Agreement
 
-Fluxify is licensed under the [Apache License 2.0](LICENSE). First-time
-contributors sign a [Contributor License Agreement](CLA.md).
+Fluxify is licensed under the [Apache License 2.0](LICENSE). Contributions are
+covered by our [Contributor License Agreement](CLA.md).
 
-**Signing takes one comment.** A bot posts a link on your first pull request;
-reply with:
-
-```
-I have read the CLA Document and I hereby sign the CLA
-```
-
-Your signature is recorded once and covers all future contributions.
+**There is nothing to sign.** Submitting a contribution — opening a pull
+request, pushing a commit, or otherwise offering work for inclusion — is your
+acceptance of the CLA. This covers your first contribution and every one after
+it.
 
 ### What it does and doesn't do
 

--- a/Readme.md
+++ b/Readme.md
@@ -147,8 +147,7 @@ We welcome contributions from the community! Please read our [CONTRIBUTING.md](C
 Fluxify is open source under the **[Apache License 2.0](LICENSE)** — free to use,
 modify, self-host, and deploy commercially, with an explicit patent grant.
 
-Contributions require signing our [CLA](CLA.md), which is a one-line comment on
-your first pull request.
+Submitting a contribution accepts our [CLA](CLA.md). There is nothing to sign.
 
 > Versions released before v0.x carried the MIT License and remain available
 > under those terms.


### PR DESCRIPTION
## Why

The CLA Assistant workflow gated **every** pull request behind a bot comment — including PRs from the org owner and maintainers. For a project this size that is friction with no payoff: the gate stopped no one it needed to stop and slowed down everyone it didn't.

The workflow itself is already gone from `main`. This PR brings the documentation in line with it, so `CLA.md`, `CONTRIBUTING.md` and `Readme.md` stop telling contributors to do something that no longer exists.

## What

**Acceptance is now implicit.** Submitting a contribution — opening a PR, pushing a commit, otherwise offering work for inclusion — *is* agreement to the CLA. First contribution and every one after. No bot, no comment, no email, no paperwork.

- `CLA.md` — "How to sign" → **"How this is accepted"**. States plainly that there is nothing to sign.
- `CLA.md` §2 — the copyright grant now says explicitly that it covers **commercial use**: selling, licensing for a fee, offering contributions as part of a paid or hosted service, and otherwise deriving revenue, with no obligation to account or pay royalties. This was already implied by the sublicense right; spelling it out is fairer to contributors than making them infer it.
- `CONTRIBUTING.md` — removes the three places describing the bot-signing flow.
- `Readme.md` — one line, same correction.
- `.gitignore` — ignores `.issue-tracker/` and the harness `IMPROVEMENTS.md` working notes.

No change to what the CLA actually grants, other than making the commercial-use right explicit. Contributors still keep copyright in their work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
