### PR TITLE
feat(harness): per-run deadline, token budget and usage telemetry

### DIFF
--- a/apps/ai-gateway/src/api/v1/harness-conversations/list-messages/dto.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/list-messages/dto.ts
@@ -20,6 +20,10 @@ export const messageSchema = z.object({
 	aiResponse: z.string().nullable(),
 	status: z.string(),
 	artifactId: z.string().nullable(),
+	/** Model calls, tokens (prompt/completion/cached) and time this run spent,
+	 *  with a per-agent breakdown. Null for runs that predate usage tracking or
+	 *  never reached a terminal state. */
+	usage: z.record(z.string(), z.any()).nullable(),
 	createdAt: z.union([z.string(), z.date()]),
 	completedAt: z.union([z.string(), z.date()]).nullable(),
 });

--- a/apps/ai-gateway/src/api/v1/harness-conversations/list-messages/repository.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/list-messages/repository.ts
@@ -28,6 +28,7 @@ export async function getMessagesPage(
 			status: agentHarnessRunsEntity.status,
 			createdAt: agentHarnessRunsEntity.createdAt,
 			completedAt: agentHarnessRunsEntity.completedAt,
+			usage: agentHarnessRunsEntity.usage,
 			artifactId: agentHarnessArtifactsEntity.id,
 		})
 		.from(agentHarnessRunsEntity)

--- a/apps/ai-gateway/src/api/v1/harness-conversations/send-message/rateLimit.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/send-message/rateLimit.ts
@@ -1,0 +1,45 @@
+import { HttpError, incrCache, expireCache } from "@fluxify/server";
+import { logger } from "@fluxify/common";
+
+/** Runs one user may start per window. 0 disables the limit. */
+const RUNS_PER_WINDOW = Number(process.env.HARNESS_RUNS_PER_HOUR ?? 30);
+const WINDOW_SECONDS = 3600;
+
+/**
+ * Caps how many harness runs one user can start per hour.
+ *
+ * The provider key belongs to the project, so without this any user with
+ * project access can drain its quota — one conversation at a time, but any
+ * number of conversations at once (`isConversationLocked` is per conversation).
+ *
+ * ponytail: fixed window, so a user can burst 2x the limit across a window
+ * boundary. Move to a sliding window only if that turns out to matter — the
+ * per-run deadline and token budget bound the damage either way.
+ */
+export async function assertRunQuota(userId: string): Promise<void> {
+	if (RUNS_PER_WINDOW <= 0) return;
+
+	const window = Math.floor(Date.now() / (WINDOW_SECONDS * 1000));
+	const key = `harness:runquota:${userId}:${window}`;
+
+	let count: number;
+	try {
+		count = await incrCache(key);
+		if (count === 1) await expireCache(key, WINDOW_SECONDS);
+	} catch (error) {
+		// Fail open: a Redis blip must not stop people from using the product.
+		// The run itself is still bounded by its deadline and token budget.
+		logger.error("[HarnessRateLimit] Quota check failed, allowing request", {
+			userId,
+			error,
+		});
+		return;
+	}
+
+	if (count > RUNS_PER_WINDOW) {
+		throw new HttpError(
+			429,
+			`You have started ${RUNS_PER_WINDOW} AI requests in the last hour, which is the limit. Please try again later.`,
+		);
+	}
+}

--- a/apps/ai-gateway/src/api/v1/harness-conversations/send-message/service.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/send-message/service.ts
@@ -8,6 +8,7 @@ import { enqueueHarnessStart } from "../../../../harness/internal/enqueue";
 import { getConversationById, getProjectIntegration } from "../repository";
 import { isConversationLocked } from "../status";
 import { bumpListCacheVersion } from "../cacheVersion";
+import { assertRunQuota } from "./rateLimit";
 import type { SendMessageBody } from "./dto";
 
 /**
@@ -43,6 +44,10 @@ export default async function handleRequest(
 	body: SendMessageBody,
 	isSystemAdmin: boolean,
 ) {
+	// Before any of the checks below: they are all about *this* request being
+	// well-formed, and the quota is about how many the user has already sent.
+	await assertRunQuota(userId);
+
 	if (body.conversationId) {
 		const conversation = await getConversationById(body.conversationId);
 		if (!conversation || conversation.projectId !== projectId) {

--- a/apps/ai-gateway/src/api/v1/harness-conversations/send-message/tests/rateLimit.spec.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/send-message/tests/rateLimit.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, spyOn, mock, afterEach } from "bun:test";
+import * as serverModule from "@fluxify/server";
+import { assertRunQuota } from "../rateLimit";
+
+describe("Harness run quota", () => {
+	afterEach(() => {
+		mock.restore();
+	});
+
+	it("allows a request while the user is under the limit", async () => {
+		spyOn(serverModule, "incrCache").mockResolvedValue(1);
+		const expireSpy = spyOn(serverModule, "expireCache").mockResolvedValue(1);
+
+		await assertRunQuota("user1");
+
+		// The window only gets a TTL on the first hit — otherwise the counter is
+		// pushed out on every request and never resets.
+		expect(expireSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not re-arm the TTL on later hits in the same window", async () => {
+		spyOn(serverModule, "incrCache").mockResolvedValue(7);
+		const expireSpy = spyOn(serverModule, "expireCache").mockResolvedValue(1);
+
+		await assertRunQuota("user1");
+
+		expect(expireSpy).not.toHaveBeenCalled();
+	});
+
+	it("rejects with 429 once the user is over the limit", async () => {
+		spyOn(serverModule, "incrCache").mockResolvedValue(31);
+		spyOn(serverModule, "expireCache").mockResolvedValue(1);
+
+		const error = await assertRunQuota("user1").catch((e) => e);
+		expect(error).toBeInstanceOf(serverModule.HttpError);
+		expect(error.httpCode).toBe(429);
+	});
+
+	it("fails open when Redis is unreachable", async () => {
+		// A cache outage must not stop people using the product; the run's own
+		// deadline and token budget still bound what one request can spend.
+		spyOn(serverModule, "incrCache").mockRejectedValue(new Error("no redis"));
+
+		expect(assertRunQuota("user1")).resolves.toBeUndefined();
+	});
+});

--- a/apps/ai-gateway/src/api/v1/harness-conversations/send-message/tests/send-message.spec.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/send-message/tests/send-message.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, spyOn, mock, afterEach } from "bun:test";
+import { describe, it, expect, spyOn, mock, afterEach, beforeEach } from "bun:test";
 import handleRequest from "../service";
 import * as repository from "../../repository";
 import * as enqueueModule from "../../../../../harness/internal/enqueue";
@@ -6,6 +6,14 @@ import * as cacheVersionModule from "../../cacheVersion";
 import * as serverModule from "@fluxify/server";
 
 describe("Send Message Service", () => {
+	beforeEach(() => {
+		// The run quota talks to Redis, which isn't up in unit tests. It fails open
+		// either way; stubbing it keeps that out of these assertions (and out of
+		// the log). Its own behavior is covered in rateLimit.spec.ts.
+		spyOn(serverModule, "incrCache").mockResolvedValue(1);
+		spyOn(serverModule, "expireCache").mockResolvedValue(1);
+	});
+
 	afterEach(() => {
 		mock.restore();
 	});

--- a/apps/ai-gateway/src/harness/errors.ts
+++ b/apps/ai-gateway/src/harness/errors.ts
@@ -1,3 +1,6 @@
+import { labelForNode } from "./streamTypes";
+import type { AgentNodeName } from "./types";
+
 /**
  * Thrown when a user interrupts a running harness graph. Propagates out of the
  * AI model layer (via the run's AbortSignal), is NOT retried by the retry
@@ -18,6 +21,28 @@ export function isUserInterrupt(error: unknown): boolean {
 }
 
 /**
+ * Best-effort message for anything thrown. Provider SDKs sometimes reject with
+ * plain objects (`{ code: 23, ... }`) whose `String()` is "[object Object]".
+ */
+export function errorMessage(error: unknown): string {
+	if (error instanceof Error) return error.message || error.name;
+	if (typeof error === "string") return error;
+	if (error && typeof error === "object") {
+		const e = error as Record<string, any>;
+		const parts = [e.message, e.error?.message, e.code, e.name].filter(
+			(p) => typeof p === "string" && p.length > 0,
+		);
+		if (parts.length > 0) return parts.join(" ");
+		try {
+			return JSON.stringify(error).slice(0, 500);
+		} catch {
+			return "Unknown error";
+		}
+	}
+	return String(error ?? "Unknown error");
+}
+
+/**
  * Turns a raw error message into a human-readable explanation, shared by the
  * terminal failure report (`describeFailure`) and the live retry-warning
  * events (`HarnessCallbacks.emitRetryWarning`) — both need the same
@@ -25,6 +50,13 @@ export function isUserInterrupt(error: unknown): boolean {
  */
 export function explainErrorReason(raw: string): string {
 	const lower = raw.toLowerCase();
+
+	// First: the harness stopped this run itself, so none of the provider-shaped
+	// diagnoses below apply (the message names both tokens and a time limit and
+	// would otherwise match two of them).
+	if (lower.includes("run budget exceeded")) {
+		return "it ran past the limit set for a single request (wall-clock time or total tokens). This usually means an agent got stuck repeating itself, or the request was too large to finish in one go — try splitting it into smaller steps.";
+	}
 
 	// Order matters: the two cases below both mention JSON, but they call for
 	// completely different action, so they must be matched before the generic
@@ -81,4 +113,17 @@ export function explainErrorReason(raw: string): string {
 		return "the AI provider took too long to respond or could not be reached. This request involved a lot of back-and-forth with the model — try again, or use a faster model.";
 	}
 	return "an unexpected error occurred while processing this request.";
+}
+
+/**
+ * Turns a thrown error into a short, user-readable explanation of why the run
+ * failed. Persisted as the run's `aiResponse` so the UI shows something more
+ * useful than a bare `failed` status.
+ */
+export function describeFailure(error: unknown, node?: AgentNodeName): string {
+	const raw = errorMessage(error);
+	const where = labelForNode(node);
+	const reason = explainErrorReason(raw);
+
+	return `This request could not be completed — it failed at the **${where}** step because ${reason}\n\nDetails: ${raw.slice(0, 500)}`;
 }

--- a/apps/ai-gateway/src/harness/index.ts
+++ b/apps/ai-gateway/src/harness/index.ts
@@ -15,10 +15,12 @@ import {
 	type CustomEventName,
 } from "./types";
 import { BaseAgentWrapper, type AgentInvokeOptions } from "./models/base";
+import { RunBudget, logRunUsage } from "./models/budget";
 import { app as graphApp } from "./graph";
 import { DbService } from "./internal/dbService";
 import { buildContextBlock } from "./internal/contextBlock";
 import {
+	describeHitlAction,
 	extractWorkingMemory,
 	HarnessService,
 	HitlPlanAction,
@@ -28,6 +30,12 @@ import {
 } from "./internal/harnessService";
 import { RedisService } from "./internal/redisService";
 import { FluxifyOtelTracer } from "./telemetry/otel-tracer";
+import {
+	startRunSpan,
+	withRunSpan,
+	recordRetryOnRunSpan,
+	endRunSpan,
+} from "./telemetry/runSpan";
 import { HarnessCallbacks } from "./callbacks";
 import {
 	RUN_NODE,
@@ -39,70 +47,13 @@ import {
 	type HarnessStreamEvent,
 } from "./streamTypes";
 import { publishHarnessEvent } from "./notifications";
-import { isUserInterrupt, explainErrorReason } from "./errors";
+import { isUserInterrupt, describeFailure } from "./errors";
 import {
 	registerRunController,
 	unregisterRunController,
 	requestInterrupt,
 } from "./interrupt";
 import type { HarnessJobData, HarnessJobMetadata } from "./queue";
-
-/**
- * Best-effort message for anything thrown. Provider SDKs sometimes reject with
- * plain objects (`{ code: 23, ... }`) whose `String()` is "[object Object]".
- */
-function errorMessage(error: unknown): string {
-	if (error instanceof Error) return error.message || error.name;
-	if (typeof error === "string") return error;
-	if (error && typeof error === "object") {
-		const e = error as Record<string, any>;
-		const parts = [e.message, e.error?.message, e.code, e.name].filter(
-			(p) => typeof p === "string" && p.length > 0,
-		);
-		if (parts.length > 0) return parts.join(" ");
-		try {
-			return JSON.stringify(error).slice(0, 500);
-		} catch {
-			return "Unknown error";
-		}
-	}
-	return String(error ?? "Unknown error");
-}
-
-/**
- * Turns a thrown error into a short, user-readable explanation of why the run
- * failed. Persisted as the run's `aiResponse` so the UI shows something more
- * useful than a bare `failed` status.
- */
-export function describeFailure(error: unknown, node?: AgentNodeName): string {
-	const raw = errorMessage(error);
-	const where = labelForNode(node);
-	const reason = explainErrorReason(raw);
-
-	return `This request could not be completed — it failed at the **${where}** step because ${reason}\n\nDetails: ${raw.slice(0, 500)}`;
-}
-
-/** Turns a HITL decision into the human turn the router/planner actually read
- *  ("check message history" per the planner prompt) — `state.action` itself is
- *  never inspected by any graph node, so this is the only path review
- *  comments have into the model. */
-function describeHitlAction(action: HitlPlanAction): string | undefined {
-	switch (action.type) {
-		case "approve":
-			return "I approve this plan. Proceed with implementation.";
-		case "reject":
-			return `I reject this plan.${action.message ? ` Reason: ${action.message}` : ""}`;
-		case "review": {
-			if (!action.comments?.length) return undefined;
-			const comments = action.comments.map((c) =>
-				typeof c === "string" ? c : c.text,
-			);
-			return `Please revise the plan based on my feedback:\n${comments.map((c) => `- ${c}`).join("\n")}`;
-		}
-		default:
-			return undefined;
-	}
-}
 
 /** Everything a single harness run needs — supplied by the worker from job data. */
 export interface HarnessRunContext {
@@ -289,12 +240,26 @@ export class FluxifyHarness {
 		// aborting it raises UserInterruptError out of the graph (caught below).
 		const abortController = new AbortController();
 		state.agentWrapper?.setAbortSignal(abortController.signal);
+		// Per-run deadline + token ceiling, and the run's usage accounting. The
+		// clock starts here, so provider-probe and queue time are excluded.
+		const budget = new RunBudget();
+		state.agentWrapper?.setRunBudget(budget);
+		// Covers the whole run — the tracer's own spans all end mid-stream, so the
+		// run's cost and outcome have nowhere else to live.
+		const runSpan = startRunSpan({
+			runId: ctx.runId,
+			conversationId: ctx.conversationId,
+			projectId: ctx.metadata?.projectId,
+			userQuery: ctx.query,
+		});
 		// Surfaces retryable model errors (bad structured output, transient
 		// network issues) as live "warning" events instead of only finding out
 		// when the run eventually finishes or fails.
-		state.agentWrapper?.setRetryWarningSink((info) =>
-			callbacks.emitRetryWarning(info),
-		);
+		state.agentWrapper?.setRetryWarningSink((info) => {
+			budget.recordRetry(info.agentNode);
+			recordRetryOnRunSpan(runSpan, info);
+			callbacks.emitRetryWarning(info);
+		});
 		registerRunController(ctx.conversationId, abortController);
 
 		// Attach the OTEL tracer as a run callback (app.invoke used to pass this;
@@ -311,6 +276,10 @@ export class FluxifyHarness {
 		let finalState: Partial<GlobalGraphState> | undefined;
 		// Last node the graph entered — the one to blame if the run throws.
 		let lastNode: AgentNodeName | undefined;
+		// How the run ended, for the trace. Set on every exit path below.
+		let outcome: { status: HarnessRunStatus; error?: unknown } = {
+			status: "completed",
+		};
 
 		try {
 			await harnessService.updateRun(
@@ -339,45 +308,23 @@ export class FluxifyHarness {
 				);
 			}
 
-			await withFluxifyContext(
-				{
-					userQuery: state.userQuery,
-					action: state.action ? JSON.stringify(state.action) : undefined,
-				},
-				async () => {
-					const events = (await this.graph.streamEvents(
-						state,
-						streamConfig,
-					)) as any;
-
-					for await (const event of events) {
-						if (event.event === "on_custom_event") {
-							await callbacks.onCustomEvent(
-								event.name as CustomEventName,
-								event.data,
-							);
-						} else if (
-							event.event === "on_chain_start" &&
-							event.name !== "LangGraph"
-						) {
-							lastNode = event.name as AgentNodeName;
-							await callbacks.onBefore(event.name as AgentNodeName, event.data);
-						} else if (event.event === "on_chain_end") {
-							if (event.name === "LangGraph") {
-								finalState = event.data.output as Partial<GlobalGraphState>;
-							} else {
-								await callbacks.onAfter(
-									event.name as AgentNodeName,
-									event.data,
-								);
-							}
-						}
-					}
-				},
+			// The run span wraps the context, not the other way round: everything
+			// the graph traces from here on nests under this one run.
+			finalState = await withRunSpan(runSpan, () =>
+				withFluxifyContext(
+					{
+						userQuery: state.userQuery,
+						action: state.action ? JSON.stringify(state.action) : undefined,
+					},
+					() =>
+						this.streamGraph(state, streamConfig, callbacks, (node) => {
+							lastNode = node;
+						}),
+				),
 			);
 
 			await callbacks.flush();
-			await this.finalizeRun(ctx, harnessService, userId, finalState);
+			await this.finalizeRun(ctx, harnessService, userId, budget, finalState);
 		} catch (error) {
 			await callbacks.flush().catch(() => {});
 
@@ -387,14 +334,16 @@ export class FluxifyHarness {
 			// actually fired — provider-side timeouts abort too, and those are
 			// failures, not user stops.
 			if (isUserInterrupt(error) && abortController.signal.aborted) {
+				outcome = { status: "interrupted" };
 				logger.info("[FluxifyHarness] Run interrupted by user", {
 					conversationId: ctx.conversationId,
 					runId: ctx.runId,
 				});
-				await this.interruptRun(ctx, harnessService, userId);
+				await this.interruptRun(ctx, harnessService, userId, budget);
 				return undefined;
 			}
 
+			outcome = { status: "failed", error };
 			logger.error("[FluxifyHarness] Graph execution failed", {
 				conversationId: ctx.conversationId,
 				runId: ctx.runId,
@@ -409,11 +358,56 @@ export class FluxifyHarness {
 				error,
 				describeFailure(error, lastNode),
 				lastNode,
+				budget,
 			);
 			throw error;
 		} finally {
 			unregisterRunController(ctx.conversationId);
+			endRunSpan(runSpan, {
+				usage: budget.snapshot(),
+				status: outcome.status,
+				error: outcome.error,
+				failedNode: outcome.error ? lastNode : undefined,
+			});
 			await harnessService.awaitAllPendingBackgroundTasks();
+		}
+
+		return finalState;
+	}
+
+	/**
+	 * Drives the graph and hands every event to the run's callbacks. Returns the
+	 * final graph state; `onNodeEnter` reports each node as it is entered, which
+	 * is how the caller knows who to blame if the run throws.
+	 */
+	private async streamGraph(
+		state: Partial<GlobalGraphState>,
+		streamConfig: any,
+		callbacks: HarnessCallbacks,
+		onNodeEnter: (node: AgentNodeName) => void,
+	): Promise<Partial<GlobalGraphState> | undefined> {
+		let finalState: Partial<GlobalGraphState> | undefined;
+		const events = (await this.graph.streamEvents(state, streamConfig)) as any;
+
+		for await (const event of events) {
+			if (event.event === "on_custom_event") {
+				await callbacks.onCustomEvent(
+					event.name as CustomEventName,
+					event.data,
+				);
+			} else if (
+				event.event === "on_chain_start" &&
+				event.name !== "LangGraph"
+			) {
+				onNodeEnter(event.name as AgentNodeName);
+				await callbacks.onBefore(event.name as AgentNodeName, event.data);
+			} else if (event.event === "on_chain_end") {
+				if (event.name === "LangGraph") {
+					finalState = event.data.output as Partial<GlobalGraphState>;
+				} else {
+					await callbacks.onAfter(event.name as AgentNodeName, event.data);
+				}
+			}
 		}
 
 		return finalState;
@@ -429,8 +423,10 @@ export class FluxifyHarness {
 		ctx: HarnessRunContext,
 		harnessService: HarnessService,
 		userId: string | null,
+		budget: RunBudget,
 		finalState?: Partial<GlobalGraphState>,
 	) {
+		const usage = logRunUsage(ctx, budget);
 		const reachedHITL =
 			finalState?.currentAgent === AgentNode.HUMAN_IN_THE_LOOP;
 
@@ -441,6 +437,7 @@ export class FluxifyHarness {
 				status: "awaiting_hitl",
 				aiResponse: markdownPlan,
 				interruptedAt: new Date(),
+				usage,
 			});
 			await harnessService.saveLiveState({
 				runId: ctx.runId,
@@ -455,7 +452,7 @@ export class FluxifyHarness {
 				"awaiting_hitl",
 				"ended",
 				"Paused — the plan is waiting for your review",
-				{ result: markdownPlan },
+				{ result: markdownPlan, usage },
 			);
 			// HITL is terminal for this run pass — evict its live-state snapshot soon.
 			await this.redisService.finalizeSnapshot(ctx.runId);
@@ -492,6 +489,7 @@ export class FluxifyHarness {
 			status,
 			aiResponse: aiResponse ?? undefined,
 			completedAt: new Date(),
+			usage,
 		});
 		await harnessService.saveLiveState({
 			runId: ctx.runId,
@@ -503,6 +501,7 @@ export class FluxifyHarness {
 		await this.redisService.clearActiveRun(ctx.conversationId);
 		await this.emitRunEvent(ctx, userId, status, "ended", message, {
 			result: aiResponse ?? undefined,
+			usage,
 			artifactId: finalState?.summarizerState?.artifactId,
 			error:
 				failedTasks.length > 0
@@ -535,14 +534,17 @@ export class FluxifyHarness {
 		error?: unknown,
 		aiResponse?: string,
 		node?: AgentNodeName,
+		budget?: RunBudget,
 	) {
 		const message =
 			error instanceof Error ? error.message : error ? String(error) : "failed";
+		const usage = budget && logRunUsage(ctx, budget);
 		try {
 			await harnessService.updateRun({
 				runId: ctx.runId,
 				status: "failed",
 				aiResponse,
+				usage,
 			});
 			await harnessService.saveLiveState({
 				runId: ctx.runId,
@@ -558,7 +560,7 @@ export class FluxifyHarness {
 				"failed",
 				"ended",
 				`Failed at the ${labelForNode(node)}`,
-				{ result: aiResponse, error: message },
+				{ result: aiResponse, error: message, usage: usage || undefined },
 			);
 			await this.redisService.finalizeSnapshot(ctx.runId);
 		} catch (e) {
@@ -584,15 +586,18 @@ export class FluxifyHarness {
 		ctx: HarnessRunContext,
 		harnessService: HarnessService,
 		userId: string | null,
+		budget: RunBudget,
 	) {
 		const message =
 			"Conversation was interrupted by the user before it finished.";
+		const usage = logRunUsage(ctx, budget);
 		try {
 			await harnessService.updateRun({
 				runId: ctx.runId,
 				status: "interrupted",
 				aiResponse: message,
 				interruptedAt: new Date(),
+				usage,
 			});
 			await harnessService.saveLiveState({
 				runId: ctx.runId,
@@ -604,6 +609,7 @@ export class FluxifyHarness {
 			await this.redisService.clearActiveRun(ctx.conversationId);
 			await this.emitRunEvent(ctx, userId, "interrupted", "ended", message, {
 				result: message,
+				usage,
 			});
 			await this.redisService.finalizeSnapshot(ctx.runId);
 		} catch (e) {
@@ -656,6 +662,8 @@ export class FluxifyHarness {
 }
 
 export {
+	// Re-exported from ./errors, where it lives with the categorization it uses.
+	describeFailure,
 	AgentFactory,
 	type AgentFactoryOptions,
 	type AgentProvider,

--- a/apps/ai-gateway/src/harness/internal/harnessService.ts
+++ b/apps/ai-gateway/src/harness/internal/harnessService.ts
@@ -19,6 +19,28 @@ export type HitlPlanAction =
 	| { type: "reject"; message: string }
 	| { type: "review"; comments: Array<{ text: string; sectionId?: string; [key: string]: any }> | string[] };
 
+/** Turns a HITL decision into the human turn the router/planner actually read
+ *  ("check message history" per the planner prompt) — `state.action` itself is
+ *  never inspected by any graph node, so this is the only path review
+ *  comments have into the model. */
+export function describeHitlAction(action: HitlPlanAction): string | undefined {
+	switch (action.type) {
+		case "approve":
+			return "I approve this plan. Proceed with implementation.";
+		case "reject":
+			return `I reject this plan.${action.message ? ` Reason: ${action.message}` : ""}`;
+		case "review": {
+			if (!action.comments?.length) return undefined;
+			const comments = action.comments.map((c) =>
+				typeof c === "string" ? c : c.text,
+			);
+			return `Please revise the plan based on my feedback:\n${comments.map((c) => `- ${c}`).join("\n")}`;
+		}
+		default:
+			return undefined;
+	}
+}
+
 export interface RecordHitlActionInput {
 	runId: string;
 	stepId?: string;
@@ -63,6 +85,9 @@ export interface UpdateRunInput {
 		| "failed";
 	interruptedAt?: Date | null;
 	completedAt?: Date | null;
+	/** Final model spend for the run (calls, tokens, time, per-agent breakdown).
+	 *  Written once, on the terminal update. */
+	usage?: Record<string, any>;
 	background?: boolean;
 }
 
@@ -412,6 +437,7 @@ export class HarnessService {
 				if (input.status !== undefined) updateData.status = input.status;
 				if (input.interruptedAt !== undefined) updateData.interruptedAt = input.interruptedAt;
 				if (input.completedAt !== undefined) updateData.completedAt = input.completedAt;
+				if (input.usage !== undefined) updateData.usage = input.usage;
 
 				const [updated] = await db
 					.update(agentHarnessRunsEntity)

--- a/apps/ai-gateway/src/harness/models/base.spec.ts
+++ b/apps/ai-gateway/src/harness/models/base.spec.ts
@@ -17,6 +17,8 @@ import {
 } from "./toolLoop";
 import { OpenAIAgentWrapper } from "./openai";
 import { AnthropicAgentWrapper } from "./anthropic";
+import { RunBudget, RunBudgetExceededError } from "./budget";
+import { withRetry } from "../../lib/retry";
 import { describeFailure } from "../index";
 import { AgentNode } from "../types";
 import { blockBuilderSchema } from "../agents/sub-agents/blockBuilder/schemas";
@@ -298,6 +300,87 @@ describe("prompt caching", () => {
 		// It is the third-newest tool result, not the system prompt or the query.
 		expect(history.length - diverged).toBeLessThanOrEqual(5);
 		expect(history[0]!.content).toBe("static prompt");
+	});
+});
+
+describe("run budget", () => {
+	/** Answers with a fixed token cost, and counts how often it was asked. */
+	class BudgetedWrapper extends BaseAgentWrapper {
+		calls = 0;
+
+		protected createModel(): BaseChatModel {
+			return {
+				invoke: async () => {
+					this.calls++;
+					return new AIMessage({
+						content: "ok",
+						usage_metadata: {
+							input_tokens: 300,
+							output_tokens: 20,
+							total_tokens: 320,
+							input_token_details: { cache_read: 200 },
+						},
+					});
+				},
+			} as unknown as BaseChatModel;
+		}
+
+		run(options: Parameters<BaseAgentWrapper["invokeAgent"]>[0]) {
+			return this.invokeAgent(options);
+		}
+	}
+
+	it("books every model call against the run's usage", async () => {
+		const wrapper = new BudgetedWrapper("test-model");
+		const budget = new RunBudget({ deadlineMs: 60_000, tokenBudget: 0 });
+		wrapper.setRunBudget(budget);
+
+		await wrapper.run({ systemPrompt: "s", userQuery: "a", agentNode: "planner" });
+
+		const usage = budget.snapshot();
+		expect(usage.calls).toBe(1);
+		expect(usage.totalTokens).toBe(320);
+		expect(usage.cachedInputTokens).toBe(200);
+		expect(usage.byAgent.planner!.calls).toBe(1);
+	});
+
+	it("refuses to spend past the ceiling instead of failing mid-call", async () => {
+		const wrapper = new BudgetedWrapper("test-model");
+		const budget = new RunBudget({ deadlineMs: 60_000, tokenBudget: 300 });
+		wrapper.setRunBudget(budget);
+
+		await wrapper.run({ userQuery: "a", agentNode: "planner" });
+		// The first call spent 320 of a 300-token budget, so the second is never
+		// made — the provider isn't billed for work the run can no longer use.
+		await expect(
+			wrapper.run({ userQuery: "b", agentNode: "planner" }),
+		).rejects.toThrow(RunBudgetExceededError);
+		expect(wrapper.calls).toBe(1);
+	});
+
+	it("is not retried — a blown budget only gets more blown", async () => {
+		// withRetry would otherwise re-issue the call three more times.
+		let attempts = 0;
+		await expect(
+			withRetry(
+				async () => {
+					attempts++;
+					throw new RunBudgetExceededError("Run budget exceeded: out of time.");
+				},
+				{ maxRetries: 3, baseDelayMs: 1 },
+			),
+		).rejects.toThrow(RunBudgetExceededError);
+		expect(attempts).toBe(1);
+	});
+
+	it("explains a budget failure as a harness limit, not a provider problem", () => {
+		const msg = describeFailure(
+			new RunBudgetExceededError(
+				"Run budget exceeded: this request used 2000000 tokens, above the 2000000 token limit.",
+			),
+			AgentNode.BLOCK_BUILDER,
+		);
+		expect(msg).toContain("limit set for a single request");
 	});
 });
 

--- a/apps/ai-gateway/src/harness/models/base.ts
+++ b/apps/ai-gateway/src/harness/models/base.ts
@@ -28,6 +28,7 @@ import {
 	makeSubmitResultTool,
 	parseAsSchema,
 } from "./toolLoop";
+import type { RunBudget } from "./budget";
 
 /** Upper bound for a single model/tool call. Long enough for big reasoning
  *  responses, short enough that a dead connection doesn't stall a run. */
@@ -96,10 +97,18 @@ export abstract class BaseAgentWrapper {
 	/** Set per run by the harness — lets retryable errors (bad structured output,
 	 *  transient network issues) be surfaced live instead of only on failure. */
 	private retryWarningSink?: (info: RetryWarningInfo) => void;
+	/** Set per run by the harness. Every model call is booked against it and
+	 *  checked against it — this class is the only place they happen. */
+	private budget?: RunBudget;
 
 	/** Wires the run's interrupt signal into this agent (called once per run). */
 	public setAbortSignal(signal: AbortSignal): void {
 		this.signal = signal;
+	}
+
+	/** Wires the run's deadline/token budget into this agent (once per run). */
+	public setRunBudget(budget: RunBudget): void {
+		this.budget = budget;
 	}
 
 	/** Wires a live retry-warning sink into this agent (called once per run). */
@@ -149,16 +158,34 @@ export abstract class BaseAgentWrapper {
 	 * until some outer layer gives up; bounded here so withRetry can retry it.
 	 */
 	private withSignal(config?: RunnableConfig): RunnableConfig {
+		// A call that would outlive the run's deadline is wasted spend — the run
+		// fails the moment it returns. Never below 1s: ensureConfig rejects a
+		// non-positive timeout, and `checkRunLimits` has already thrown by then.
+		const remaining = this.budget?.remainingMs() ?? MODEL_CALL_TIMEOUT_MS;
 		return {
-			timeout: MODEL_CALL_TIMEOUT_MS,
+			timeout: Math.max(1_000, Math.min(MODEL_CALL_TIMEOUT_MS, remaining)),
 			...config,
 			...(this.signal ? { signal: this.signal } : {}),
 		};
 	}
 
-	/** Raises a UserInterruptError if the run has been interrupted. */
-	private throwIfInterrupted(): void {
+	/** Raises before a model call the run can't afford: a UserInterruptError if
+	 *  the user stopped it, a RunBudgetExceededError if it is out of time or
+	 *  tokens. */
+	private checkRunLimits(): void {
 		if (this.signal?.aborted) throw new UserInterruptError();
+		this.budget?.check();
+	}
+
+	/** Books a completed model call against the run budget. `response` is an
+	 *  AIMessage on every path; anything without `usage_metadata` (compatible
+	 *  servers that don't report it) still counts as a call. */
+	private recordUsage(
+		agentNode: string | undefined,
+		response: unknown,
+		startedAt: number,
+	): void {
+		this.budget?.record(agentNode, response, Date.now() - startedAt);
 	}
 
 	constructor(
@@ -250,7 +277,7 @@ export abstract class BaseAgentWrapper {
 	private async invokeAgentInner<T = any>(
 		options: AgentInvokeOptions,
 	): Promise<T | AIMessage> {
-		this.throwIfInterrupted();
+		this.checkRunLimits();
 		const {
 			zodSchema,
 			userQuery,
@@ -320,15 +347,28 @@ export abstract class BaseAgentWrapper {
 				this.supportsStructuredOutput() &&
 				originalModel.withStructuredOutput
 			) {
-				const structuredModel = originalModel.withStructuredOutput(zodSchema);
+				// `includeRaw` keeps the underlying AIMessage, which is the only place
+				// this path's token usage exists — without it the natively-structured
+				// calls (a whole provider family) are invisible to the budget.
+				const structuredModel = originalModel.withStructuredOutput(zodSchema, {
+					includeRaw: true,
+				});
 				try {
 					// By using invoke with config, it automatically logs to LangSmith/Langfuse
 					result = await withRetry(
-						() =>
-							structuredModel.invoke(
-								finalMessages,
-								this.withSignal(config),
-							) as Promise<T>,
+						async () => {
+							const startedAt = Date.now();
+							const { raw, parsed, parsingError } =
+								(await structuredModel.invoke(
+									finalMessages,
+									this.withSignal(config),
+								)) as { raw: AIMessage; parsed: T; parsingError?: Error };
+							this.recordUsage(agentNode, raw, startedAt);
+							// Without includeRaw this would have thrown out of `invoke`;
+							// rethrow so the retry and the prompt fallback below still see it.
+							if (parsingError) throw parsingError;
+							return parsed;
+						},
 						{
 							maxRetries: 3,
 							signal: this.signal,
@@ -339,8 +379,9 @@ export abstract class BaseAgentWrapper {
 				} catch (e) {
 					// Native structured output can fail outright (unsupported schema
 					// features, provider quirks). Fall through to the prompt-based
-					// fallback below rather than killing the run.
-					this.throwIfInterrupted();
+					// fallback below rather than killing the run. A budget failure is
+					// not a provider quirk, though — `checkRunLimits` rethrows it.
+					this.checkRunLimits();
 					logger.warn(
 						"[BaseAgentWrapper] Native structured output failed, using prompt fallback",
 						{
@@ -373,7 +414,15 @@ export abstract class BaseAgentWrapper {
 		}
 
 		return await withRetry(
-			() => originalModel.invoke(finalMessages, this.withSignal(config)),
+			async () => {
+				const startedAt = Date.now();
+				const response = await originalModel.invoke(
+					finalMessages,
+					this.withSignal(config),
+				);
+				this.recordUsage(agentNode, response, startedAt);
+				return response;
+			},
 			{
 				maxRetries: 3,
 				signal: this.signal,
@@ -402,12 +451,20 @@ export abstract class BaseAgentWrapper {
 			options.maxToolIterations ?? this.maxToolIterations ?? 8;
 
 		for (let i = 0; i < maxIterations; i++) {
-			this.throwIfInterrupted();
+			this.checkRunLimits();
 			compactToolHistory(finalMessages);
 			// Retried like every other model call — a single network timeout
 			// mid-loop used to kill the whole run.
 			const response = (await withRetry(
-				() => model.invoke(finalMessages, this.withSignal(config)),
+				async () => {
+					const startedAt = Date.now();
+					const message = await model.invoke(
+						finalMessages,
+						this.withSignal(config),
+					);
+					this.recordUsage(agentNode, message, startedAt);
+					return message;
+				},
 				{
 					maxRetries: 2,
 					signal: this.signal,
@@ -577,12 +634,14 @@ ${JSON.stringify(jsonSchema, null, 2)}`;
 				: model;
 
 		for (let attempt = 0; attempt < STRUCTURED_OUTPUT_ATTEMPTS; attempt++) {
-			this.throwIfInterrupted();
+			this.checkRunLimits();
 
 			let content = "";
 			let rawResponse: unknown;
 			try {
+				const startedAt = Date.now();
 				const response = await jsonModel.invoke(modifiedMessages, config);
+				this.recordUsage(agentNode, response, startedAt);
 				rawResponse = response;
 				content = cleanJsonOutput(extractText(response));
 

--- a/apps/ai-gateway/src/harness/models/budget.spec.ts
+++ b/apps/ai-gateway/src/harness/models/budget.spec.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "bun:test";
+import { AIMessage } from "@langchain/core/messages";
+import { RunBudget, RunBudgetExceededError } from "./budget";
+
+/** An AIMessage carrying the usage shape every provider normalizes to. */
+function reply(input: number, output: number, cacheRead = 0) {
+	return new AIMessage({
+		content: "ok",
+		usage_metadata: {
+			input_tokens: input,
+			output_tokens: output,
+			total_tokens: input + output,
+			input_token_details: { cache_read: cacheRead },
+		},
+	});
+}
+
+describe("RunBudget", () => {
+	it("allows calls while there is time and tokens left", () => {
+		const budget = new RunBudget({ deadlineMs: 60_000, tokenBudget: 1000 });
+		budget.record("planner", reply(100, 10), 5);
+		expect(() => budget.check()).not.toThrow();
+	});
+
+	it("stops the run once the token ceiling is reached", () => {
+		const budget = new RunBudget({ deadlineMs: 60_000, tokenBudget: 500 });
+		budget.record("planner", reply(400, 50), 5);
+		expect(() => budget.check()).not.toThrow();
+		budget.record("planner", reply(40, 20), 5);
+		expect(() => budget.check()).toThrow(RunBudgetExceededError);
+	});
+
+	it("stops the run once the deadline has passed", async () => {
+		const budget = new RunBudget({ deadlineMs: 1, tokenBudget: 0 });
+		await Bun.sleep(5);
+		expect(budget.remainingMs()).toBeLessThan(0);
+		expect(() => budget.check()).toThrow(/time limit/);
+	});
+
+	it("says 'run budget exceeded' so the failure report can explain itself", () => {
+		// `explainErrorReason` keys off this exact phrase — the message names both
+		// tokens and a limit, so without it the run would be blamed on the provider.
+		const budget = new RunBudget({ deadlineMs: 60_000, tokenBudget: 1 });
+		budget.record("planner", reply(5, 5), 1);
+		expect(() => budget.check()).toThrow(/run budget exceeded/i);
+	});
+
+	it("treats a zero budget as unlimited", () => {
+		const budget = new RunBudget({ deadlineMs: 0, tokenBudget: 0 });
+		budget.record("planner", reply(10_000_000, 1), 1);
+		expect(() => budget.check()).not.toThrow();
+	});
+
+	it("accounts per agent as well as per run, cache reads included", () => {
+		const budget = new RunBudget({ deadlineMs: 60_000, tokenBudget: 0 });
+		budget.record("planner", reply(100, 10, 80), 20);
+		budget.record("blockBuilder", reply(200, 20, 150), 30);
+		budget.record("blockBuilder", reply(50, 5), 10);
+
+		const usage = budget.snapshot();
+		expect(usage.calls).toBe(3);
+		expect(usage.totalTokens).toBe(385);
+		expect(usage.cachedInputTokens).toBe(230);
+		expect(usage.modelMs).toBe(60);
+		expect(usage.byAgent.blockBuilder).toEqual({
+			calls: 2,
+			retries: 0,
+			inputTokens: 250,
+			outputTokens: 25,
+			cachedInputTokens: 150,
+			modelMs: 40,
+		});
+	});
+
+	it("counts re-asks separately from calls", () => {
+		// Retries are already counted as calls; without this the run looks like it
+		// did four different things instead of the same one four times.
+		const budget = new RunBudget({ deadlineMs: 60_000, tokenBudget: 0 });
+		budget.record("planner", reply(10, 1), 1);
+		budget.recordRetry("planner");
+		budget.record("planner", reply(10, 1), 1);
+
+		const usage = budget.snapshot();
+		expect(usage.calls).toBe(2);
+		expect(usage.retries).toBe(1);
+		expect(usage.byAgent.planner!.retries).toBe(1);
+	});
+
+	it("still counts a call from a provider that reports no usage", () => {
+		// Compatible servers often omit usage_metadata. The call must still be
+		// visible, otherwise the run looks free.
+		const budget = new RunBudget({ deadlineMs: 60_000, tokenBudget: 0 });
+		budget.record(undefined, new AIMessage("ok"), 12);
+
+		const usage = budget.snapshot();
+		expect(usage.calls).toBe(1);
+		expect(usage.totalTokens).toBe(0);
+		expect(usage.byAgent.unknown!.calls).toBe(1);
+	});
+});

--- a/apps/ai-gateway/src/harness/models/budget.ts
+++ b/apps/ai-gateway/src/harness/models/budget.ts
@@ -1,0 +1,151 @@
+import type { AIMessage } from "@langchain/core/messages";
+import { logger } from "@fluxify/common";
+
+/**
+ * Wall-clock ceiling for one run. Retry budgets multiply: `withRetry` (3) x the
+ * structured-output attempts (3) x `MODEL_CALL_TIMEOUT_MS` (3 min) means a
+ * *single* agent call can legitimately burn 27 minutes, and a build runs dozens
+ * of them. This is the backstop that a stuck run eventually hits.
+ */
+export const RUN_DEADLINE_MS = Number(
+	process.env.HARNESS_RUN_DEADLINE_MS ?? 10 * 60_000,
+);
+
+/**
+ * Token ceiling for one run. Sized well above a heavy multi-task build (~40
+ * calls carrying the whole history) so it only ever catches a runaway loop, not
+ * legitimate work. Providers that report no usage leave this unenforceable —
+ * the deadline above still applies.
+ */
+export const RUN_TOKEN_BUDGET = Number(
+	process.env.HARNESS_RUN_TOKEN_BUDGET ?? 2_000_000,
+);
+
+/** Thrown when a run passes its deadline or token ceiling. Not an interrupt:
+ *  the run is finalized as `failed` with an explanation. */
+export class RunBudgetExceededError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "RunBudgetExceededError";
+	}
+}
+
+/** Model spend attributable to one agent (or to the whole run). */
+export interface AgentUsage {
+	calls: number;
+	/** Calls that had to be re-asked (bad structured output, transient network
+	 *  errors). A healthy run is near zero; a rising number is the first sign an
+	 *  agent's prompt or the chosen model is a bad fit. */
+	retries: number;
+	inputTokens: number;
+	outputTokens: number;
+	/** Prompt tokens served from the provider's cache — the payoff of #148's
+	 *  cache-friendly prompt ordering, and the only way to see it working. */
+	cachedInputTokens: number;
+	/** Time spent inside model calls. */
+	modelMs: number;
+}
+
+export interface RunUsage extends AgentUsage {
+	totalTokens: number;
+	/** Wall clock for the whole run, including graph and tool time. */
+	elapsedMs: number;
+	byAgent: Record<string, AgentUsage>;
+}
+
+function emptyUsage(): AgentUsage {
+	return {
+		calls: 0,
+		retries: 0,
+		inputTokens: 0,
+		outputTokens: 0,
+		cachedInputTokens: 0,
+		modelMs: 0,
+	};
+}
+
+/**
+ * Per-run deadline, token ceiling and usage accounting. One instance per run,
+ * handed to the agent wrapper (which makes every model call) by the harness.
+ */
+export class RunBudget {
+	private readonly startedAt = Date.now();
+	private readonly deadlineMs: number;
+	private readonly tokenBudget: number;
+	private readonly total = emptyUsage();
+	private readonly byAgent = new Map<string, AgentUsage>();
+
+	constructor(options: { deadlineMs?: number; tokenBudget?: number } = {}) {
+		this.deadlineMs = options.deadlineMs ?? RUN_DEADLINE_MS;
+		this.tokenBudget = options.tokenBudget ?? RUN_TOKEN_BUDGET;
+	}
+
+	/** Milliseconds left before the deadline (negative once past it). */
+	remainingMs(): number {
+		return this.deadlineMs - (Date.now() - this.startedAt);
+	}
+
+	/** Throws once the run is out of time or tokens. Called before every model
+	 *  call — a run only ever grows its spend by making one. */
+	check(): void {
+		if (this.deadlineMs > 0 && this.remainingMs() <= 0) {
+			throw new RunBudgetExceededError(
+				`Run budget exceeded: this request passed its ${Math.round(this.deadlineMs / 60_000)} minute time limit.`,
+			);
+		}
+		const used = this.total.inputTokens + this.total.outputTokens;
+		if (this.tokenBudget > 0 && used >= this.tokenBudget) {
+			throw new RunBudgetExceededError(
+				`Run budget exceeded: this request used ${used} tokens, above the ${this.tokenBudget} token limit.`,
+			);
+		}
+	}
+
+	private bucketFor(agentNode: string | undefined): AgentUsage {
+		const agent = this.byAgent.get(agentNode ?? "unknown") ?? emptyUsage();
+		this.byAgent.set(agentNode ?? "unknown", agent);
+		return agent;
+	}
+
+	/** Books a re-ask against the run. Retries are the cost that hides: they are
+	 *  already counted as calls, but nothing said they were the *same* call. */
+	recordRetry(agentNode: string | undefined): void {
+		this.total.retries += 1;
+		this.bucketFor(agentNode).retries += 1;
+	}
+
+	/** Books one model call against the run and the agent that made it. */
+	record(agentNode: string | undefined, response: unknown, modelMs: number): void {
+		const usage = (response as AIMessage | undefined)?.usage_metadata;
+		const agent = this.bucketFor(agentNode);
+
+		for (const bucket of [this.total, agent]) {
+			bucket.calls += 1;
+			bucket.modelMs += modelMs;
+			bucket.inputTokens += usage?.input_tokens ?? 0;
+			bucket.outputTokens += usage?.output_tokens ?? 0;
+			bucket.cachedInputTokens += usage?.input_token_details?.cache_read ?? 0;
+		}
+	}
+
+	snapshot(): RunUsage {
+		return {
+			...this.total,
+			totalTokens: this.total.inputTokens + this.total.outputTokens,
+			elapsedMs: Date.now() - this.startedAt,
+			byAgent: Object.fromEntries(this.byAgent),
+		};
+	}
+}
+
+/** Takes the run's final numbers and logs them, so a run's cost survives even
+ *  if persisting it afterwards fails. Called once per run, on every terminal
+ *  path. */
+export function logRunUsage(
+	ids: { runId: string; conversationId: string },
+	budget: RunBudget,
+): RunUsage {
+	const usage = budget.snapshot();
+	logger.info("[FluxifyHarness] Run usage", { ...ids, ...usage });
+	return usage;
+}

--- a/apps/ai-gateway/src/harness/streamTypes.ts
+++ b/apps/ai-gateway/src/harness/streamTypes.ts
@@ -8,6 +8,7 @@ import {
 	type SummarizerState,
 	type SubAgentResult,
 } from "./types";
+import type { RunUsage } from "./models/budget";
 
 /* ============================================================================
  * HARNESS STREAM EVENT CONTRACT
@@ -119,6 +120,9 @@ export interface HarnessRunResult {
 	artifactId?: string;
 	/** Why the run failed or was interrupted. Absent on success. */
 	error?: string;
+	/** What the run cost: model calls, tokens (including cache reads) and time,
+	 *  with a per-agent breakdown. */
+	usage?: RunUsage;
 }
 
 /**

--- a/apps/ai-gateway/src/harness/telemetry/otel-tracer.spec.ts
+++ b/apps/ai-gateway/src/harness/telemetry/otel-tracer.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "bun:test";
+import { AIMessage } from "@langchain/core/messages";
+import { FluxifyOtelTracer } from "./otel-tracer";
+
+/** Exposes the usage extraction that turns a provider response into span
+ *  attributes — the part that silently produced nothing before. */
+class Probe extends FluxifyOtelTracer {
+	attributes(output: any) {
+		return (this as any).usageAttributes(output);
+	}
+}
+
+const tracer = new Probe();
+
+function generation(usage?: Record<string, any>) {
+	const message = new AIMessage("ok");
+	if (usage) (message as any).usage_metadata = usage;
+	return [[{ text: "ok", message }]];
+}
+
+describe("FluxifyOtelTracer usage attributes", () => {
+	it("reads usage from the message, where every provider puts it", () => {
+		// `llmOutput.tokenUsage` is the OpenAI shape and is absent for Anthropic,
+		// Google and Mistral — those calls used to trace as costing nothing.
+		const attributes = tracer.attributes({
+			generations: generation({
+				input_tokens: 1200,
+				output_tokens: 300,
+				total_tokens: 1500,
+				input_token_details: { cache_read: 1000, cache_creation: 200 },
+			}),
+		});
+
+		expect(attributes).toEqual({
+			"llm.token_count.prompt": 1200,
+			"llm.token_count.completion": 300,
+			"llm.token_count.total": 1500,
+			"llm.token_count.prompt_details.cache_read": 1000,
+			"llm.token_count.prompt_details.cache_write": 200,
+		});
+	});
+
+	it("falls back to the OpenAI-shaped llmOutput when the message has none", () => {
+		const attributes = tracer.attributes({
+			generations: generation(),
+			llmOutput: { tokenUsage: { promptTokens: 10, completionTokens: 4 } },
+		});
+
+		expect(attributes["llm.token_count.prompt"]).toBe(10);
+		expect(attributes["llm.token_count.total"]).toBe(14);
+	});
+
+	it("reports nothing rather than zeros when the provider reports nothing", () => {
+		// A missing count and a genuine zero are different facts; recording 0 here
+		// would make an un-instrumented provider look free.
+		expect(tracer.attributes({ generations: generation() })).toEqual({});
+		expect(tracer.attributes(undefined)).toEqual({});
+	});
+});

--- a/apps/ai-gateway/src/harness/telemetry/otel-tracer.ts
+++ b/apps/ai-gateway/src/harness/telemetry/otel-tracer.ts
@@ -60,13 +60,17 @@ export class FluxifyOtelTracer extends BaseCallbackHandler {
 		this.spans.set(id, span);
 	}
 
-	private endSpan(id: string, error?: Error, outputs?: any) {
+	private endSpan(id: string, error?: unknown, outputs?: any) {
 		const span = this.spans.get(id);
 		if (!span) return;
 
 		if (error) {
-			span.recordException(error);
-			span.setStatus({ code: 2, message: error.message }); // 2 = ERROR
+			// Provider SDKs reject with plain objects as happily as with Errors
+			// (`{ code: 23 }`), and `recordException` would keep none of it.
+			const thrown =
+				error instanceof Error ? error : new Error(this.safeStringify(error));
+			span.recordException(thrown);
+			span.setStatus({ code: 2, message: thrown.message }); // 2 = ERROR
 		} else {
 			span.setStatus({ code: 1 }); // 1 = OK
 		}
@@ -131,28 +135,65 @@ export class FluxifyOtelTracer extends BaseCallbackHandler {
 		const span = this.spans.get(runId);
 		if (span) {
 			span.setAttribute("input.value", this.safeStringify(prompts));
+			// Which model actually served the call — the run may be configured with
+			// one and fall back to another, and token counts mean nothing without it.
+			const params = extraParams?.invocation_params;
+			const model = params?.model ?? params?.model_name;
+			if (model) span.setAttribute("llm.model_name", String(model));
 			if (metadata) {
 				span.setAttribute("llm.metadata", JSON.stringify(metadata));
 			}
 		}
 	}
 
+	/**
+	 * Token usage for one model call, in OpenInference attribute names.
+	 *
+	 * `llmOutput.tokenUsage` is the OpenAI-shaped field and is simply absent for
+	 * several providers; the portable place is `usage_metadata` on the returned
+	 * message, which every LangChain chat model normalizes to. Read both, prefer
+	 * the message, and carry the cache-read count — prompt caching is invisible
+	 * without it, and it is the cheapest token there is.
+	 */
+	private usageAttributes(output: any): Record<string, number> {
+		const messages = (output?.generations ?? [])
+			.flat()
+			.map((generation: any) => generation?.message)
+			.filter(Boolean);
+
+		const totals = { prompt: 0, completion: 0, cacheRead: 0, cacheWrite: 0 };
+		let found = false;
+		for (const message of messages) {
+			const usage = message.usage_metadata;
+			if (!usage) continue;
+			found = true;
+			totals.prompt += usage.input_tokens ?? 0;
+			totals.completion += usage.output_tokens ?? 0;
+			totals.cacheRead += usage.input_token_details?.cache_read ?? 0;
+			totals.cacheWrite += usage.input_token_details?.cache_creation ?? 0;
+		}
+
+		if (!found) {
+			const legacy =
+				output?.llmOutput?.tokenUsage || output?.llmOutput?.estimatedTokenUsage;
+			if (!legacy) return {};
+			totals.prompt = legacy.promptTokens ?? 0;
+			totals.completion = legacy.completionTokens ?? 0;
+		}
+
+		return {
+			"llm.token_count.prompt": totals.prompt,
+			"llm.token_count.completion": totals.completion,
+			"llm.token_count.total": totals.prompt + totals.completion,
+			"llm.token_count.prompt_details.cache_read": totals.cacheRead,
+			"llm.token_count.prompt_details.cache_write": totals.cacheWrite,
+		};
+	}
+
 	async handleLLMEnd(output: any, runId: string) {
 		const span = this.spans.get(runId);
-		if (span && output?.llmOutput) {
-			// LangChain typically returns token usage here
-			const usage = output.llmOutput.tokenUsage || output.llmOutput.estimatedTokenUsage;
-			if (usage) {
-				if (usage.promptTokens !== undefined) {
-					span.setAttribute("llm.token_count.prompt", usage.promptTokens);
-				}
-				if (usage.completionTokens !== undefined) {
-					span.setAttribute("llm.token_count.completion", usage.completionTokens);
-				}
-				if (usage.totalTokens !== undefined) {
-					span.setAttribute("llm.token_count.total", usage.totalTokens);
-				}
-			}
+		if (span) {
+			span.setAttributes(this.usageAttributes(output));
 		}
 		this.endSpan(runId, undefined, output);
 	}

--- a/apps/ai-gateway/src/harness/telemetry/runSpan.ts
+++ b/apps/ai-gateway/src/harness/telemetry/runSpan.ts
@@ -1,0 +1,107 @@
+import { trace, context, type Span } from "@fluxify/common/tracing";
+import type { RunUsage } from "../models/budget";
+
+/**
+ * The one span that covers a whole harness run, from graph start to the
+ * persisted outcome.
+ *
+ * `FluxifyOtelTracer` traces individual chains, LLM calls and tools, but every
+ * one of those spans ends while the graph is still streaming — there is nowhere
+ * to hang what a *run* cost, why it failed, or how often it had to re-ask. This
+ * is that place, and because it is made the active span, all of the tracer's
+ * spans nest underneath it.
+ *
+ * Attributes follow the OpenInference conventions (`llm.token_count.*`) so
+ * Phoenix/Arize read them without a mapping, plus `fluxify.run.*` for what is
+ * ours alone.
+ */
+export function startRunSpan(input: {
+	runId: string;
+	conversationId: string;
+	projectId?: string;
+	userQuery?: string;
+}): Span {
+	const span = trace.getTracer("fluxify-harness").startSpan("harness.run", {
+		attributes: {
+			"openinference.span.kind": "AGENT",
+			"fluxify.run.id": input.runId,
+			"fluxify.conversation.id": input.conversationId,
+			...(input.projectId ? { "fluxify.project.id": input.projectId } : {}),
+			...(input.userQuery ? { "input.value": input.userQuery } : {}),
+		},
+	});
+	return span;
+}
+
+/** Runs `fn` with the run span active, so spans created inside it nest under
+ *  the run instead of dangling at the trace root. */
+export function withRunSpan<T>(span: Span, fn: () => T): T {
+	return context.with(trace.setSpan(context.active(), span), fn);
+}
+
+/** Records a model call that had to be re-asked. Kept as an event rather than a
+ *  counter so the trace shows *when* the run started struggling. */
+export function recordRetryOnRunSpan(
+	span: Span,
+	info: { agentNode?: string; attempt: number; maxAttempts: number; rawError: string },
+): void {
+	span.addEvent("model.retry", {
+		"fluxify.agent": info.agentNode ?? "unknown",
+		"fluxify.retry.attempt": info.attempt,
+		"fluxify.retry.max_attempts": info.maxAttempts,
+		// The raw provider message, not the user-facing explanation — this is the
+		// one place the underlying cause is worth keeping verbatim.
+		"exception.message": info.rawError.slice(0, 1000),
+	});
+}
+
+/**
+ * Closes the run span with what the run actually cost and how it ended. `error`
+ * is the raw thrown value: the friendly `aiResponse` explanation is for the
+ * user, the trace wants the real thing.
+ */
+export function endRunSpan(
+	span: Span,
+	outcome: {
+		usage: RunUsage;
+		status: string;
+		error?: unknown;
+		failedNode?: string;
+	},
+): void {
+	const { usage } = outcome;
+	span.setAttributes({
+		"fluxify.run.status": outcome.status,
+		"fluxify.run.model_calls": usage.calls,
+		"fluxify.run.retries": usage.retries,
+		"fluxify.run.model_ms": usage.modelMs,
+		"fluxify.run.elapsed_ms": usage.elapsedMs,
+		"fluxify.run.usage_by_agent": JSON.stringify(usage.byAgent),
+		"llm.token_count.prompt": usage.inputTokens,
+		"llm.token_count.completion": usage.outputTokens,
+		"llm.token_count.total": usage.totalTokens,
+		"llm.token_count.prompt_details.cache_read": usage.cachedInputTokens,
+	});
+	if (outcome.failedNode) {
+		span.setAttribute("fluxify.run.failed_node", outcome.failedNode);
+	}
+
+	if (outcome.error !== undefined) {
+		span.recordException(
+			outcome.error instanceof Error
+				? outcome.error
+				: new Error(String(outcome.error)),
+		);
+		span.setStatus({
+			code: 2,
+			message:
+				outcome.error instanceof Error
+					? outcome.error.message
+					: String(outcome.error),
+		});
+	} else {
+		span.setStatus({ code: 1 });
+	}
+
+	span.end();
+}

--- a/apps/ai-gateway/src/lib/retry.ts
+++ b/apps/ai-gateway/src/lib/retry.ts
@@ -30,10 +30,13 @@ export async function withRetry<T>(
       return await operation();
     } catch (error) {
       // A user interrupt / abort must never be retried — propagate immediately.
+      // Nor a blown run budget: retrying only spends more of what ran out.
       if (
         options.signal?.aborted ||
         (error instanceof Error &&
-          (error.name === "UserInterruptError" || error.name === "AbortError"))
+          (error.name === "UserInterruptError" ||
+            error.name === "AbortError" ||
+            error.name === "RunBudgetExceededError"))
       ) {
         throw error;
       }

--- a/apps/server/src/db/agent-harness-schema.ts
+++ b/apps/server/src/db/agent-harness-schema.ts
@@ -128,6 +128,10 @@ export const agentHarnessRunsEntity = pgTable(
 			{ onDelete: "set null" },
 		),
 		status: agentHarnessRunStatusEnum("status").default("queued").notNull(),
+		// What the run cost the provider: model calls, prompt/completion/cached
+		// tokens, wall clock, and the same breakdown per agent. Written once when
+		// the run reaches a terminal state; null for runs that never got there.
+		usage: jsonb("usage").$type<Record<string, any>>(),
 		interruptedAt: timestamp("interrupted_at"),
 		createdAt: timestamp("created_at").defaultNow().notNull(),
 		completedAt: timestamp("completed_at"),

--- a/apps/server/src/db/migrations/0046_fixed_hiroim.sql
+++ b/apps/server/src/db/migrations/0046_fixed_hiroim.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "agent_harness_runs" ADD COLUMN "usage" jsonb;

--- a/apps/server/src/db/migrations/meta/0046_snapshot.json
+++ b/apps/server/src/db/migrations/meta/0046_snapshot.json
@@ -1,0 +1,2869 @@
+{
+  "id": "884df6ec-efa1-4f9b-90d5-1e8e47b11e5d",
+  "prevId": "6376bf6c-d7f8-4a41-92ca-820abdab6e61",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.access_control": {
+      "name": "access_control",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "access_control_roles",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_access_control_user_id": {
+          "name": "idx_access_control_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_access_control_project_id": {
+          "name": "idx_access_control_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "access_control_user_id_system_users_id_fk": {
+          "name": "access_control_user_id_system_users_id_fk",
+          "tableFrom": "access_control",
+          "tableTo": "system_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "access_control_project_id_projects_id_fk": {
+          "name": "access_control_project_id_projects_id_fk",
+          "tableFrom": "access_control",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_config": {
+      "name": "app_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key_name": {
+          "name": "key_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_encrypted": {
+          "name": "is_encrypted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "encoding_type": {
+          "name": "encoding_type",
+          "type": "encoding_types",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "app_config_data_types",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'string'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_app_config_key_name": {
+          "name": "idx_app_config_key_name",
+          "columns": [
+            {
+              "expression": "key_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_app_config_project_id": {
+          "name": "idx_app_config_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_app_config_is_encrypted": {
+          "name": "idx_app_config_is_encrypted",
+          "columns": [
+            {
+              "expression": "is_encrypted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_app_config_encoding_type": {
+          "name": "idx_app_config_encoding_type",
+          "columns": [
+            {
+              "expression": "encoding_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_app_config_key_name_fts": {
+          "name": "idx_app_config_key_name_fts",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', \"key_name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_app_config_desc_fts": {
+          "name": "idx_app_config_desc_fts",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', coalesce(\"description\", ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_config_project_id_projects_id_fk": {
+          "name": "app_config_project_id_projects_id_fk",
+          "tableFrom": "app_config",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocks": {
+      "name": "blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_id": {
+          "name": "route_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_blocks_route_id": {
+          "name": "idx_blocks_route_id",
+          "columns": [
+            {
+              "expression": "route_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blocks_route_id_routes_id_fk": {
+          "name": "blocks_route_id_routes_id_fk",
+          "tableFrom": "blocks",
+          "tableTo": "routes",
+          "columnsFrom": [
+            "route_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_block_graphs": {
+      "name": "custom_block_graphs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "custom_block_id": {
+          "name": "custom_block_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_block_id": {
+          "name": "next_block_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_custom_block_graphs_custom_block_id": {
+          "name": "idx_custom_block_graphs_custom_block_id",
+          "columns": [
+            {
+              "expression": "custom_block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "custom_block_graphs_custom_block_id_custom_blocks_list_id_fk": {
+          "name": "custom_block_graphs_custom_block_id_custom_blocks_list_id_fk",
+          "tableFrom": "custom_block_graphs",
+          "tableTo": "custom_blocks_list",
+          "columnsFrom": [
+            "custom_block_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_blocks_list": {
+      "name": "custom_blocks_list",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "custom_block_icon_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_params": {
+          "name": "input_params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "custom_block_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user-defined'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_custom_blocks_list_project_id": {
+          "name": "idx_custom_blocks_list_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_custom_blocks_list_name": {
+          "name": "idx_custom_blocks_list_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "custom_blocks_list_project_id_projects_id_fk": {
+          "name": "custom_blocks_list_project_id_projects_id_fk",
+          "tableFrom": "custom_blocks_list",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.edges": {
+      "name": "edges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "from": {
+          "name": "from",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to": {
+          "name": "to",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_handle": {
+          "name": "from_handle",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_handle": {
+          "name": "to_handle",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_id": {
+          "name": "route_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_edges_from": {
+          "name": "idx_edges_from",
+          "columns": [
+            {
+              "expression": "from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_edges_to": {
+          "name": "idx_edges_to",
+          "columns": [
+            {
+              "expression": "to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_edges_route_id": {
+          "name": "idx_edges_route_id",
+          "columns": [
+            {
+              "expression": "route_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "edges_from_blocks_id_fk": {
+          "name": "edges_from_blocks_id_fk",
+          "tableFrom": "edges",
+          "tableTo": "blocks",
+          "columnsFrom": [
+            "from"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edges_to_blocks_id_fk": {
+          "name": "edges_to_blocks_id_fk",
+          "tableFrom": "edges",
+          "tableTo": "blocks",
+          "columnsFrom": [
+            "to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edges_route_id_routes_id_fk": {
+          "name": "edges_route_id_routes_id_fk",
+          "tableFrom": "edges",
+          "tableTo": "routes",
+          "columnsFrom": [
+            "route_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instance_settings": {
+      "name": "instance_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "instance_setting_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "instance_settings_key_unique": {
+          "name": "instance_settings_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integrations": {
+      "name": "integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group": {
+          "name": "group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_integrations_name": {
+          "name": "idx_integrations_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integrations_group": {
+          "name": "idx_integrations_group",
+          "columns": [
+            {
+              "expression": "group",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integrations_variant": {
+          "name": "idx_integrations_variant",
+          "columns": [
+            {
+              "expression": "variant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integrations_tags": {
+          "name": "idx_integrations_tags",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integrations_project_id": {
+          "name": "idx_integrations_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integrations_name_fts": {
+          "name": "idx_integrations_name_fts",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', \"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_integrations_meta_fts": {
+          "name": "idx_integrations_meta_fts",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', coalesce(\"group\", '') || ' ' || coalesce(\"variant\", '') || ' ' || coalesce(\"tags\", ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integrations_project_id_projects_id_fk": {
+          "name": "integrations_project_id_projects_id_fk",
+          "tableFrom": "integrations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_settings": {
+      "name": "project_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_project_settings_project_id": {
+          "name": "idx_project_settings_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_settings_key": {
+          "name": "idx_project_settings_key",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_settings_project_id_projects_id_fk": {
+          "name": "project_settings_project_id_projects_id_fk",
+          "tableFrom": "project_settings",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_projects_id": {
+          "name": "idx_projects_id",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_projects_name": {
+          "name": "idx_projects_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_projects_updated_at": {
+          "name": "idx_projects_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.routes": {
+      "name": "routes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "NULL"
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_schema": {
+          "name": "body_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query_schema": {
+          "name": "query_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "params_schema": {
+          "name": "params_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_routes_project_id": {
+          "name": "idx_routes_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_routes_path": {
+          "name": "idx_routes_path",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_routes_name_fts": {
+          "name": "idx_routes_name_fts",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', \"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_routes_path_fts": {
+          "name": "idx_routes_path_fts",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', translate(coalesce(\"path\", ''), '/:-_', '    '))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "routes_project_id_projects_id_fk": {
+          "name": "routes_project_id_projects_id_fk",
+          "tableFrom": "routes",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_suites": {
+      "name": "test_suites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_id": {
+          "name": "route_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "query_params": {
+          "name": "query_params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "route_params": {
+          "name": "route_params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "body": {
+          "name": "body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assertions": {
+          "name": "assertions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "integration_overrides": {
+          "name": "integration_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "app_config_overrides": {
+          "name": "app_config_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_suites_route_id_routes_id_fk": {
+          "name": "test_suites_route_id_routes_id_fk",
+          "tableFrom": "test_suites",
+          "tableTo": "routes",
+          "columnsFrom": [
+            "route_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_harness_artifacts": {
+      "name": "agent_harness_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_harness_artifacts_conv_id": {
+          "name": "idx_harness_artifacts_conv_id",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_harness_artifacts_run_id": {
+          "name": "idx_harness_artifacts_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_harness_artifacts_conversation_id_agent_harness_conversations_id_fk": {
+          "name": "agent_harness_artifacts_conversation_id_agent_harness_conversations_id_fk",
+          "tableFrom": "agent_harness_artifacts",
+          "tableTo": "agent_harness_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_harness_artifacts_run_id_agent_harness_runs_id_fk": {
+          "name": "agent_harness_artifacts_run_id_agent_harness_runs_id_fk",
+          "tableFrom": "agent_harness_artifacts",
+          "tableTo": "agent_harness_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_harness_conversations": {
+      "name": "agent_harness_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'New Chat'"
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_harness_conversation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "active_run_id": {
+          "name": "active_run_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_harness_conv_user_id": {
+          "name": "idx_harness_conv_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_harness_conv_project_id": {
+          "name": "idx_harness_conv_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_harness_conv_user_archived_pinned": {
+          "name": "idx_harness_conv_user_archived_pinned",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_harness_conversations_user_id_system_users_id_fk": {
+          "name": "agent_harness_conversations_user_id_system_users_id_fk",
+          "tableFrom": "agent_harness_conversations",
+          "tableTo": "system_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_harness_conversations_project_id_projects_id_fk": {
+          "name": "agent_harness_conversations_project_id_projects_id_fk",
+          "tableFrom": "agent_harness_conversations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_harness_hitl_actions": {
+      "name": "agent_harness_hitl_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_id": {
+          "name": "step_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "agent_harness_hitl_action_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_response": {
+          "name": "user_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_harness_hitl_run_id": {
+          "name": "idx_harness_hitl_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_harness_hitl_step_id": {
+          "name": "idx_harness_hitl_step_id",
+          "columns": [
+            {
+              "expression": "step_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_harness_hitl_actions_run_id_agent_harness_runs_id_fk": {
+          "name": "agent_harness_hitl_actions_run_id_agent_harness_runs_id_fk",
+          "tableFrom": "agent_harness_hitl_actions",
+          "tableTo": "agent_harness_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_harness_hitl_actions_step_id_agent_harness_steps_id_fk": {
+          "name": "agent_harness_hitl_actions_step_id_agent_harness_steps_id_fk",
+          "tableFrom": "agent_harness_hitl_actions",
+          "tableTo": "agent_harness_steps",
+          "columnsFrom": [
+            "step_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_harness_live_states": {
+      "name": "agent_harness_live_states",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_state": {
+          "name": "current_state",
+          "type": "agent_harness_live_state_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "active_step_id": {
+          "name": "active_step_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "working_memory": {
+          "name": "working_memory",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_harness_live_conv_id": {
+          "name": "idx_harness_live_conv_id",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_harness_live_states_run_id_agent_harness_runs_id_fk": {
+          "name": "agent_harness_live_states_run_id_agent_harness_runs_id_fk",
+          "tableFrom": "agent_harness_live_states",
+          "tableTo": "agent_harness_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_harness_live_states_conversation_id_agent_harness_conversations_id_fk": {
+          "name": "agent_harness_live_states_conversation_id_agent_harness_conversations_id_fk",
+          "tableFrom": "agent_harness_live_states",
+          "tableTo": "agent_harness_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_harness_runs": {
+      "name": "agent_harness_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_query": {
+          "name": "user_query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_response": {
+          "name": "ai_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_harness_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "usage": {
+          "name": "usage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interrupted_at": {
+          "name": "interrupted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_harness_runs_conv_id": {
+          "name": "idx_harness_runs_conv_id",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_harness_runs_status": {
+          "name": "idx_harness_runs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_harness_runs_integration_id": {
+          "name": "idx_harness_runs_integration_id",
+          "columns": [
+            {
+              "expression": "integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_harness_runs_conversation_id_agent_harness_conversations_id_fk": {
+          "name": "agent_harness_runs_conversation_id_agent_harness_conversations_id_fk",
+          "tableFrom": "agent_harness_runs",
+          "tableTo": "agent_harness_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_harness_runs_integration_id_integrations_id_fk": {
+          "name": "agent_harness_runs_integration_id_integrations_id_fk",
+          "tableFrom": "agent_harness_runs",
+          "tableTo": "integrations",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_harness_steps": {
+      "name": "agent_harness_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_type": {
+          "name": "step_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_order": {
+          "name": "step_order",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sub_agent_role": {
+          "name": "sub_agent_role",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sub_agent_id": {
+          "name": "sub_agent_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_harness_step_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_harness_steps_run_id": {
+          "name": "idx_harness_steps_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_harness_steps_sub_agent_id": {
+          "name": "idx_harness_steps_sub_agent_id",
+          "columns": [
+            {
+              "expression": "sub_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_harness_steps_run_sub_agent": {
+          "name": "uq_harness_steps_run_sub_agent",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sub_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_harness_steps_run_id_agent_harness_runs_id_fk": {
+          "name": "agent_harness_steps_run_id_agent_harness_runs_id_fk",
+          "tableFrom": "agent_harness_steps",
+          "tableTo": "agent_harness_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_harness_steps_conversation_id_agent_harness_conversations_id_fk": {
+          "name": "agent_harness_steps_conversation_id_agent_harness_conversations_id_fk",
+          "tableFrom": "agent_harness_steps",
+          "tableTo": "agent_harness_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_harness_sub_artifacts": {
+      "name": "agent_harness_sub_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sub_agent_id": {
+          "name": "sub_agent_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_harness_sub_artifacts_artifact_id": {
+          "name": "idx_harness_sub_artifacts_artifact_id",
+          "columns": [
+            {
+              "expression": "artifact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_harness_sub_artifacts_run_id": {
+          "name": "idx_harness_sub_artifacts_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_harness_sub_artifacts_artifact_id_agent_harness_artifacts_id_fk": {
+          "name": "agent_harness_sub_artifacts_artifact_id_agent_harness_artifacts_id_fk",
+          "tableFrom": "agent_harness_sub_artifacts",
+          "tableTo": "agent_harness_artifacts",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_harness_sub_artifacts_conversation_id_agent_harness_conversations_id_fk": {
+          "name": "agent_harness_sub_artifacts_conversation_id_agent_harness_conversations_id_fk",
+          "tableFrom": "agent_harness_sub_artifacts",
+          "tableTo": "agent_harness_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_harness_sub_artifacts_run_id_agent_harness_runs_id_fk": {
+          "name": "agent_harness_sub_artifacts_run_id_agent_harness_runs_id_fk",
+          "tableFrom": "agent_harness_sub_artifacts",
+          "tableTo": "agent_harness_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_users": {
+      "name": "system_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system_admin": {
+          "name": "is_system_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "system_users_email_unique": {
+          "name": "system_users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_id_system_users_id_fk": {
+          "name": "user_id_system_users_id_fk",
+          "tableFrom": "user",
+          "tableTo": "system_users",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.access_control_roles": {
+      "name": "access_control_roles",
+      "schema": "public",
+      "values": [
+        "viewer",
+        "creator",
+        "project_admin",
+        "system_admin"
+      ]
+    },
+    "public.app_config_data_types": {
+      "name": "app_config_data_types",
+      "schema": "public",
+      "values": [
+        "string",
+        "number",
+        "boolean"
+      ]
+    },
+    "public.custom_block_icon_type": {
+      "name": "custom_block_icon_type",
+      "schema": "public",
+      "values": [
+        "premade-list",
+        "custom"
+      ]
+    },
+    "public.custom_block_source_type": {
+      "name": "custom_block_source_type",
+      "schema": "public",
+      "values": [
+        "plugin",
+        "inhouse",
+        "user-defined"
+      ]
+    },
+    "public.encoding_types": {
+      "name": "encoding_types",
+      "schema": "public",
+      "values": [
+        "plaintext",
+        "base64",
+        "hex"
+      ]
+    },
+    "public.instance_setting_category": {
+      "name": "instance_setting_category",
+      "schema": "public",
+      "values": [
+        "auth"
+      ]
+    },
+    "public.agent_harness_conversation_status": {
+      "name": "agent_harness_conversation_status",
+      "schema": "public",
+      "values": [
+        "idle",
+        "running",
+        "paused_hitl",
+        "interrupted",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.agent_harness_hitl_action_type": {
+      "name": "agent_harness_hitl_action_type",
+      "schema": "public",
+      "values": [
+        "plan_approval",
+        "plan_rejection",
+        "user_input",
+        "confirmation",
+        "cancellation",
+        "custom"
+      ]
+    },
+    "public.agent_harness_live_state_status": {
+      "name": "agent_harness_live_state_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "paused_hitl",
+        "interrupted",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.agent_harness_run_status": {
+      "name": "agent_harness_run_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "routing",
+        "verifying",
+        "planning",
+        "orchestrating",
+        "executing",
+        "awaiting_hitl",
+        "completed",
+        "interrupted",
+        "failed"
+      ]
+    },
+    "public.agent_harness_step_status": {
+      "name": "agent_harness_step_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "interrupted"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/server/src/db/migrations/meta/_journal.json
+++ b/apps/server/src/db/migrations/meta/_journal.json
@@ -323,6 +323,13 @@
       "when": 1785278355449,
       "tag": "0045_nasty_firelord",
       "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "7",
+      "when": 1785710041862,
+      "tag": "0046_fixed_hiroim",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/db/redis.ts
+++ b/apps/server/src/db/redis.ts
@@ -79,3 +79,10 @@ export async function mgetCache(keys: string[]): Promise<(string | null)[]> {
 export async function incrCache(key: string): Promise<number> {
 	return redisClient.incr(key);
 }
+
+/** Puts a TTL on an existing key — pair with `incrCache` to build a counter
+ *  that expires (a rate-limit window), which `setCacheEx` can't do without
+ *  overwriting the count. */
+export async function expireCache(key: string, ttl: number): Promise<number> {
+	return redisClient.expire(key, ttl);
+}


### PR DESCRIPTION
Closes #149 · part of #139

## A run had no ceiling and left no trace

One agent call can legitimately spend 9 model calls and 27 minutes — `withRetry` (3) x `STRUCTURED_OUTPUT_ATTEMPTS` (3) x `MODEL_CALL_TIMEOUT_MS` (3 min) — and a build makes dozens of them. Nothing above that counted calls, tokens or wall clock, or stopped any of it. That is also why the empty-schema bug went unnoticed for so long: there was nothing to notice it *with*.

## 1. `RunBudget` — one object per run, checked before every call

`models/budget.ts` owns the deadline (10 min, `HARNESS_RUN_DEADLINE_MS`), the token ceiling (2M, `HARNESS_RUN_TOKEN_BUDGET`) and the run's usage accounting. The harness creates it and hands it to the agent wrapper, which is the only place model calls happen.

- Checked **before** each call, so a run that is out of budget stops instead of paying for one more answer it can't use.
- Per-call timeouts are clamped to the time left — a 3-minute call with 40 seconds of deadline left is pure waste.
- `RunBudgetExceededError` is never retried (`lib/retry.ts`) and gets its own branch in `explainErrorReason`, so the user is told the harness stopped the run, not that the provider misbehaved.
- `0` disables either ceiling.

Usage is booked on all four call paths. The native `withStructuredOutput` path needed `includeRaw: true` to get there — the underlying `AIMessage` is the only place its token counts exist. The returned `parsingError` is rethrown, which is exactly what `invoke` did before, so retries and the prompt fallback behave as they did.

## 2. Per-user rate limit on `send-message`

30 runs/hour (`HARNESS_RUNS_PER_HOUR`). The provider key belongs to the *project*, and `isConversationLocked` is per conversation — so any user with project access could open N conversations and drain the project's quota. Fails open on a Redis outage: a cache blip must not stop people using the product, and the per-run budget still bounds what any one request can spend.

## 3. Telemetry — "the reason this issue matters most"

Persisted on `agent_harness_runs.usage`, returned by list-messages, carried on the run-level `ended` event, and logged: model calls, retries, prompt / completion / **cached** tokens, model time, wall clock — each also broken down per agent.

## 4. OpenInference traces carry the same facts

Requested on top of the issue.

- A new `harness.run` span covers a whole run. Every span the LangChain tracer opens ends mid-stream, so there was nowhere to hang a run-level number. It is made the active span, so the graph's spans nest under it.
- It carries `llm.token_count.prompt|completion|total|prompt_details.cache_read`, `fluxify.run.{model_calls,retries,model_ms,elapsed_ms,usage_by_agent,status,failed_node}`, a `model.retry` event per re-ask (with the raw provider message), and — on failure — the **raw exception**, not the friendly `aiResponse` explanation.
- Per-call LLM spans now read usage from the message's `usage_metadata`. `llmOutput.tokenUsage` is the OpenAI shape and is simply **absent** for Anthropic, Google and Mistral, so those calls used to trace as free. They also record the cache-read count, which is the only way to see #148's prompt caching actually working, and `llm.model_name`.
- `endSpan` no longer assumes an `Error`: provider SDKs reject with plain objects (`{ code: 23 }`), and `recordException` would have kept none of it.

## Verification

`bun test` (ai-gateway) 155 pass · pre-commit 458 pass across 88 files · `tsgo --noEmit` clean on ai-gateway and server.

New tests cover the budget (ceilings, per-agent accounting, retries counted apart from calls, providers that report no usage), the wrapper (usage booked, refuses to call once spent, not retried, explained as a harness limit), the quota (429, TTL armed once, fails open), and the tracer's usage extraction.

Live-probed against a real provider (Mistral, `mistral-medium-latest`): native structured output **and** the tool loop both returned the right answer and booked their tokens (135/22 and 288/23, per agent), and a pre-spent budget refused before the call was made.

## Note on the migration

`drizzle-kit generate` also wanted to drop the `ai_chat_*` tables — drift from an earlier commit that removed them from the schema without generating a migration. Dropping live tables is not this change's call, so the migration carries only `ADD COLUMN usage`. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
