### PR TITLE
fix(harness): validate taskGenerator output before it reaches the graph

### DIFF
--- a/apps/ai-gateway/src/harness/agents/taskGenerator.spec.ts
+++ b/apps/ai-gateway/src/harness/agents/taskGenerator.spec.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "bun:test";
+import { sanitizeTasks } from "./taskGenerator";
+import { AgentNode } from "../types";
+
+type RawTask = Parameters<typeof sanitizeTasks>[0][number];
+
+function raw(overrides: Partial<RawTask> = {}): RawTask {
+	return {
+		id: "abc12",
+		title: "Build the route",
+		description: "…",
+		dependsOnAgentId: [],
+		assignedAgentNode: AgentNode.ROUTE_CONFIG_AGENT,
+		...overrides,
+	};
+}
+
+describe("sanitizeTasks", () => {
+	it("keeps a well-formed task untouched", () => {
+		const { tasks, notes } = sanitizeTasks([raw()]);
+		expect(tasks).toHaveLength(1);
+		expect(tasks[0]!.id).toBe("abc12");
+		expect(tasks[0]!.assignedAgentNode).toBe(AgentNode.ROUTE_CONFIG_AGENT);
+		expect(tasks[0]!.status).toBe("pending");
+		expect(notes).toEqual([]);
+	});
+
+	it("drops a task assigned to a node that is not a sub-agent", () => {
+		const { tasks, notes } = sanitizeTasks([
+			raw({ id: "aaa11", assignedAgentNode: "databaseAgent" }),
+			raw({ id: "bbb22" }),
+		]);
+		expect(tasks.map((t) => t.id)).toEqual(["bbb22"]);
+		expect(notes[0]).toContain("databaseAgent");
+	});
+
+	it("drops a task pointed at a control-plane node, which would loop the graph", () => {
+		// `new Send(AgentNode.ORCHESTRATOR)` re-enters the orchestrator and
+		// re-dispatches until recursionLimit — the expensive failure.
+		const { tasks } = sanitizeTasks([
+			raw({ assignedAgentNode: AgentNode.ORCHESTRATOR }),
+			raw({ id: "ccc33", assignedAgentNode: AgentNode.PLANNER }),
+		]);
+		expect(tasks).toEqual([]);
+	});
+
+	it("matches node names case-insensitively", () => {
+		const { tasks, notes } = sanitizeTasks([
+			raw({ assignedAgentNode: " BlockBuilder " }),
+		]);
+		expect(tasks[0]!.assignedAgentNode).toBe(AgentNode.BLOCK_BUILDER);
+		expect(notes).toEqual([]);
+	});
+
+	it("re-keys duplicate ids so every task still runs", () => {
+		const { tasks, notes } = sanitizeTasks([
+			raw({ id: "dup01", title: "first" }),
+			raw({ id: "dup01", title: "second" }),
+		]);
+		expect(tasks).toHaveLength(2);
+		expect(tasks[0]!.id).toBe("dup01");
+		expect(tasks[1]!.id).not.toBe("dup01");
+		expect(notes[0]).toContain("duplicate");
+	});
+
+	it("removes a dependency on a task that does not exist", () => {
+		const { tasks, notes } = sanitizeTasks([
+			raw({ id: "aaa11", dependsOnAgentId: ["ghost1"] }),
+		]);
+		expect(tasks[0]!.dependsOnAgentId).toEqual([]);
+		expect(notes[0]).toContain("ghost1");
+	});
+
+	it("removes a dependency on a task that was dropped", () => {
+		const { tasks } = sanitizeTasks([
+			raw({ id: "aaa11", assignedAgentNode: "nope" }),
+			raw({ id: "bbb22", dependsOnAgentId: ["aaa11"] }),
+		]);
+		expect(tasks).toHaveLength(1);
+		expect(tasks[0]!.dependsOnAgentId).toEqual([]);
+	});
+
+	it("removes a self-dependency", () => {
+		const { tasks } = sanitizeTasks([
+			raw({ id: "aaa11", dependsOnAgentId: ["aaa11"] }),
+		]);
+		expect(tasks[0]!.dependsOnAgentId).toEqual([]);
+	});
+
+	it("keeps a real dependency edge", () => {
+		const { tasks, notes } = sanitizeTasks([
+			raw({ id: "aaa11" }),
+			raw({ id: "bbb22", dependsOnAgentId: ["aaa11"] }),
+		]);
+		expect(tasks[1]!.dependsOnAgentId).toEqual(["aaa11"]);
+		expect(notes).toEqual([]);
+	});
+});

--- a/apps/ai-gateway/src/harness/agents/taskGenerator.ts
+++ b/apps/ai-gateway/src/harness/agents/taskGenerator.ts
@@ -42,6 +42,81 @@ const taskSchema = z.object({
 		.describe("Directed Acyclic Graph (DAG) of tasks to execute the plan"),
 });
 
+/**
+ * The model writes task ids, agent node names and dependency edges by hand, so
+ * all three arrive wrong sometimes. Repair them here, before they reach the
+ * graph, because each one fails badly downstream:
+ *
+ * - an unknown `assignedAgentNode` throws inside `new Send()` and kills the
+ *   run; a *valid but wrong* one (`orchestrator`, `planner`) is worse — it
+ *   dispatches back into the control plane and loops until `recursionLimit`.
+ * - a `dependsOnAgentId` naming a task that doesn't exist leaves the child's
+ *   in-degree permanently above zero, so the topological sort reports a cycle
+ *   that isn't there.
+ * - a duplicate id makes `supervisor.setStatus` update only the first match,
+ *   stranding the other task as `running` forever.
+ *
+ * Repairs are recorded so the caller can put them in the scratchpad — a
+ * dropped task is lost work and shouldn't happen silently.
+ */
+export function sanitizeTasks(
+	raw: z.infer<typeof taskSchema>["tasks"],
+): { tasks: Task[]; notes: string[] } {
+	const validNodes = new Map(
+		subAgents.map((a) => [a.nodeName.toLowerCase(), a.nodeName]),
+	);
+	const notes: string[] = [];
+
+	const kept: Task[] = [];
+	const seenIds = new Set<string>();
+
+	for (const t of raw) {
+		const node = validNodes.get(t.assignedAgentNode?.trim().toLowerCase());
+		if (!node) {
+			notes.push(
+				`Task "${t.title}" was dropped: it was assigned to "${t.assignedAgentNode}", which is not an available sub-agent.`,
+			);
+			continue;
+		}
+
+		let id = t.id?.trim();
+		if (!id || seenIds.has(id)) {
+			const replacement = `t${kept.length}${Math.random().toString(36).slice(2, 5)}`;
+			notes.push(
+				`Task "${t.title}" had a ${id ? "duplicate" : "missing"} id${id ? ` ("${id}")` : ""}; re-keyed to "${replacement}".`,
+			);
+			id = replacement;
+		}
+		seenIds.add(id);
+
+		kept.push({
+			...t,
+			id,
+			assignedAgentNode: node,
+			dependsOnAgentId: t.dependsOnAgentId ?? [],
+			status: "pending",
+		});
+	}
+
+	// Second pass: edges can only be checked once every surviving id is known.
+	for (const task of kept) {
+		const resolved = task.dependsOnAgentId.filter(
+			(dep) => dep !== task.id && seenIds.has(dep),
+		);
+		if (resolved.length !== task.dependsOnAgentId.length) {
+			notes.push(
+				`Task "${task.title}" depended on ${task.dependsOnAgentId
+					.filter((d) => !resolved.includes(d))
+					.map((d) => `"${d}"`)
+					.join(", ")}, which do not exist; those dependencies were removed.`,
+			);
+			task.dependsOnAgentId = resolved;
+		}
+	}
+
+	return { tasks: kept, notes };
+}
+
 function topologicalSortByLevel(tasks: Task[]): string[][] {
 	const inDegree = new Map<string, number>();
 	const children = new Map<string, string[]>();
@@ -154,12 +229,7 @@ ${scratchPadText}`;
 			agentNode: AgentNode.TASK_GENERATOR,
 		})) as z.infer<typeof taskSchema>;
 
-		// Map to our internal state type
-		const generatedTasks: Task[] = response.tasks.map((t) => ({
-			...t,
-			assignedAgentNode: t.assignedAgentNode as any,
-			status: "pending",
-		}));
+		const { tasks: generatedTasks, notes } = sanitizeTasks(response.tasks);
 
 		let taskQueue: string[][] = [];
 		if (generatedTasks.length > 0) {
@@ -169,6 +239,8 @@ ${scratchPadText}`;
 		return {
 			currentAgent: AgentNode.TASK_GENERATOR,
 			nextRoute: AgentNode.ORCHESTRATOR,
+			// `scratchpad`'s reducer appends, so return only the new notes.
+			scratchpad: notes,
 			orchestratorState: {
 				...this.state.orchestratorState,
 				tasks: generatedTasks,


### PR DESCRIPTION
Closes #142 · part of #139 · Phase 1

## Why

`taskGenerator` mapped the model's output straight into graph state (`assignedAgentNode: t.assignedAgentNode as any`). Three routine LLM slips therefore became hard failures:

**B1 — unknown or wrong `assignedAgentNode`.** An unknown node name throws inside `new Send()` at `graph.ts:114` and kills the run. A *valid but wrong* one is worse: `Send(AgentNode.ORCHESTRATOR)` re-enters the orchestrator with `activeTask` set and re-dispatches — a real loop, bounded only by `recursionLimit: 100`, so ~100 model calls burn before it dies.

**B2 — phantom `dependsOnAgentId`.** A dependency naming a task that doesn't exist increments the child's in-degree, but the phantom parent never enters the queue, so the child never reaches zero and the sort throws `"Cyclic dependency detected in tasks"` on a graph with no cycle. The user sees *"failed at the Task Generator"* for a trivially recoverable mistake.

**B5 — duplicate ids.** `supervisor.setStatus` finds tasks by id and only ever updates the first match, so the duplicate stays `running` forever — never `pending`, so the orchestrator skips it and the run completes without it. `subAgentResults[task.id]` overwrites too.

## What

One `sanitizeTasks()` pass before the topological sort:

- **Unknown agent nodes are dropped.** Matched case-insensitively against `subAgents` first, since the model varies casing and whitespace — a recoverable slip shouldn't cost a task.
- **Duplicate and missing ids are re-keyed** server-side. Asking an LLM for unique keys was the bug.
- **Dependency edges are filtered** to ids that actually survived, self-edges included. Runs as a second pass, because an edge can only be checked once every surviving id is known. Real cycles still throw.
- **Every repair goes to the scratchpad.** A dropped task is lost work; it shouldn't vanish silently, and downstream agents get to see what happened.

## Tests

9 new cases in `taskGenerator.spec.ts` covering each acceptance criterion plus the control-plane-node loop case. `apps/ai-gateway`: **110 pass, 0 fail** (was 101). Full pre-commit suite: 413 pass, 0 fail.

## Deliberately skipped

The issue suggests a belt-and-braces re-check in `orchestrator.execute()`. `taskGenerator` is the only writer of `orchestratorState.tasks`, so that check is unreachable today. Worth adding if another path ever starts producing tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
