### PR TITLE
perf(harness): execute a turn's tool calls concurrently

### DIFF
--- a/apps/ai-gateway/src/harness/models/base.spec.ts
+++ b/apps/ai-gateway/src/harness/models/base.spec.ts
@@ -335,6 +335,102 @@ describe("submit_result", () => {
 	});
 });
 
+describe("parallel tool calls", () => {
+	let active = 0;
+	let peak = 0;
+
+	const slowTool = (name: string, output: string) =>
+		tool(
+			async () => {
+				peak = Math.max(peak, ++active);
+				await new Promise((r) => setTimeout(r, 10));
+				active--;
+				return output;
+			},
+			{ name, description: name, schema: z.object({}) },
+		) as unknown as StructuredTool;
+
+	class BatchWrapper extends BaseAgentWrapper {
+		calls: BaseMessage[][] = [];
+
+		constructor(private responses: AIMessage[]) {
+			super("test-model");
+		}
+
+		protected getModel(): BaseChatModel {
+			let i = 0;
+			const model: any = {
+				bindTools: () => model,
+				invoke: async (messages: BaseMessage[]) => {
+					this.calls.push([...messages]);
+					return this.responses[Math.min(i++, this.responses.length - 1)];
+				},
+			};
+			return model as BaseChatModel;
+		}
+
+		run() {
+			return this.invokeAgent({
+				zodSchema: schema,
+				systemPrompt: "you are a builder",
+				userQuery: "build it",
+				tools: [slowTool("tool_a", "A"), slowTool("tool_b", "B")],
+			});
+		}
+	}
+
+	it("runs a batch concurrently and appends results in call order", async () => {
+		active = 0;
+		peak = 0;
+		const wrapper = new BatchWrapper([
+			new AIMessage({
+				content: "",
+				tool_calls: [
+					{ id: "call_a", name: "tool_a", args: {} },
+					{ id: "call_b", name: "tool_b", args: {} },
+				],
+			}),
+			new AIMessage({
+				content: "",
+				tool_calls: [
+					{ id: "call_s", name: SUBMIT_RESULT_TOOL, args: { blocks: ["a"] } },
+				],
+			}),
+		]);
+
+		expect(await wrapper.run()).toEqual({ blocks: ["a"] });
+		// Both tools were in flight at the same time — the whole point.
+		expect(peak).toBe(2);
+
+		// Completion order must not leak into the history: a ToolMessage that
+		// doesn't line up with its tool_call is rejected by strict providers.
+		const second = wrapper.calls[1]!;
+		const results = second.filter(
+			(m): m is ToolMessage => m instanceof ToolMessage,
+		);
+		expect(results.map((m) => m.tool_call_id)).toEqual(["call_a", "call_b"]);
+		expect(results.map((m) => String(m.content))).toEqual(["A", "B"]);
+	});
+
+	it("skips the rest of the batch when submit_result validates", async () => {
+		active = 0;
+		peak = 0;
+		const wrapper = new BatchWrapper([
+			new AIMessage({
+				content: "",
+				tool_calls: [
+					{ id: "call_s", name: SUBMIT_RESULT_TOOL, args: { blocks: ["a"] } },
+					{ id: "call_a", name: "tool_a", args: {} },
+				],
+			}),
+		]);
+
+		expect(await wrapper.run()).toEqual({ blocks: ["a"] });
+		// The answer is in hand; running the rest is paid-for work nobody reads.
+		expect(peak).toBe(0);
+	});
+});
+
 describe("flattenToolMessages", () => {
 	it("strips tool_use blocks and ends on a human turn", () => {
 		// Anthropic and Mistral reject a request carrying tool_use blocks when no

--- a/apps/ai-gateway/src/harness/models/base.ts
+++ b/apps/ai-gateway/src/harness/models/base.ts
@@ -388,29 +388,40 @@ export abstract class BaseAgentWrapper {
 			finalMessages.push(response);
 
 			if (response.tool_calls && response.tool_calls.length > 0) {
-				for (const tc of response.tool_calls) {
-					if (tc.name === SUBMIT_RESULT_TOOL && zodSchema) {
-						const parsed = zodSchema.safeParse(tc.args);
-						if (parsed.success)
-							return { done: true, value: parsed.data as T };
-						// Answer the call so the history stays valid (a tool_call with no
-						// result is rejected outright) and let the model correct itself
-						// on the next iteration.
-						finalMessages.push(
-							new ToolMessage({
+				// `submit_result` is the answer, not work — if it validates, nothing
+				// else the model asked for in this batch is worth running.
+				const submit = zodSchema
+					? response.tool_calls.find((tc) => tc.name === SUBMIT_RESULT_TOOL)
+					: undefined;
+				const submitParsed = submit && zodSchema?.safeParse(submit.args);
+				if (submitParsed?.success)
+					return { done: true, value: submitParsed.data as T };
+
+				// Models emit parallel tool calls precisely so they can run in
+				// parallel; running them in sequence costs the sum of the round
+				// trips instead of the max. Results are pushed in call order, not
+				// completion order — strict providers reject a batch whose
+				// ToolMessages don't line up with their tool_calls.
+				const results = await Promise.all(
+					response.tool_calls.map((tc) => {
+						if (submitParsed && !submitParsed.success && tc === submit) {
+							// Answer the call so the history stays valid (a tool_call with
+							// no result is rejected outright) and let the model correct
+							// itself on the next iteration.
+							return new ToolMessage({
 								tool_call_id: tc.id!,
 								name: tc.name,
-								content: `Rejected — the result did not match the required schema.\n\n${describeSchemaError(parsed.error)}\n\nCall ${SUBMIT_RESULT_TOOL} again with the corrected values.`,
-							}),
-						);
-						continue;
-					}
-					await this.executeToolCall(tc, tools, finalMessages, {
-						agent: agentNode,
-						agentId,
-						config,
-					});
-				}
+								content: `Rejected — the result did not match the required schema.\n\n${describeSchemaError(submitParsed.error)}\n\nCall ${SUBMIT_RESULT_TOOL} again with the corrected values.`,
+							});
+						}
+						return this.executeToolCall(tc, tools, {
+							agent: agentNode,
+							agentId,
+							config,
+						});
+					}),
+				);
+				finalMessages.push(...results);
 				continue;
 			}
 
@@ -436,62 +447,58 @@ export abstract class BaseAgentWrapper {
 		return { done: false };
 	}
 
-	/** Invokes a single tool call and pushes its result (or error) as a ToolMessage. */
+	/**
+	 * Invokes a single tool call and returns its result (or error) as a
+	 * ToolMessage. It returns rather than appending so a batch can run
+	 * concurrently and still be appended in call order.
+	 */
 	private async executeToolCall(
 		tc: NonNullable<AIMessage["tool_calls"]>[number],
 		tools: StructuredTool[],
-		finalMessages: BaseMessage[],
 		ctx: { agent?: string; agentId?: string; config?: RunnableConfig },
-	): Promise<void> {
+	): Promise<ToolMessage> {
 		const tool = tools.find((t) => t.name === tc.name);
 		const toolEvent = { agent: ctx.agent, agentId: ctx.agentId, tool: tc.name };
 		await this.emitToolEvent({ ...toolEvent, status: "started" });
 
 		if (!tool) {
-			finalMessages.push(
-				new ToolMessage({
-					tool_call_id: tc.id!,
-					content: `Tool ${tc.name} not found.`,
-					name: tc.name,
-				}),
-			);
 			await this.emitToolEvent({
 				...toolEvent,
 				status: "ended",
 				error: `tool ${tc.name} not found`,
 			});
-			return;
+			return new ToolMessage({
+				tool_call_id: tc.id!,
+				content: `Tool ${tc.name} not found.`,
+				name: tc.name,
+			});
 		}
 
 		try {
 			const toolResult = await tool.invoke(tc.args, this.withSignal(ctx.config));
-			finalMessages.push(
-				new ToolMessage({
-					tool_call_id: tc.id!,
-					content:
-						typeof toolResult === "string"
-							? toolResult
-							: JSON.stringify(toolResult),
-					name: tc.name,
-				}),
-			);
 			await this.emitToolEvent({
 				...toolEvent,
 				status: "ended",
 				summary: summarizeToolResult(toolResult),
 			});
+			return new ToolMessage({
+				tool_call_id: tc.id!,
+				content:
+					typeof toolResult === "string"
+						? toolResult
+						: JSON.stringify(toolResult),
+				name: tc.name,
+			});
 		} catch (e) {
-			finalMessages.push(
-				new ToolMessage({
-					tool_call_id: tc.id!,
-					content: `Error executing tool ${tc.name}: ${e}`,
-					name: tc.name,
-				}),
-			);
 			await this.emitToolEvent({
 				...toolEvent,
 				status: "ended",
 				error: e instanceof Error ? e.message : String(e),
+			});
+			return new ToolMessage({
+				tool_call_id: tc.id!,
+				content: `Error executing tool ${tc.name}: ${e}`,
+				name: tc.name,
 			});
 		}
 	}


### PR DESCRIPTION
Closes #146 · part of #139

## The loop was serialising calls the model asked to parallelise

`models/base.ts` ran the batch one at a time:

```ts
for (const tc of response.tool_calls) { await this.executeToolCall(tc, …) }
```

A turn containing `find_resource` + `search_docs` + `get_block_schemas` cost the **sum** of three DB/vector round trips instead of the max.

## Fix

`executeToolCall` now **returns** its `ToolMessage` instead of appending to `finalMessages`, so the batch runs under `Promise.all` and the results are appended in **call order**:

```ts
const results = await Promise.all(
    response.tool_calls.map((tc) => …),
);
finalMessages.push(...results);
```

Completion order must not leak into the history — a `ToolMessage` that doesn't line up with its `tool_call` is rejected outright by strict providers.

Ordering is safe here because every harness tool is a read: `search_docs`, `get_route_details`, `find_resource`, `get_artifact` (`tools/index.ts`) plus `get_block_schemas` on the block builder. Nothing in the batch writes, so there is no dependency between two calls in the same turn.

## Also: `submit_result` is checked before the batch runs

It is the answer, not work. When the model emitted it alongside other calls, those calls were executed and *then* discarded by the early return — paid-for work nobody reads. It's now resolved first, and the batch only runs if it isn't there or doesn't validate. The invalid case still gets its rejection `ToolMessage` in place, so the history stays valid.

## Verification

2 new cases:
- a two-tool batch reaches peak concurrency 2 (both in flight simultaneously) and the `ToolMessage`s land as `call_a`, `call_b` with contents `A`, `B` regardless of completion order
- a batch led by a valid `submit_result` runs zero tools

`apps/ai-gateway`: **127 pass, 0 fail**. `tsgo --noEmit` clean. Pre-commit: 430 pass.

## Not done here

The issue's optional half — folding the supervisor (pure local validation, no model call) into the sub-agent's return to cut a superstep per task level. It rewrites the same boundary as #147, so it belongs with that change rather than ahead of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
