### PR TITLE
fix(harness): put the JSON contract in the last turn, not the system prompt

### DIFF
--- a/apps/ai-gateway/src/harness/errors.ts
+++ b/apps/ai-gateway/src/harness/errors.ts
@@ -26,6 +26,20 @@ export function isUserInterrupt(error: unknown): boolean {
 export function explainErrorReason(raw: string): string {
 	const lower = raw.toLowerCase();
 
+	// Order matters: the two cases below both mention JSON, but they call for
+	// completely different action, so they must be matched before the generic
+	// structured-output branch.
+	if (lower.includes("empty response")) {
+		return "the AI model returned nothing at all — it most likely spent its whole output budget on reasoning. Try a model with a larger output limit, or one that does not reason as heavily.";
+	}
+	if (
+		lower.includes("json parse error") ||
+		lower.includes("unexpected identifier") ||
+		lower.includes("unexpected token") ||
+		lower.includes("unexpected eof")
+	) {
+		return "the AI model replied in plain prose instead of JSON. Models behind an OpenAI-compatible endpoint often ignore the JSON output format — the harness re-asks and usually recovers, but a model with reliable JSON support will be faster.";
+	}
 	if (
 		lower.includes("structured output") ||
 		lower.includes("json") ||

--- a/apps/ai-gateway/src/harness/models/base.spec.ts
+++ b/apps/ai-gateway/src/harness/models/base.spec.ts
@@ -4,6 +4,7 @@ import { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import {
 	AIMessage,
 	HumanMessage,
+	SystemMessage,
 	ToolMessage,
 	type BaseMessage,
 } from "@langchain/core/messages";
@@ -33,7 +34,10 @@ class TestWrapper extends BaseAgentWrapper {
 	}
 
 	/** Replays `responses` one per attempt, recording what each attempt was sent. */
-	parseSequence(responses: (string | Record<string, any>)[]) {
+	parseSequence(
+		responses: (string | Record<string, any>)[],
+		history: BaseMessage[] = [],
+	) {
 		const seen: BaseMessage[][] = [];
 		let i = 0;
 		const model = {
@@ -43,7 +47,10 @@ class TestWrapper extends BaseAgentWrapper {
 				return typeof next === "string" ? { content: next } : next;
 			},
 		} as any;
-		return { result: this.fallbackStructuredOutput(model, [], schema), seen };
+		return {
+			result: this.fallbackStructuredOutput(model, history, schema),
+			seen,
+		};
 	}
 }
 
@@ -132,6 +139,25 @@ describe("fallbackStructuredOutput", () => {
 		expect(echoed.additional_kwargs.reasoning_content).toBe("I picked numbers");
 	});
 
+	it("puts the JSON contract in the last turn, not in the system prompt", async () => {
+		// Buried at the end of a long system prompt, the contract loses to the
+		// user's question — providers that ignore `response_format` answer in
+		// prose and attempt 1 is wasted. Attempt 2 only worked because the
+		// correction was the last thing the model read.
+		const { result, seen } = wrapper.parseSequence(
+			['{"blocks":[]}'],
+			[new SystemMessage("You are the router."), new HumanMessage("build a route")],
+		);
+		expect(await result).toEqual({ blocks: [] });
+
+		const sent = seen[0]!;
+		expect(sent.at(-1)!.getType()).toBe("human");
+		expect(sent.at(-1)!.content).toContain("JSON schema");
+		// The agent's own prompt is left exactly as the agent wrote it.
+		expect(sent[0]!.content).toBe("You are the router.");
+		expect(sent.at(-2)!.content).toBe("build a route");
+	});
+
 	it("gives up after the attempt budget with the last validation error", async () => {
 		const { result, seen } = wrapper.parseSequence(['{"blocks":[1]}']);
 		expect(result).rejects.toThrow(/after 3 attempts/);
@@ -198,6 +224,21 @@ describe("describeFailure", () => {
 		);
 		expect(msg).toContain("block builder");
 		expect(msg).toContain("required format");
+	});
+
+	it("tells prose-instead-of-JSON apart from running out of output space", () => {
+		// Both mention JSON but need opposite advice: one is the provider ignoring
+		// the JSON format, the other is a model that reasoned away its budget.
+		const prose = describeFailure(
+			new Error('JSON Parse error: Unexpected identifier "Fluxify"'),
+			AgentNode.ROUTER,
+		);
+		expect(prose).toContain("plain prose");
+		expect(prose).not.toContain("ran out of output space");
+
+		expect(
+			describeFailure(new Error("The model returned an empty response instead of the required JSON")),
+		).toContain("output budget on reasoning");
 	});
 
 	it("explains provider timeouts", () => {

--- a/apps/ai-gateway/src/harness/models/base.ts
+++ b/apps/ai-gateway/src/harness/models/base.ts
@@ -508,28 +508,22 @@ export abstract class BaseAgentWrapper {
 		// this schema: {}" and guesses field names. zod v4 ships its own converter.
 		const jsonSchema = z.toJSONSchema(schema, { target: "draft-7", io: "output" });
 
-		const formatInstructions = `
-You must respond with ONLY a valid JSON object matching the following JSON schema. 
+		const formatInstructions = `You must respond with ONLY a valid JSON object matching the following JSON schema.
 Do not include any markdown formatting (like \`\`\`json) or <think> tags in your final JSON output.
+Do not explain your answer in prose — the JSON object IS the answer.
 Your output will be parsed directly by JSON.parse().
 
 Schema:
-${JSON.stringify(jsonSchema, null, 2)}
-`;
+${JSON.stringify(jsonSchema, null, 2)}`;
 
-		let modifiedMessages = [...messages];
-		const systemMessageIndex = modifiedMessages.findIndex(
-			(m) => m.type === "system",
-		);
-
-		if (systemMessageIndex >= 0) {
-			const existingSystem = modifiedMessages[systemMessageIndex].content;
-			modifiedMessages[systemMessageIndex] = new SystemMessage(
-				`${existingSystem}\n\n${formatInstructions}`,
-			);
-		} else {
-			modifiedMessages.unshift(new SystemMessage(formatInstructions));
-		}
+		// The contract goes in the LAST turn, not appended to the system prompt.
+		// Buried behind a long system prompt plus history, providers that ignore
+		// `response_format` (Poolside, some compatible servers) answer the user's
+		// question in prose and the first attempt is spent discovering that — the
+		// correction turn then works purely because it is the last thing read.
+		// A trailing human turn keeps the history provider-valid (see the
+		// `invalid_request_message_order` rules in AGENT.md).
+		let modifiedMessages = [...messages, new HumanMessage(formatInstructions)];
 
 		// Self-correcting loop: a blind retry just makes the model repeat the same
 		// mistake, so each attempt shows it what it got back and what was wrong.


### PR DESCRIPTION
Closes #140 · part of #139

## Every structured call was burning its first attempt

Reported on `poolside/laguna-s-2.1` — every run, always attempt 1, always recovered on attempt 2:

```
[WARN] [BaseAgentWrapper] Structured output invalid, re-asking
  {"model":"poolside/laguna-s-2.1","attempt":1,
   "error":"JSON Parse error: Unexpected identifier \"Fluxify\""}
```

`Unexpected identifier "Fluxify"` means the model replied in **plain prose** — there was no `{` anywhere for `sliceBalancedJson` to recover. Not truncation, not a schema mismatch.

Poolside is the *OpenAI Compatible* variant → provider `openai` with a `baseUrl` → `supportsStructuredOutput()` is false, so every structured call takes the prompt fallback, which binds `response_format: { type: "json_object" }`. Poolside answers 200 with prose, so it is **ignoring** that flag (a rejection would have logged `JSON mode rejected, dropping it`, and real constrained decoding cannot emit a bare identifier).

With nothing constraining the output, the instruction is all there is — and it was appended to the end of the system prompt:

```
system:  [agent prompt: capabilities + constraints + block catalog + rules]
         + "You must respond with ONLY a valid JSON object matching…"   ← here
human:   ...conversation history...
human:   "Create a route that returns tasks from the tasks table"       ← last thing read
```

Thousands of tokens back, with a conversational question in the final turn. The model answers the question. Attempt 2 succeeds for exactly one reason: the correction turn is the **last** message.

**Fix:** the contract is now a trailing `HumanMessage` after the user query — the same position that already demonstrably worked on attempt 2. The history still ends on a user role, so it stays valid for providers like Mistral (see the `invalid_request_message_order` rules in AGENT.md). The agent's own system prompt is left exactly as the agent wrote it.

Cost removed: one wasted round trip per structured call — router, planner, taskGenerator, routeConfig, blockBuilder, summarizer — so ~5–7 per run on any provider that ignores `response_format`, each re-sending the whole prompt.

## The error message was sending diagnosis the wrong way

`explainErrorReason` matched `"json" | "schema" | "structured output"` in one branch, so a parse error, an empty response and a genuine zod violation all produced:

> …the model ran out of output space or is not reliable at structured output — try a larger or stronger model

For this bug that is wrong on both counts. Split into three:

| Error | Message |
| --- | --- |
| empty response | spent its whole output budget on reasoning — use a model with a larger output limit |
| JSON parse error | replied in plain prose; models behind an OpenAI-compatible endpoint often ignore the JSON output format |
| everything else | unchanged |

## Verification

Live on `mistral-medium-latest` with `supportsStructuredOutput()` forced to false, so the probe exercises the exact fallback path Poolside takes:

```
> Create a route that returns tasks from the tasks table
  fallback attempts: 1   nextRoute: planner            { intent: builder, capable: true }
> hey, what blocks do you have for databases?
  fallback attempts: 1   nextRoute: discussion         { intent: discussion, capable: true }
> Build me an endpoint that accepts a file upload and streams it back over a websocket
  fallback attempts: 1   nextRoute: (none — run ends)  { intent: builder, capable: false }
```

Caveat: Mistral honours `json_object`, so this shows the new placement does not regress a provider that was already fine — it is not a reproduction of the Poolside failure. That needs a Poolside key to confirm end to end.

2 new cases: the contract lands in the last turn with the system prompt untouched, and the two reclassified errors. `apps/ai-gateway`: **125 pass, 0 fail**. `tsc --noEmit` clean. Pre-commit: 428 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
