### PR TITLE
perf(harness): cut per-run tokens and round trips

### DIFF
--- a/apps/ai-gateway/src/harness/models/anthropic/index.ts
+++ b/apps/ai-gateway/src/harness/models/anthropic/index.ts
@@ -1,6 +1,10 @@
 import { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import { ChatAnthropic } from "@langchain/anthropic";
-import { BaseAgentWrapper, HARNESS_TEMPERATURE } from "../base";
+import {
+	BaseAgentWrapper,
+	HARNESS_MAX_TOKENS,
+	HARNESS_TEMPERATURE,
+} from "../base";
 
 export class AnthropicAgentWrapper extends BaseAgentWrapper {
 	private baseUrl?: string;
@@ -22,6 +26,7 @@ export class AnthropicAgentWrapper extends BaseAgentWrapper {
 			// `apiKey` is the canonical field; `anthropicApiKey` is a legacy alias.
 			apiKey: this.apiKey,
 			temperature: HARNESS_TEMPERATURE,
+			maxTokens: HARNESS_MAX_TOKENS,
 			anthropicApiUrl: this.baseUrl,
 			clientOptions: {
 				defaultHeaders: this.additionalHeaders,

--- a/apps/ai-gateway/src/harness/models/base.spec.ts
+++ b/apps/ai-gateway/src/harness/models/base.spec.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from "bun:test";
 import { z } from "zod";
 import { BaseChatModel } from "@langchain/core/language_models/chat_models";
-import type { BaseMessage } from "@langchain/core/messages";
-import { BaseAgentWrapper } from "./base";
+import {
+	HumanMessage,
+	ToolMessage,
+	type BaseMessage,
+} from "@langchain/core/messages";
+import { BaseAgentWrapper, compactToolHistory } from "./base";
 import { OpenAIAgentWrapper } from "./openai";
 import { describeFailure } from "../index";
 import { AgentNode } from "../types";
@@ -203,5 +207,62 @@ describe("describeFailure", () => {
 
 	it("falls back to a generic explanation", () => {
 		expect(describeFailure(new Error("boom"))).toContain("unexpected error");
+	});
+});
+
+describe("compactToolHistory", () => {
+	const toolMsg = (name: string, content: string) =>
+		new ToolMessage({ tool_call_id: `call_${name}`, name, content });
+
+	it("leaves the most recent tool results verbatim", () => {
+		const messages: BaseMessage[] = [
+			new HumanMessage("build it"),
+			toolMsg("a", JSON.stringify([1, 2, 3])),
+			toolMsg("b", JSON.stringify([4, 5])),
+		];
+		compactToolHistory(messages);
+		expect(messages[1]!.content).toBe(JSON.stringify([1, 2, 3]));
+		expect(messages[2]!.content).toBe(JSON.stringify([4, 5]));
+	});
+
+	it("condenses older tool results and keeps them addressable", () => {
+		const big = JSON.stringify(Array.from({ length: 40 }, (_, i) => ({ i })));
+		const messages: BaseMessage[] = [
+			toolMsg("find_resource", big),
+			toolMsg("b", "{}"),
+			toolMsg("c", "{}"),
+		];
+		compactToolHistory(messages);
+
+		const first = messages[0] as ToolMessage;
+		expect(first.content).not.toBe(big);
+		expect(String(first.content)).toContain("40 results");
+		// The tool_call_id must survive — a ToolMessage without its matching id
+		// is rejected by every provider.
+		expect(first.tool_call_id).toBe("call_find_resource");
+		expect(first.name).toBe("find_resource");
+	});
+
+	it("summarises non-JSON results by truncation", () => {
+		const markdown = "x".repeat(500);
+		const messages: BaseMessage[] = [
+			toolMsg("a", markdown),
+			toolMsg("b", "{}"),
+			toolMsg("c", "{}"),
+		];
+		compactToolHistory(messages);
+		expect(String(messages[0]!.content).length).toBeLessThan(400);
+	});
+
+	it("is idempotent — a second pass doesn't summarise the summary", () => {
+		const messages: BaseMessage[] = [
+			toolMsg("a", JSON.stringify([1, 2, 3])),
+			toolMsg("b", "{}"),
+			toolMsg("c", "{}"),
+		];
+		compactToolHistory(messages);
+		const once = messages[0]!.content;
+		compactToolHistory(messages);
+		expect(messages[0]!.content).toBe(once);
 	});
 });

--- a/apps/ai-gateway/src/harness/models/base.ts
+++ b/apps/ai-gateway/src/harness/models/base.ts
@@ -32,6 +32,58 @@ const STRUCTURED_OUTPUT_ATTEMPTS = 3;
  *  edits, not prose — sampling variance is pure error surface. */
 export const HARNESS_TEMPERATURE = 0;
 
+/** Output cap for every harness call. Agents emit JSON graph edits and short
+ *  summaries; without a cap, a model that decides to narrate runs to the
+ *  provider's own limit and burns the budget before it ever emits the payload. */
+export const HARNESS_MAX_TOKENS = Number(
+	process.env.HARNESS_MAX_TOKENS ?? 8192,
+);
+
+/** Successful connection probes, keyed per provider+model+credential.
+ *  See `checkConnection`. */
+const connectionProbeCache = new Map<string, number>();
+const CONNECTION_PROBE_TTL_MS = 5 * 60_000;
+
+/** Tool results older than this many tool turns are replaced with a one-line
+ *  summary. The whole history is re-sent every iteration, so without this the
+ *  first tool result is billed once per remaining turn. */
+const VERBATIM_TOOL_RESULTS = 2;
+
+/**
+ * Replaces all but the most recent tool results with a one-line summary, in
+ * place. The full history is re-sent on every tool iteration, so a fat result
+ * from turn 1 is otherwise billed again on turns 2..n — the single biggest
+ * source of token growth in a multi-tool run.
+ *
+ * The last {@link VERBATIM_TOOL_RESULTS} stay intact because those are what the
+ * model is reasoning over right now. Older ones only need to record that the
+ * call happened and roughly what came back. Compacted messages are marked so a
+ * second pass doesn't summarise a summary.
+ */
+export function compactToolHistory(messages: BaseMessage[]): void {
+	const toolIndexes: number[] = [];
+	messages.forEach((m, i) => {
+		if (m instanceof ToolMessage) toolIndexes.push(i);
+	});
+
+	for (const i of toolIndexes.slice(0, -VERBATIM_TOOL_RESULTS)) {
+		const msg = messages[i] as ToolMessage;
+		if (msg.additional_kwargs?.compacted) continue;
+		const text = typeof msg.content === "string" ? msg.content : "";
+		messages[i] = new ToolMessage({
+			tool_call_id: msg.tool_call_id,
+			name: msg.name,
+			// summarizeToolResult only understands JSON; markdown tables and prose
+			// fall back to a head slice.
+			content: `[earlier result from ${msg.name ?? "tool"}, condensed] ${
+				summarizeToolResult(text) ??
+				(text.length > 300 ? `${text.slice(0, 300)}…` : text)
+			}`,
+			additional_kwargs: { ...msg.additional_kwargs, compacted: true },
+		});
+	}
+}
+
 export interface AgentInvokeOptions {
 	zodSchema?: z.ZodType<any>;
 	userQuery?: string;
@@ -63,6 +115,7 @@ export abstract class BaseAgentWrapper {
 	protected apiKey?: string;
 	protected additionalHeaders?: Record<string, string>;
 	protected maxToolIterations?: number;
+	private readonly connectionBaseUrl?: string;
 	/** Set per run by the harness; when aborted, every model call is cancelled and
 	 *  a UserInterruptError is raised. */
 	protected signal?: AbortSignal;
@@ -145,6 +198,11 @@ export abstract class BaseAgentWrapper {
 		this.apiKey = apiKey;
 		this.additionalHeaders = additionalHeaders;
 		this.maxToolIterations = maxToolIterations;
+		// Subclasses keep their own `baseUrl` (each SDK names the field
+		// differently); this copy exists only to key the connection probe cache,
+		// so two integrations pointing the same model at different servers don't
+		// share a result.
+		this.connectionBaseUrl = baseUrl;
 	}
 
 	// Each subclass implements this to return the initialized LangChain chat model
@@ -156,9 +214,17 @@ export abstract class BaseAgentWrapper {
 	 * failure so callers can bail early with a meaningful message.
 	 */
 	public async checkConnection(): Promise<void> {
+		// This runs before every run, so an uncached probe is a full RTT (plus
+		// cold-connection TLS) added to every user request. Only successes are
+		// cached — a failure must re-probe so a user who fixes their key isn't
+		// locked out for the rest of the TTL.
+		const key = `${this.constructor.name}:${this.modelName}:${this.connectionBaseUrl ?? ""}:${this.apiKey ?? ""}`;
+		if ((connectionProbeCache.get(key) ?? 0) > Date.now()) return;
+
 		await this.getModel().invoke([new HumanMessage("ping")], {
 			timeout: 30_000,
 		});
+		connectionProbeCache.set(key, Date.now() + CONNECTION_PROBE_TTL_MS);
 	}
 
 	// Subclasses can override this if they don't natively support withStructuredOutput.
@@ -317,10 +383,11 @@ export abstract class BaseAgentWrapper {
 	): Promise<{ done: true; value: T | AIMessage } | { done: false }> {
 		const { zodSchema, config, agentNode, agentId } = options;
 		const maxIterations =
-			options.maxToolIterations ?? this.maxToolIterations ?? 15;
+			options.maxToolIterations ?? this.maxToolIterations ?? 8;
 
 		for (let i = 0; i < maxIterations; i++) {
 			this.throwIfInterrupted();
+			compactToolHistory(finalMessages);
 			// Retried like every other model call — a single network timeout
 			// mid-loop used to kill the whole run.
 			const response = (await withRetry(

--- a/apps/ai-gateway/src/harness/models/google/index.ts
+++ b/apps/ai-gateway/src/harness/models/google/index.ts
@@ -1,6 +1,10 @@
 import { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import { ChatGoogle } from "@langchain/google";
-import { BaseAgentWrapper, HARNESS_TEMPERATURE } from "../base";
+import {
+	BaseAgentWrapper,
+	HARNESS_MAX_TOKENS,
+	HARNESS_TEMPERATURE,
+} from "../base";
 
 export class GoogleAgentWrapper extends BaseAgentWrapper {
 	protected getModel(): BaseChatModel {
@@ -8,6 +12,7 @@ export class GoogleAgentWrapper extends BaseAgentWrapper {
 			model: this.modelName,
 			apiKey: this.apiKey,
 			temperature: HARNESS_TEMPERATURE,
+			maxOutputTokens: HARNESS_MAX_TOKENS,
 		});
 	}
 }

--- a/apps/ai-gateway/src/harness/models/mistral/index.ts
+++ b/apps/ai-gateway/src/harness/models/mistral/index.ts
@@ -1,6 +1,10 @@
 import { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import { ChatMistralAI } from "@langchain/mistralai";
-import { BaseAgentWrapper, HARNESS_TEMPERATURE } from "../base";
+import {
+	BaseAgentWrapper,
+	HARNESS_MAX_TOKENS,
+	HARNESS_TEMPERATURE,
+} from "../base";
 
 export class MistralAgentWrapper extends BaseAgentWrapper {
 	protected getModel(): BaseChatModel {
@@ -8,6 +12,7 @@ export class MistralAgentWrapper extends BaseAgentWrapper {
 			model: this.modelName,
 			apiKey: this.apiKey,
 			temperature: HARNESS_TEMPERATURE,
+			maxTokens: HARNESS_MAX_TOKENS,
 		});
 	}
 

--- a/apps/ai-gateway/src/harness/models/ollama/index.ts
+++ b/apps/ai-gateway/src/harness/models/ollama/index.ts
@@ -1,6 +1,10 @@
 import { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import { ChatOllama } from "@langchain/ollama";
-import { BaseAgentWrapper, HARNESS_TEMPERATURE } from "../base";
+import {
+	BaseAgentWrapper,
+	HARNESS_MAX_TOKENS,
+	HARNESS_TEMPERATURE,
+} from "../base";
 
 export class OllamaAgentWrapper extends BaseAgentWrapper {
 	private baseUrl?: string;
@@ -20,6 +24,8 @@ export class OllamaAgentWrapper extends BaseAgentWrapper {
 			model: this.modelName,
 			baseUrl: this.baseUrl,
 			temperature: HARNESS_TEMPERATURE,
+			// Ollama's name for the output cap.
+			numPredict: HARNESS_MAX_TOKENS,
 		});
 	}
 

--- a/apps/ai-gateway/src/harness/models/openai/index.ts
+++ b/apps/ai-gateway/src/harness/models/openai/index.ts
@@ -1,6 +1,10 @@
 import { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import { ChatOpenAI } from "@langchain/openai";
-import { BaseAgentWrapper, HARNESS_TEMPERATURE } from "../base";
+import {
+	BaseAgentWrapper,
+	HARNESS_MAX_TOKENS,
+	HARNESS_TEMPERATURE,
+} from "../base";
 
 /** Reasoning models reject any temperature but the default and 400 the request. */
 const FIXED_TEMPERATURE_MODEL = /(^|\/)(o\d|gpt-5)/i;
@@ -22,9 +26,14 @@ export class OpenAIAgentWrapper extends BaseAgentWrapper {
 	protected getModel(): BaseChatModel {
 		return new ChatOpenAI({
 			model: this.modelName,
+			// Reasoning models take `maxCompletionTokens` (the cap covers reasoning
+			// tokens too) and reject `maxTokens`; everything else is the reverse.
 			...(FIXED_TEMPERATURE_MODEL.test(this.modelName)
-				? {}
-				: { temperature: HARNESS_TEMPERATURE }),
+				? { maxCompletionTokens: HARNESS_MAX_TOKENS }
+				: {
+						temperature: HARNESS_TEMPERATURE,
+						maxTokens: HARNESS_MAX_TOKENS,
+					}),
 			// Must be `apiKey`. ChatOpenAI reads only `fields.apiKey`,
 			// `configuration.apiKey`, or $OPENAI_API_KEY — `openAIApiKey` is a dead
 			// alias on chat models (it still works on OpenAI() / OpenAIEmbeddings),

--- a/apps/ai-gateway/src/harness/models/openrouter/index.ts
+++ b/apps/ai-gateway/src/harness/models/openrouter/index.ts
@@ -1,6 +1,10 @@
 import { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import { ChatOpenRouter } from "@langchain/openrouter";
-import { BaseAgentWrapper, HARNESS_TEMPERATURE } from "../base";
+import {
+	BaseAgentWrapper,
+	HARNESS_MAX_TOKENS,
+	HARNESS_TEMPERATURE,
+} from "../base";
 
 export class OpenRouterAgentWrapper extends BaseAgentWrapper {
 	protected getModel(): BaseChatModel {
@@ -8,6 +12,7 @@ export class OpenRouterAgentWrapper extends BaseAgentWrapper {
 			model: this.modelName,
 			apiKey: this.apiKey,
 			temperature: HARNESS_TEMPERATURE,
+			maxTokens: HARNESS_MAX_TOKENS,
 			...(this.additionalHeaders
 				? { modelKwargs: { extra_headers: this.additionalHeaders } }
 				: {}),

--- a/apps/ai-gateway/src/harness/tools/findResource.ts
+++ b/apps/ai-gateway/src/harness/tools/findResource.ts
@@ -5,6 +5,20 @@ import type { WorkflowMetadata } from "../types";
 import type { DbService } from "../internal/dbService";
 import { ResourceType } from "../types";
 
+/**
+ * Canvases are the fattest thing this tool returns, and the whole result is
+ * re-sent on every subsequent tool iteration. Two cuts: no pretty-printing
+ * (indentation alone was ~15% of the payload) and no `position`, which is
+ * layout the model neither reads nor sets. `data` stays — the block builder
+ * edits existing blocks, and making it fetch that separately would add back
+ * the round trip this is trying to remove.
+ */
+function renderCanvas(canvas: Array<Record<string, any>>): string {
+	return JSON.stringify(
+		canvas.map(({ position, ...block }) => block),
+	);
+}
+
 export const createFindResourceTool = (
 	dbService: DbService,
 	metadata: WorkflowMetadata,
@@ -21,21 +35,17 @@ export const createFindResourceTool = (
 
 			if (resourceType === "route_canvas") {
 				if (toolMetadata?.isNewRoute) {
-					return JSON.stringify(
-						[
-							{ id: "entrypoint", blockType: "entrypoint" },
-							{ id: "response", blockType: "response" },
-							{ id: "error_handler", blockType: "error_handler" },
-						],
-						null,
-						2,
-					);
+					return JSON.stringify([
+						{ id: "entrypoint", blockType: "entrypoint" },
+						{ id: "response", blockType: "response" },
+						{ id: "error_handler", blockType: "error_handler" },
+					]);
 				}
 				const canvas = await dbService.getRouteCanvas(
 					metadata.projectId,
 					singleId,
 				);
-				return canvas ? JSON.stringify(canvas, null, 2) : "No canvas found.";
+				return canvas ? renderCanvas(canvas) : "No canvas found.";
 			}
 
 			if (resourceType === "custom_block_canvas") {
@@ -43,7 +53,7 @@ export const createFindResourceTool = (
 					metadata.projectId,
 					singleId,
 				);
-				return canvas ? JSON.stringify(canvas, null, 2) : "No canvas found.";
+				return canvas ? renderCanvas(canvas) : "No canvas found.";
 			}
 
 			let results: any[] = [];

--- a/apps/ai-gateway/src/harness/tools/getAgentOutput.ts
+++ b/apps/ai-gateway/src/harness/tools/getAgentOutput.ts
@@ -13,7 +13,7 @@ export const createGetAgentOutputTool = (
 					results[id] = subAgentResults[id];
 				}
 			}
-			return JSON.stringify(results, null, 2);
+			return JSON.stringify(results);
 		},
 		{
 			name: "get_agent_output",

--- a/apps/ai-gateway/src/harness/tools/getArtifact.spec.ts
+++ b/apps/ai-gateway/src/harness/tools/getArtifact.spec.ts
@@ -37,7 +37,9 @@ describe("get_artifact", () => {
 
 		expect(calls[0]).toEqual(["conv-1", ["sub-1"]]);
 		expect(out).toContain("kind=route, action=add");
-		expect(out).toContain('"path": "/users"');
+		// Compact, not pretty-printed — indentation was ~15% of the payload and
+		// this result is re-sent on every later tool iteration.
+		expect(out).toContain('"path":"/users"');
 	});
 
 	it("tells the agent whether the output is already applied", async () => {

--- a/apps/ai-gateway/src/harness/tools/getArtifact.ts
+++ b/apps/ai-gateway/src/harness/tools/getArtifact.ts
@@ -35,7 +35,7 @@ export const createGetArtifactTool = (
 			const body = rows
 				.map(
 					(r) =>
-						`## artifact ${r.id} (kind=${r.kind}, action=${r.action ?? "n/a"}, applied=${r.appliedAt ? `yes, at ${new Date(r.appliedAt).toISOString()}` : "no"}, run=${r.runId}, created=${new Date(r.createdAt).toISOString()})\n${JSON.stringify(r.payload, null, 2)}`,
+						`## artifact ${r.id} (kind=${r.kind}, action=${r.action ?? "n/a"}, applied=${r.appliedAt ? `yes, at ${new Date(r.appliedAt).toISOString()}` : "no"}, run=${r.runId}, created=${new Date(r.createdAt).toISOString()})\n${JSON.stringify(r.payload)}`,
 				)
 				.join("\n\n");
 

--- a/apps/ai-gateway/src/harness/tools/getBlockSchemas.ts
+++ b/apps/ai-gateway/src/harness/tools/getBlockSchemas.ts
@@ -44,6 +44,10 @@ function mapInputParamsToNaturalLanguage(inputParams: any[]): string {
 	return `{\n${props.join("\n")}\n}`;
 }
 
+/** ponytail: flat cap. Raise it if a legitimate build needs more blocks
+ *  configured in one turn. */
+const MAX_BLOCK_TYPES_PER_CALL = 8;
+
 export const createGetBlockSchemasTool = (
 	dbService: DbService,
 	projectId: string,
@@ -53,7 +57,14 @@ export const createGetBlockSchemasTool = (
 			logger.info(`[Tools] Fetching schemas for blocks: ${blockTypes.join(", ")}`);
 			
 			const results: string[] = [];
-			const requestedTypes = new Set(blockTypes);
+			// Uncapped, the model can ask for all 28 built-ins in one call — around
+			// 5,000 tokens, re-sent on every later tool iteration. It only ever
+			// needs the handful it is about to configure.
+			const requestedTypes = [...new Set(blockTypes)].slice(
+				0,
+				MAX_BLOCK_TYPES_PER_CALL,
+			);
+			const dropped = new Set(blockTypes).size - requestedTypes.length;
 
 			for (const blockType of requestedTypes) {
 				if (blockType.startsWith("custom:")) {
@@ -76,16 +87,22 @@ export const createGetBlockSchemasTool = (
 				}
 			}
 
+			if (dropped > 0) {
+				results.push(
+					`// ${dropped} more block type(s) were not returned: this tool serves at most ${MAX_BLOCK_TYPES_PER_CALL} per call. Call it again for the rest.`,
+				);
+			}
+
 			return results.join("\n\n");
 		},
 		{
 			name: "get_block_schemas",
 			description:
-				"Fetches the detailed configuration schemas for the requested block types. For custom blocks, prefix the block name with 'custom:'.",
+				`Fetches the detailed configuration schemas for the requested block types. For custom blocks, prefix the block name with 'custom:'. Returns at most ${MAX_BLOCK_TYPES_PER_CALL} schemas per call — request only the blocks you are about to configure.`,
 			schema: z.object({
 				blockTypes: z
 					.array(z.string())
-					.describe("Array of block types to fetch schemas for (e.g. ['http_request', 'custom:stripe_charge'])."),
+					.describe(`Array of block types to fetch schemas for (e.g. ['http_request', 'custom:stripe_charge']). At most ${MAX_BLOCK_TYPES_PER_CALL} per call.`),
 			}),
 		},
 	);

--- a/apps/ai-gateway/src/harness/tools/getRouteDetails.ts
+++ b/apps/ai-gateway/src/harness/tools/getRouteDetails.ts
@@ -22,8 +22,19 @@ export const createGetRouteDetailsTool = (
 				return "Route not found.";
 			}
 
-			// We return JSON stringified to prevent crashing LLM with huge objects
-			return JSON.stringify(route, null, 2);
+			// Project only what the tool description promises. The raw row also
+			// carries projectId, createdBy and timestamps — tokens the model pays
+			// for on every re-send and can do nothing with.
+			return JSON.stringify({
+				id: route.id,
+				name: route.name,
+				method: route.method,
+				path: route.path,
+				active: route.active,
+				bodySchema: route.bodySchema,
+				querySchema: route.querySchema,
+				paramsSchema: route.paramsSchema,
+			});
 		},
 		{
 			name: "get_route_details",

--- a/apps/ai-gateway/src/harness/worker.ts
+++ b/apps/ai-gateway/src/harness/worker.ts
@@ -42,9 +42,11 @@ export async function initializeHarnessWorker() {
 			const agentOptions = integrationId
 				? resolveAgentOptionsFromIntegrationId(integrationId)
 				: await resolveAgentOptionsFromProjectId(projectId);
-			const harness = new FluxifyHarness(
-				new AgentFactory({ ...agentOptions, maxToolIterations: 20 }),
-			);
+			// No maxToolIterations override — the wrapper default (8) is already
+			// well above what a correct sub-agent run needs (2-4). Reaching the
+			// cap means the agent is thrashing, and every iteration costs a full
+			// round trip carrying the whole history.
+			const harness = new FluxifyHarness(new AgentFactory(agentOptions));
 			const ctx: HarnessRunContext = {
 				conversationId: data.conversationId,
 				runId: data.runId,


### PR DESCRIPTION
Closes #143 · part of #139 · Phase 1

Four independent cuts. They share one root cause: the harness re-sends its entire history on every tool iteration, so anything fat is billed once per remaining turn.

## L2 — pre-flight ping on every run

`checkConnection` sent a `"ping"` to the provider before **every** run — a full round trip plus cold-connection TLS on every user request, to catch a misconfiguration the first real call surfaces anyway via `explainErrorReason`.

Successful probes are now cached for 5 minutes, keyed per provider + model + credential + baseUrl. **Failures are never cached**, so a user who fixes their API key isn't locked out for the rest of the TTL.

## B10 — `maxToolIterations: 20`

`worker.ts` overrode the default with 20. A correct sub-agent run needs 2–4; reaching 20 means the agent is thrashing, and every iteration is a full round trip carrying the whole history. Override removed, wrapper default lowered to **8**.

## B11 — no output cap on any wrapper

A model that decided to narrate ran to the provider's own limit. The `"exhausted its output token budget"` guard in `base.ts` exists precisely because this happens.

`HARNESS_MAX_TOKENS` (8192, `HARNESS_MAX_TOKENS` env override) is now passed by all six wrappers, under each SDK's own field name — **verified in `node_modules`, not guessed**, per AGENT.md:

| Wrapper | Field |
|---|---|
| Anthropic, Mistral, OpenRouter | `maxTokens` |
| Google | `maxOutputTokens` |
| Ollama | `numPredict` |
| OpenAI (reasoning models) | `maxCompletionTokens` — they reject `maxTokens` |

## T5 — unbounded, pretty-printed, re-sent tool results

- **No `JSON.stringify(x, null, 2)` left anywhere in `harness/tools/`.** Indentation alone was ~15% of those payloads.
- `get_route_details` projects the fields its own description promises (method, path, schemas) instead of the raw row, which also carried `projectId`, `createdBy` and timestamps.
- `find_resource` drops each block's `position` — layout the model neither reads nor sets.
- `get_block_schemas` caps at **8 types per call** and states the cap in its description and parameter docs. Uncapped, the model could pull all 28 built-ins (~5,000 tokens) and then carry them for the rest of the run.

**And the compounding fix:** `compactToolHistory()` runs before each iteration and replaces all but the two most recent tool results with a one-line summary, in place. `tool_call_id` and `name` are preserved — a `ToolMessage` without its matching id is rejected by every provider — and compacted messages are marked so a later pass doesn't summarise a summary. Non-JSON results (markdown tables) fall back to a head slice, since `summarizeToolResult` only understands JSON.

## Deviation from the issue

The issue suggests gating `data` out of the `find_resource` canvas payload. Kept it: the block builder edits *existing* blocks, so making it fetch `data` separately would add back a round trip this change is trying to remove. `position` was the free win.

## Tests

4 new cases for `compactToolHistory` (verbatim tail, id preservation, non-JSON fallback, idempotence). One existing `getArtifact` assertion updated for compact JSON. `apps/ai-gateway`: **114 pass, 0 fail**. `tsc --noEmit` clean. Pre-commit: 417 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
