### PR TITLE
perf(harness): make prompts cacheable and build the model client once

### DIFF
--- a/apps/ai-gateway/src/harness/agents/discussion.ts
+++ b/apps/ai-gateway/src/harness/agents/discussion.ts
@@ -80,7 +80,7 @@ Two calibrations:
 Q: "Does Fluxify support MongoDB?" -> "Yes. There is a dedicated MongoDB block alongside the PostgreSQL and MySQL ones, so you can query it directly in a workflow without any custom scripting." Not a heading plus three bullets.
 Q: "What can I access inside the script block?" -> a lead sentence, then a bullet list of what is actually exposed, because that genuinely is a set of parallel items.
 
-- Your final output must be in plain Markdown format without wrappers like \`\`\`markdown.${contextBlock ? `\n\n${contextBlock}` : ""}`;
+- Your final output must be in plain Markdown format without wrappers like \`\`\`markdown.`;
 
 		// Instantiate tools
 		const tools = createHarnessTools(
@@ -90,6 +90,7 @@ Q: "What can I access inside the script block?" -> a lead sentence, then a bulle
 
 		const response: any = await this.state.agentWrapper.invokeAgent({
 			systemPrompt,
+			context: contextBlock,
 			messages: this.state.messages,
 			userQuery: this.state.userQuery,
 			tools: tools,

--- a/apps/ai-gateway/src/harness/agents/planner.ts
+++ b/apps/ai-gateway/src/harness/agents/planner.ts
@@ -72,10 +72,15 @@ export class PlannerAgent extends BaseAgent {
 		});
 
 		const scratchPadText = this.state.scratchpad?.length
-			? `\n\n## Context / Scratch Pad from Previous Agents\nHere is information gathered from previous steps:\n${this.state.scratchpad.map((s) => `- ${s}`).join("\n")}`
+			? `## Context / Scratch Pad from Previous Agents\nHere is information gathered from previous steps:\n${this.state.scratchpad.map((s) => `- ${s}`).join("\n")}`
 			: "";
 
 		const contextBlock = this.state.internal?.metadata?.contextBlock;
+
+		// Both change every run, so they travel with the user's turn — see
+		// `AgentInvokeOptions.context`. The system prompt above is now identical
+		// across runs and can be served from the provider's prompt cache.
+		const context = [scratchPadText, contextBlock].filter(Boolean).join("\n\n");
 
 		const systemPrompt = `You are the Expert Planner Agent for Fluxify — a No/Low-Code Backend Engine.
 Fluxify allows users to build, deploy, and scale APIs visually without writing boilerplate code. It uses a visual graph where "Blocks" (units of logic like DB fetching, AI generation, or JS VM execution) are connected by "Edges" (defining direct flow, decision paths, and error handling paths).
@@ -136,7 +141,7 @@ Other blocks may require secrets from **app configs**.
    - **Small, simple feedback**: If the feedback is minor (e.g. renaming a field, tweaking a value, a one-line clarification) and does not change the plan's overall complexity or risk, apply it directly, then raise \`confidenceScore\` accordingly — don't keep bouncing a nearly-finished plan back for review over trivial changes.
    - **Substantial feedback**: If the feedback changes scope, architecture, or introduces real ambiguity, revise the plan fully and score confidence honestly — it's fine to require another review in that case.
 
-Plan carefully, thoroughly, and output excellent English craft for the user's plan.${scratchPadText}${contextBlock ? `\n\n${contextBlock}` : ""}`;
+Plan carefully, thoroughly, and output excellent English craft for the user's plan.`;
 
 		const tools = [
 			createFindResourceTool(
@@ -152,6 +157,7 @@ Plan carefully, thoroughly, and output excellent English craft for the user's pl
 		const response = (await this.state.agentWrapper.invokeAgent({
 			zodSchema: plannerSchema,
 			systemPrompt,
+			context,
 			tools,
 			messages: this.state.messages,
 			userQuery: this.state.userQuery,

--- a/apps/ai-gateway/src/harness/agents/router.ts
+++ b/apps/ai-gateway/src/harness/agents/router.ts
@@ -115,11 +115,12 @@ CRITICAL INSTRUCTIONS:
 - Your output must rigidly conform to the provided schema.
 - You MUST select exactly ONE 'intent': either "discussion" or "builder".
 - Provide a concise but definitive reason for your classification in the 'reason' field.
-- Instead of raw reasoning, provide a 'scratchpad' note for the downstream agents if there is important context, a warning, or a missing integration detail.${contextBlock ? `\n\n${contextBlock}` : ""}`;
+- Instead of raw reasoning, provide a 'scratchpad' note for the downstream agents if there is important context, a warning, or a missing integration detail.`;
 
 		const response = (await this.state.agentWrapper.invokeAgent({
 			zodSchema: routerSchema,
 			systemPrompt,
+			context: contextBlock,
 			messages: this.state.messages,
 			userQuery: this.state.userQuery,
 			agentNode: AgentNode.ROUTER,

--- a/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/agent.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/agent.ts
@@ -84,7 +84,7 @@ export class BlockBuilderAgent extends BaseAgent {
 		const projectId = this.state.internal?.metadata?.projectId || "NONE";
 		const customBlocksTable = await this.getCustomBlocksInfo(projectId);
 		const contextBlock = this.state.internal?.metadata?.contextBlock;
-		const systemPrompt = createSystemPrompt(customBlocksTable, contextBlock);
+		const systemPrompt = createSystemPrompt(customBlocksTable);
 		const userQuery = createUserQuery(activeTask);
 
 		const tools = [
@@ -106,6 +106,7 @@ export class BlockBuilderAgent extends BaseAgent {
 		const response = (await this.state.agentWrapper.invokeAgent({
 			zodSchema: blockBuilderSchema,
 			systemPrompt,
+			context: contextBlock,
 			tools,
 			messages: [],
 			userQuery,

--- a/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/promptHelpers.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/promptHelpers.ts
@@ -24,10 +24,7 @@ export const BUILTIN_BLOCKS_TABLE = createBlocksTable(
 	})),
 );
 
-export function createSystemPrompt(
-	customBlocksTable: string,
-	contextBlock?: string,
-): string {
+export function createSystemPrompt(customBlocksTable: string): string {
 	return `You are the Block Builder Agent for Fluxify \u2014 an Agentic Low Code Backend Development Platform.
 Your responsibility is to build and modify the canvas of a workflow DAG, which consists of various blocks (nodes) connected by edges. You are capable of building the canvas for both Routes and Custom Blocks. The task description will define what you are editing.
 
@@ -119,7 +116,7 @@ Use these exact property names — do not rename or omit them:
 - \`connections\` and \`canvasChanges\` are always present — use \`[]\` when empty.
 - Set \`status\` to 'impossible' (with a short \`reasoning\`) only when the canvas genuinely cannot be built.
 
-The orchestrator will apply the configuration after supervisor approval. Keep your reasoning concise.${contextBlock ? `\n\n${contextBlock}` : ""}`;
+The orchestrator will apply the configuration after supervisor approval. Keep your reasoning concise.`;
 }
 
 export function createUserQuery(

--- a/apps/ai-gateway/src/harness/agents/sub-agents/routeConfig.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/routeConfig.ts
@@ -132,7 +132,7 @@ Fluxify uses a specific JSON format for schemas. DO NOT output standard JSON Sch
 6. **DO NOT generate a UUID for new routes.** Leave \`routeId\` empty/undefined when the action is \`create\`. The system will generate it.
 7. If the action is \`update-partial\` or \`delete\`, you MUST include the \`routeId\` extracted from the task context.
 8. Make sure to generate the schemas (\`bodySchema\`, \`querySchema\`, \`paramsSchema\`) exactly following the custom \`ValidationSchemaZod\` format above. 
-9. The orchestrator will use your exact structured output to apply the changes after human approval.${contextBlock ? `\n\n${contextBlock}` : ""}`;
+9. The orchestrator will use your exact structured output to apply the changes after human approval.`;
 
 		const userQuery = `Task Title: ${activeTask.title}
 Task Description: ${activeTask.description}
@@ -150,6 +150,7 @@ Determine the exact route configuration intent. Use your tools if you need more 
 		const response = (await this.state.agentWrapper.invokeAgent({
 			zodSchema: routeConfigSchema,
 			systemPrompt,
+			context: contextBlock,
 			tools,
 			messages: [],
 			userQuery: userQuery,

--- a/apps/ai-gateway/src/harness/agents/taskGenerator.ts
+++ b/apps/ai-gateway/src/harness/agents/taskGenerator.ts
@@ -191,8 +191,10 @@ export class TaskGeneratorAgent extends BaseAgent {
 			},
 		});
 
+		// Volatile — kept out of the system prompt so the prefix stays cacheable
+		// (see `AgentInvokeOptions.context`).
 		const scratchPadText = this.state.scratchpad?.length
-			? `\n\n## Context / Scratch Pad from Previous Agents\nHere is information gathered from previous steps:\n${this.state.scratchpad.map((s) => `- ${s}`).join("\n")}`
+			? `## Context / Scratch Pad from Previous Agents\nHere is information gathered from previous steps:\n${this.state.scratchpad.map((s) => `- ${s}`).join("\n")}`
 			: "";
 
 		const systemPrompt = `You are the Expert Task Generator Agent for Fluxify — an Agentic Low Code Backend Development Platform.
@@ -213,8 +215,7 @@ ${SUB_AGENTS_TABLE}
 7. **Resource Identifiers**: The plan may contain \`:resource{type="..." identifier="..."}\` directives. You MUST extract the exact \`identifier\` value from these directives and explicitly include it in the task description for the assigned sub-agent so they know exactly which resource to operate on. Write the plain ID in the description — do NOT copy the directive syntax into task descriptions.
 8. **Consolidate Tasks**: Combine related tasks that are assigned to the SAME sub-agent to minimize redundant graph executions. For example, if the plan involves adding blocks and connecting blocks, combine them into a single comprehensive task for the Block Builder Agent.
 
-If there are no sub-agents available, output an empty task list.
-${scratchPadText}`;
+If there are no sub-agents available, output an empty task list.`;
 
 		// Provide the plan as the query to focus the LLM on breaking it down
 		const planText = this.state.plannerState?.markdownPlan
@@ -224,6 +225,7 @@ ${scratchPadText}`;
 		const response = (await this.state.agentWrapper.invokeAgent({
 			zodSchema: taskSchema,
 			systemPrompt,
+			context: scratchPadText,
 			messages: [], // We only pass the plan to keep it strictly focused
 			userQuery: planText,
 			agentNode: AgentNode.TASK_GENERATOR,

--- a/apps/ai-gateway/src/harness/models/anthropic/index.ts
+++ b/apps/ai-gateway/src/harness/models/anthropic/index.ts
@@ -1,4 +1,5 @@
 import { BaseChatModel } from "@langchain/core/language_models/chat_models";
+import { SystemMessage } from "@langchain/core/messages";
 import { ChatAnthropic } from "@langchain/anthropic";
 import {
 	BaseAgentWrapper,
@@ -20,7 +21,25 @@ export class AnthropicAgentWrapper extends BaseAgentWrapper {
 		this.baseUrl = baseUrl;
 	}
 
-	protected getModel(): BaseChatModel {
+	/**
+	 * Marks the system block as a cache breakpoint, so the tools + system prefix
+	 * ahead of it is written once and read back at ~10% of the input price on
+	 * every later call (each tool-loop iteration re-sends the whole prompt).
+	 *
+	 * The breakpoint deliberately sits on the system block and nowhere else: the
+	 * message list is rewritten by `compactToolHistory` as the loop runs, so a
+	 * breakpoint further down would be a paid cache write that never gets read.
+	 * Prompts under Anthropic's 1024-token minimum simply aren't cached — no error.
+	 */
+	protected buildSystemMessage(text: string): SystemMessage {
+		return new SystemMessage({
+			content: [
+				{ type: "text", text, cache_control: { type: "ephemeral" } },
+			],
+		});
+	}
+
+	protected createModel(): BaseChatModel {
 		return new ChatAnthropic({
 			model: this.modelName,
 			// `apiKey` is the canonical field; `anthropicApiKey` is a legacy alias.

--- a/apps/ai-gateway/src/harness/models/base.spec.ts
+++ b/apps/ai-gateway/src/harness/models/base.spec.ts
@@ -16,6 +16,7 @@ import {
 	flattenToolMessages,
 } from "./toolLoop";
 import { OpenAIAgentWrapper } from "./openai";
+import { AnthropicAgentWrapper } from "./anthropic";
 import { describeFailure } from "../index";
 import { AgentNode } from "../types";
 import { blockBuilderSchema } from "../agents/sub-agents/blockBuilder/schemas";
@@ -24,7 +25,7 @@ const schema = z.object({ blocks: z.array(z.string()) });
 
 /** Exposes the protected fallback path and lets a test supply a canned response. */
 class TestWrapper extends BaseAgentWrapper {
-	protected getModel(): BaseChatModel {
+	protected createModel(): BaseChatModel {
 		throw new Error("not used");
 	}
 
@@ -201,6 +202,105 @@ describe("OpenAIAgentWrapper", () => {
 	});
 });
 
+describe("prompt caching", () => {
+	/** Records every message array sent, and how often the client was built. */
+	class CountingWrapper extends BaseAgentWrapper {
+		built = 0;
+		calls: BaseMessage[][] = [];
+
+		protected createModel(): BaseChatModel {
+			this.built++;
+			return {
+				invoke: async (messages: BaseMessage[]) => {
+					this.calls.push([...messages]);
+					return new AIMessage("ok");
+				},
+			} as unknown as BaseChatModel;
+		}
+
+		run(options: Parameters<BaseAgentWrapper["invokeAgent"]>[0]) {
+			return this.invokeAgent(options);
+		}
+	}
+
+	it("builds the chat client once per wrapper, not once per call", async () => {
+		const wrapper = new CountingWrapper("test-model");
+		await wrapper.run({ systemPrompt: "static", userQuery: "a" });
+		await wrapper.run({ systemPrompt: "static", userQuery: "b" });
+		expect(wrapper.built).toBe(1);
+	});
+
+	it("keeps volatile context out of the system prompt", async () => {
+		const wrapper = new CountingWrapper("test-model");
+		await wrapper.run({
+			systemPrompt: "you are the planner",
+			context: "## Current context\nroute abc",
+			userQuery: "build it",
+		});
+
+		const sent = wrapper.calls[0]!;
+		// The cached prefix: byte-identical whatever the run's context is.
+		expect(sent[0]!.getType()).toBe("system");
+		expect(sent[0]!.content).toBe("you are the planner");
+		// Context rides with the user's turn, ahead of the request itself.
+		expect(sent.at(-1)!.getType()).toBe("human");
+		expect(sent.at(-1)!.content).toBe(
+			"## Current context\nroute abc\n\nbuild it",
+		);
+	});
+
+	it("marks the Anthropic system block as a cache breakpoint", () => {
+		class Probe extends AnthropicAgentWrapper {
+			system(text: string) {
+				return this.buildSystemMessage(text);
+			}
+		}
+		const content = new Probe("claude-sonnet-4-5", "sk-test").system("prompt")
+			.content as Array<Record<string, any>>;
+
+		expect(content).toEqual([
+			{ type: "text", text: "prompt", cache_control: { type: "ephemeral" } },
+		]);
+	});
+
+	it("leaves the cacheable prefix untouched when history is compacted", () => {
+		// #148 flagged compaction and prefix caching as mutually exclusive. They
+		// are not: compaction only ever rewrites near the tail, so everything
+		// ahead of that point stays byte-identical and still hits the cache.
+		const history: BaseMessage[] = [
+			new SystemMessage("static prompt"),
+			new HumanMessage("build it"),
+		];
+		const addToolTurn = (name: string) => {
+			history.push(new AIMessage({ content: "", tool_calls: [] }));
+			history.push(
+				new ToolMessage({
+					tool_call_id: `call_${name}`,
+					name,
+					content: JSON.stringify(Array.from({ length: 30 }, (_, i) => ({ i }))),
+				}),
+			);
+		};
+
+		addToolTurn("a");
+		addToolTurn("b");
+		addToolTurn("c");
+		compactToolHistory(history);
+		const before = history.map((m) => JSON.stringify(m.content));
+
+		addToolTurn("d");
+		compactToolHistory(history);
+		const after = history.map((m) => JSON.stringify(m.content));
+
+		// The first message that changed — everything before it is a cache hit.
+		const diverged = after.findIndex((c, i) => c !== before[i]);
+		expect(diverged).toBeGreaterThan(0);
+		// It is the third-newest tool result, not the system prompt or the query.
+		expect(history.length - diverged).toBeLessThanOrEqual(5);
+		expect(history[0]!.content).toBe("static prompt");
+	});
+});
+
 describe("fallbackStructuredOutput schema conversion", () => {
 	it("produces a real JSON schema for the block builder schema, not an empty one", () => {
 		// zod-to-json-schema (v3) reads zod v3 `_def` internals and silently emits
@@ -274,7 +374,7 @@ describe("submit_result", () => {
 			super("test-model");
 		}
 
-		protected getModel(): BaseChatModel {
+		protected createModel(): BaseChatModel {
 			let i = 0;
 			const model: any = {
 				bindTools: (tools: StructuredTool[]) => {
@@ -357,7 +457,7 @@ describe("parallel tool calls", () => {
 			super("test-model");
 		}
 
-		protected getModel(): BaseChatModel {
+		protected createModel(): BaseChatModel {
 			let i = 0;
 			const model: any = {
 				bindTools: () => model,

--- a/apps/ai-gateway/src/harness/models/base.ts
+++ b/apps/ai-gateway/src/harness/models/base.ts
@@ -56,6 +56,12 @@ export interface AgentInvokeOptions {
 	zodSchema?: z.ZodType<any>;
 	userQuery?: string;
 	systemPrompt?: string;
+	/** Per-run volatile context (scratchpad notes, the "Current context" block).
+	 *  It belongs here rather than concatenated onto `systemPrompt`: a system
+	 *  prompt that changes per run can never be a cached prefix, and providers
+	 *  cache by byte-identical prefix. Sent as part of the trailing human turn,
+	 *  ahead of `userQuery`. */
+	context?: string;
 	messages?: BaseMessage[];
 	tools?: StructuredTool[];
 	config?: RunnableConfig;
@@ -174,7 +180,24 @@ export abstract class BaseAgentWrapper {
 	}
 
 	// Each subclass implements this to return the initialized LangChain chat model
-	protected abstract getModel(): BaseChatModel;
+	protected abstract createModel(): BaseChatModel;
+
+	/** The model is immutable for the life of a wrapper (one wrapper per run), yet
+	 *  every invokeAgent used to construct a fresh SDK client — and throw away its
+	 *  connection pool with it. Built once, on first use. */
+	protected getModel(): BaseChatModel {
+		this.model ??= this.createModel();
+		return this.model;
+	}
+	private model?: BaseChatModel;
+
+	/**
+	 * Wraps the system prompt in a provider-native message. Anthropic overrides
+	 * this to attach a cache breakpoint; everyone else gets a plain string.
+	 */
+	protected buildSystemMessage(text: string): SystemMessage {
+		return new SystemMessage(text);
+	}
 
 	/**
 	 * Lightweight liveness probe — a tiny completion to confirm the provider,
@@ -232,6 +255,7 @@ export abstract class BaseAgentWrapper {
 			zodSchema,
 			userQuery,
 			systemPrompt,
+			context,
 			messages = [],
 			tools,
 			config,
@@ -250,7 +274,7 @@ export abstract class BaseAgentWrapper {
 
 		if (systemPrompt && !finalMessages.some((m) => m.type === "system")) {
 			finalMessages.unshift(
-				new SystemMessage(
+				this.buildSystemMessage(
 					submitTool
 						? `${systemPrompt}\n\n${SUBMIT_RESULT_INSTRUCTION}`
 						: systemPrompt,
@@ -258,8 +282,14 @@ export abstract class BaseAgentWrapper {
 			);
 		}
 
-		if (userQuery) {
-			finalMessages.push(new HumanMessage(userQuery));
+		// Volatile context rides with the user's turn, not the system prompt, so
+		// the prefix ahead of it stays byte-identical across runs and can be
+		// served from the provider's cache. Being last is also where a model
+		// reads it most reliably.
+		if (userQuery || context) {
+			finalMessages.push(
+				new HumanMessage([context, userQuery].filter(Boolean).join("\n\n")),
+			);
 		}
 
 		let model = this.getModel();

--- a/apps/ai-gateway/src/harness/models/google/index.ts
+++ b/apps/ai-gateway/src/harness/models/google/index.ts
@@ -7,7 +7,7 @@ import {
 } from "../base";
 
 export class GoogleAgentWrapper extends BaseAgentWrapper {
-	protected getModel(): BaseChatModel {
+	protected createModel(): BaseChatModel {
 		return new ChatGoogle({
 			model: this.modelName,
 			apiKey: this.apiKey,

--- a/apps/ai-gateway/src/harness/models/mistral/index.ts
+++ b/apps/ai-gateway/src/harness/models/mistral/index.ts
@@ -7,7 +7,7 @@ import {
 } from "../base";
 
 export class MistralAgentWrapper extends BaseAgentWrapper {
-	protected getModel(): BaseChatModel {
+	protected createModel(): BaseChatModel {
 		return new ChatMistralAI({
 			model: this.modelName,
 			apiKey: this.apiKey,

--- a/apps/ai-gateway/src/harness/models/ollama/index.ts
+++ b/apps/ai-gateway/src/harness/models/ollama/index.ts
@@ -19,7 +19,7 @@ export class OllamaAgentWrapper extends BaseAgentWrapper {
 		this.baseUrl = baseUrl;
 	}
 
-	protected getModel(): BaseChatModel {
+	protected createModel(): BaseChatModel {
 		return new ChatOllama({
 			model: this.modelName,
 			baseUrl: this.baseUrl,

--- a/apps/ai-gateway/src/harness/models/openai/index.ts
+++ b/apps/ai-gateway/src/harness/models/openai/index.ts
@@ -23,7 +23,7 @@ export class OpenAIAgentWrapper extends BaseAgentWrapper {
 		this.baseUrl = baseUrl;
 	}
 
-	protected getModel(): BaseChatModel {
+	protected createModel(): BaseChatModel {
 		return new ChatOpenAI({
 			model: this.modelName,
 			// Reasoning models take `maxCompletionTokens` (the cap covers reasoning

--- a/apps/ai-gateway/src/harness/models/openrouter/index.ts
+++ b/apps/ai-gateway/src/harness/models/openrouter/index.ts
@@ -7,7 +7,7 @@ import {
 } from "../base";
 
 export class OpenRouterAgentWrapper extends BaseAgentWrapper {
-	protected getModel(): BaseChatModel {
+	protected createModel(): BaseChatModel {
 		return new ChatOpenRouter({
 			model: this.modelName,
 			apiKey: this.apiKey,


### PR DESCRIPTION
Closes #148 · part of #139

## Nothing was cacheable, because every prompt ended in per-run text

Providers serve a repeated prefix from cache only when it is **byte-identical**. Every agent broke that on the last line of its system prompt:

```ts
...output excellent English craft for the user's plan.${scratchPadText}${contextBlock ? `\n\n${contextBlock}` : ""}`;
```

So the block catalog, the sub-agent table, the schema examples — thousands of static tokens — were paid for in full on every call, and inside a tool loop on every iteration.

## 1. Volatile text moves to the trailing human turn

New `AgentInvokeOptions.context`. `base.ts` appends it to the same human turn as `userQuery`, ahead of the query, so the prefix in front of it never changes and the model still reads the context last (where it reads it most reliably). No prompt wording was rewritten — the blocks are the same strings, in a different position.

Applied to the six agents that had it inline: router, planner, task generator, discussion, route config, block builder. Their system prompts are now identical from run to run.

## 2. Anthropic marks the system block

```ts
new SystemMessage({ content: [{ type: "text", text, cache_control: { type: "ephemeral" } }] })
```

Anthropic orders the request tools → system → messages, so one breakpoint there caches the tool schemas as well, read back at ~10% of input price. Verified `cache_control` passthrough on content blocks in `@langchain/anthropic` 1.5 rather than assuming it.

The breakpoint sits there **and nowhere else** deliberately: `compactToolHistory` rewrites the message list as the loop runs, so a breakpoint further down would be a paid cache write that never gets read.

## 3. One client per run, not one per call

`getModel()` used to run `new ChatOpenAI({...})` on every `invokeAgent`, discarding its connection pool each time. Wrappers now implement `createModel()`; `getModel()` memoizes. The wrapper is already constructed once per run, and the model is immutable — `bindTools`/`withStructuredOutput`/`bind` all return new runnables.

## On the compaction conflict

The issue expects compaction and prefix caching to cancel out and suggests rewriting compaction into batches. They don't cancel out, so I didn't. Compaction condenses the *third-most-recent* tool result and marks it, so on any given call the only byte that changes near the front is... nothing: the rewrite is always near the tail, and everything ahead of it is byte-identical to the previous call. That prefix is exactly what gets served from cache. A test pins it:

> `leaves the cacheable prefix untouched when history is compacted` — grows a tool history across two compaction passes and asserts the first divergent message is within the last few, with the system prompt untouched.

## Verification

`bun test src/harness` 79 pass · `apps/ai-gateway` 136 pass · pre-commit 439 pass · `tsgo --noEmit` clean.

New tests: client built once across two calls; context lands in the human turn with the system prompt left alone; the Anthropic system block carries exactly one ephemeral breakpoint; compaction/prefix coexistence.

Live-probed the new message shape end to end against a real provider (Mistral, tool loop + structured output): the model picked the route id out of the context block in the human turn, so nothing was lost by moving it out of the system prompt.

## Not done

The deterministic single-change summary the issue suggests under "Also". Required user actions reach the summarizer only as free-text scratchpad hints, so a template can't tell "connect your tasks database first" apart from "routeId=abc" — and the scratchpad is almost never empty, which is the only condition under which skipping the call is safe today. It needs a structured required-actions channel from the build agents first; that fits better alongside #150.

Cache-hit token counts in the usage log are left to #149, as the issue notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
