### PR TITLE
fix(harness): retry or stop a failed task instead of finalizing as completed

### DIFF
--- a/apps/ai-gateway/src/harness/agents/orchestrator.spec.ts
+++ b/apps/ai-gateway/src/harness/agents/orchestrator.spec.ts
@@ -49,6 +49,24 @@ describe("OrchestratorAgent", () => {
 		expect((await dispatch([a, b])).map((t) => t.id)).toEqual(["b"]);
 	});
 
+	it("fails dependents of a failed task instead of dispatching them", async () => {
+		const a = task("a");
+		a.status = "failed";
+		const b = task("b", ["a"]);
+		const c = task("c", ["b"]); // transitive
+
+		expect(await dispatch([a, b, c])).toEqual([]);
+		expect([b.status, c.status]).toEqual(["failed", "failed"]);
+		expect(b.supervisorReviews).toContain("a");
+	});
+
+	it("still dispatches siblings of a failed task", async () => {
+		const a = task("a");
+		a.status = "failed";
+		const dispatched = await dispatch([a, task("b", ["a"]), task("c")]);
+		expect(dispatched.map((t) => t.id)).toEqual(["c"]);
+	});
+
 	it("ends the run when nothing is left to dispatch", async () => {
 		const done = task("a");
 		done.status = "completed";

--- a/apps/ai-gateway/src/harness/agents/orchestrator.ts
+++ b/apps/ai-gateway/src/harness/agents/orchestrator.ts
@@ -30,14 +30,36 @@ export class OrchestratorAgent extends BaseAgent {
 		// and dispatching overlapping levels concurrently. Deriving the next level
 		// makes those concurrent runs produce the identical result instead.
 		const byId = new Map(tasks.map((task) => [task.id, task]));
-		const isSettled = (task?: Task) =>
-			task ? task.status === "completed" || task.status === "failed" : true;
+
+		// A failed dependency is not a satisfied one. Dispatching its dependents
+		// anyway produced work referencing a route that was never configured — and
+		// the run still finalized as `completed`. They fail with it instead,
+		// transitively, since a chain can be several levels deep. An unknown
+		// dependency id can't fail and can't block: the task generator already
+		// strips those, so anything left is treated as satisfied rather than
+		// stalling the build forever.
+		for (let changed = true; changed; ) {
+			changed = false;
+			for (const task of tasks) {
+				if (task.status !== "pending") continue;
+				const failedDep = (task.dependsOnAgentId ?? []).find(
+					(depId) => byId.get(depId)?.status === "failed",
+				);
+				if (!failedDep) continue;
+				task.status = "failed";
+				task.supervisorReviews = `Skipped — it depends on task ${failedDep}, which failed.`;
+				changed = true;
+			}
+		}
+
+		const isSatisfied = (task?: Task) =>
+			task ? task.status === "completed" : true;
 
 		const readyTasks = tasks.filter(
 			(task) =>
 				task.status === "pending" &&
 				(task.dependsOnAgentId ?? []).every((depId) =>
-					isSettled(byId.get(depId)),
+					isSatisfied(byId.get(depId)),
 				),
 		);
 

--- a/apps/ai-gateway/src/harness/agents/sub-agents/routeConfig.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/routeConfig.ts
@@ -136,7 +136,7 @@ Fluxify uses a specific JSON format for schemas. DO NOT output standard JSON Sch
 
 		const userQuery = `Task Title: ${activeTask.title}
 Task Description: ${activeTask.description}
-
+${activeTask.supervisorReviews ? `\nYour previous attempt was rejected. Fix this:\n${activeTask.supervisorReviews}\n` : ""}
 Determine the exact route configuration intent. Use your tools if you need more context before generating the configuration schema.`;
 
 		const tools = [

--- a/apps/ai-gateway/src/harness/agents/summarizer.ts
+++ b/apps/ai-gateway/src/harness/agents/summarizer.ts
@@ -62,6 +62,10 @@ export class SummarizerAgent extends BaseAgent {
 			let newRouteSubArtifactId: string | undefined;
 
 			for (const task of tasks) {
+				// A failed task's last (rejected) output is still sitting in
+				// subAgentResults — persisting it would show the user a chip for work
+				// that was never applied.
+				if (task.status === "failed") continue;
 				const result = (results as Record<string, any>)[task.id];
 				if (!result) continue;
 
@@ -131,6 +135,16 @@ export class SummarizerAgent extends BaseAgent {
 					.join("\n\n")
 			: "No structured changes were produced by the build agents.";
 
+		const failedTasks = tasks.filter((t) => t.status === "failed");
+		const failedText = failedTasks.length
+			? failedTasks
+					.map(
+						(t) =>
+							`- "${t.title}" — ${t.supervisorReviews ?? "the agent produced no usable result"}`,
+					)
+					.join("\n")
+			: "None.";
+
 		const hintsText = scratchpad.length
 			? scratchpad.map((s) => `- ${s}`).join("\n")
 			: "None.";
@@ -169,6 +183,7 @@ Tokens are markdown directives: a leading colon, the token name, then attributes
 
 # STRUCTURE & STYLE
 - Lead with a one-line overview of what the run accomplished (no token on this line).
+- If the "Parts that did NOT get done" section is not "None.", say so plainly right after the overview — name what was not completed, in the user's language, and never describe it as done or imply it exists. Do not emit a token for it.
 - Then one line per change, each ending with its exact reference token (section A).
 - Put required user actions in markdown blockquotes (\`> ...\`), with any creation chips (section B) inline inside them.
 - Be concise and to the point: what changed + what the user must do. NO preamble, NO restating these instructions, NO internal implementation details (no block ids, schemas, agent names, or internal reasoning).
@@ -183,6 +198,9 @@ Created a new endpoint to fetch task items and wired up its logic.
 
 # Changes (each has an EXACT token to place at end of its line)
 ${changesTable}
+
+# Parts that did NOT get done
+${failedText}
 
 # Hints / required user actions (from the build agents)
 ${hintsText}`;

--- a/apps/ai-gateway/src/harness/agents/supervisor.spec.ts
+++ b/apps/ai-gateway/src/harness/agents/supervisor.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "bun:test";
+import { MAX_TASK_ATTEMPTS, SupervisorAgent } from "./supervisor";
+import { AgentNode, type GlobalGraphState, type Task } from "../types";
+
+// A task assigned to an agent with no validator: a missing result is then the
+// only way it can be rejected, which keeps the test off the DB-backed validators.
+const task = (id: string): Task =>
+	({
+		id,
+		title: id,
+		description: id,
+		status: "running",
+		assignedAgentNode: AgentNode.DISCUSSION,
+		dependsOnAgentId: [],
+	}) as Task;
+
+const supervise = async (tasks: Task[]) =>
+	new SupervisorAgent({
+		orchestratorState: {
+			tasks,
+			dispatchedTasks: tasks,
+			subAgentResults: {},
+		},
+		scratchpad: [],
+	} as unknown as GlobalGraphState).execute();
+
+describe("SupervisorAgent", () => {
+	it("re-queues a rejected task with the reason as feedback", async () => {
+		const a = task("a");
+		const result = await supervise([a]);
+
+		expect(a.status).toBe("pending");
+		expect(a.attempts).toBe(1);
+		expect(a.supervisorReviews).toContain("No result");
+		expect(result.scratchpad?.[0]).toContain("Retry 1/2");
+	});
+
+	it("fails the task once the attempts run out", async () => {
+		const a = task("a");
+		for (let i = 0; i < MAX_TASK_ATTEMPTS; i++) {
+			a.status = "running";
+			await supervise([a]);
+		}
+
+		expect(a.status).toBe("failed");
+		expect(a.attempts).toBe(MAX_TASK_ATTEMPTS);
+	});
+
+	it("completes a task its validator accepts", async () => {
+		const a = task("a");
+		await new SupervisorAgent({
+			orchestratorState: {
+				tasks: [a],
+				dispatchedTasks: [a],
+				subAgentResults: { a: { ok: true } },
+			},
+			scratchpad: [],
+		} as unknown as GlobalGraphState).execute();
+
+		expect(a.status).toBe("completed");
+		expect(a.attempts).toBeUndefined();
+	});
+});

--- a/apps/ai-gateway/src/harness/agents/supervisor.ts
+++ b/apps/ai-gateway/src/harness/agents/supervisor.ts
@@ -4,6 +4,9 @@ import { dispatchAgentEvent } from "../callbacks";
 import { validateAgentOutput as validateRouteConfig } from "./sub-agents/routeConfig";
 import { validateBlockBuilderOutput } from "./sub-agents/blockBuilder";
 
+/** Total validation rounds a task gets — the first run plus its retries. */
+export const MAX_TASK_ATTEMPTS = 2;
+
 export class SupervisorAgent extends BaseAgent {
 	constructor(state: GlobalGraphState) {
 		super(state);
@@ -34,6 +37,28 @@ export class SupervisorAgent extends BaseAgent {
 			if (entry) entry.status = status;
 		};
 
+		// A rejection is feedback, not a verdict. The sub-agent prompts read
+		// `supervisorReviews`, so put the reason there and send the task back to
+		// `pending` — the orchestrator re-dispatches it with the correction in
+		// context. Only once the attempts run out does the task fail terminally,
+		// and a terminal failure must take its dependents with it (orchestrator).
+		const reject = (i: number, task: Task, reason: string) => {
+			const entry = tasks.find((t) => t.id === task.id) ?? task;
+			entry.attempts = (entry.attempts ?? 0) + 1;
+			entry.supervisorReviews = reason;
+
+			const terminal = entry.attempts >= MAX_TASK_ATTEMPTS;
+			const status = terminal ? "failed" : "pending";
+			dispatchedTasks[i].status = status;
+			setStatus(task.id, status);
+			scratchpad.push(
+				terminal
+					? `[Supervisor Error - Task ${task.id} (${task.assignedAgentNode})]: ${reason}`
+					: `[Supervisor Retry ${entry.attempts}/${MAX_TASK_ATTEMPTS} - Task ${task.id} (${task.assignedAgentNode})]: ${reason}`,
+			);
+			hasErrors = true;
+		};
+
 		for (let i = 0; i < dispatchedTasks.length; i++) {
 			const task = dispatchedTasks[i];
 			// Only verify tasks that are currently running
@@ -42,12 +67,7 @@ export class SupervisorAgent extends BaseAgent {
 			const result = results[task.id];
 
 			if (!result) {
-				dispatchedTasks[i].status = "failed";
-				setStatus(task.id, "failed");
-				scratchpad.push(
-					`[Supervisor Error - Task ${task.id}]: No result provided by agent.`,
-				);
-				hasErrors = true;
+				reject(i, task, "No result provided by agent.");
 				continue;
 			}
 
@@ -65,12 +85,7 @@ export class SupervisorAgent extends BaseAgent {
 			}
 
 			if (error) {
-				dispatchedTasks[i].status = "failed";
-				setStatus(task.id, "failed");
-				scratchpad.push(
-					`[Supervisor Error - Task ${task.id} (${task.assignedAgentNode})]: ${error}`,
-				);
-				hasErrors = true;
+				reject(i, task, error);
 			} else {
 				dispatchedTasks[i].status = "completed";
 				setStatus(task.id, "completed");

--- a/apps/ai-gateway/src/harness/index.ts
+++ b/apps/ai-gateway/src/harness/index.ts
@@ -475,23 +475,39 @@ export class FluxifyHarness {
 			finalState?.routerState?.rejectReason ??
 			null;
 
+		// A build whose tasks didn't all land is not "All done". The summary still
+		// ships as the response — it names what was and wasn't built — but the run
+		// must not report success over a route that was never configured.
+		const failedTasks = (finalState?.orchestratorState?.tasks ?? []).filter(
+			(task) => task.status === "failed",
+		);
+		const status = failedTasks.length > 0 ? "failed" : "completed";
+		const message =
+			failedTasks.length > 0
+				? `Finished with ${failedTasks.length} unfinished task${failedTasks.length === 1 ? "" : "s"}`
+				: "All done";
+
 		await harnessService.updateRun({
 			runId: ctx.runId,
-			status: "completed",
+			status,
 			aiResponse: aiResponse ?? undefined,
 			completedAt: new Date(),
 		});
 		await harnessService.saveLiveState({
 			runId: ctx.runId,
 			conversationId: ctx.conversationId,
-			currentState: "completed",
+			currentState: status,
 			graphState: finalState,
 		});
-		await harnessService.updateConversationStatus("completed", null);
+		await harnessService.updateConversationStatus(status, null);
 		await this.redisService.clearActiveRun(ctx.conversationId);
-		await this.emitRunEvent(ctx, userId, "completed", "ended", "All done", {
+		await this.emitRunEvent(ctx, userId, status, "ended", message, {
 			result: aiResponse ?? undefined,
 			artifactId: finalState?.summarizerState?.artifactId,
+			error:
+				failedTasks.length > 0
+					? failedTasks.map((t) => t.title).join("; ")
+					: undefined,
 		});
 		await this.redisService.finalizeSnapshot(ctx.runId);
 	}

--- a/apps/ai-gateway/src/harness/types.ts
+++ b/apps/ai-gateway/src/harness/types.ts
@@ -76,7 +76,11 @@ export interface Task {
 	dependsOnAgentId: string[];
 	status: "pending" | "running" | "completed" | "failed";
 	assignedAgentNode: AgentNodeName;
+	/** The supervisor's rejection reason, fed back to the sub-agent on its retry. */
 	supervisorReviews?: string;
+	/** Rejected rounds so far. The task is re-queued with the feedback above
+	 *  until this reaches MAX_TASK_ATTEMPTS, then it fails terminally. */
+	attempts?: number;
 }
 
 export interface RouterState {


### PR DESCRIPTION
Closes #147 · part of #139

## The failure path told the user the opposite of what happened

The supervisor marked a rejected task `failed`; the orchestrator counted `failed` as **settled**:

```ts
const isSettled = (task?: Task) =>
    task ? task.status === "completed" || task.status === "failed" : true;
```

So dependents dispatched against a dependency that produced nothing, the run walked to the summarizer, and `finalizeRun` wrote **`completed`** — "All done" over a route that was never configured. `Task.supervisorReviews` was read by the block builder prompt and written by nothing: the retry-with-feedback loop the design implies did not exist.

## 1. A rejection is feedback, not a verdict

The supervisor writes the reason into `supervisorReviews` and puts the task back to `pending`. The orchestrator re-dispatches it with the correction in the sub-agent's user query, capped by `MAX_TASK_ATTEMPTS` (2 — one retry). The route config agent now carries that feedback too; the block builder already read it.

Scratchpad lines distinguish the two: `[Supervisor Retry 1/2 - Task …]` vs `[Supervisor Error - Task …]`.

## 2. A terminal failure takes its dependents with it

```ts
for (let changed = true; changed; ) { … }
```

Transitively — a chain can be several levels deep — with the reason recorded on each. Siblings that don't depend on it still dispatch. Dependencies are only satisfied by `completed` now.

An **unknown** dependency id stays satisfied: #155 already strips phantom deps at generation time, and blocking on one would stall the build forever rather than fail it.

## 3. The run stops claiming success

- The summarizer skips failed tasks when persisting sub-artifacts — the last rejected output was still sitting in `subAgentResults`, so the user got a chip for work that was never applied.
- It is handed a "Parts that did NOT get done" section plus a rule to state it plainly and never imply the work exists.
- `finalizeRun` finalizes a run with failed tasks as `failed` (run, live state, conversation and the terminal event), with the message `Finished with N unfinished tasks`. The summary still ships as `aiResponse`, so the user sees what *did* land.

## Verification

`agents/supervisor.spec.ts` (new): a rejected task is re-queued with the reason and `attempts: 1`; it fails only once the attempts run out; an accepted task completes untouched.
`agents/orchestrator.spec.ts`: dependents of a failed task are marked failed transitively and never dispatch; siblings still do.

`apps/ai-gateway`: **132 pass, 0 fail**. `tsgo --noEmit` clean. Pre-commit: 435 pass.

## Note

A block builder that answers `status: "impossible"` is validated as a rejection, so it now gets one retry before failing. Left as-is — it's one call in a path that was already going to end in failure, and the retry carries the tool context the first pass gathered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
