### PR TITLE
fix(harness): look up resources by exact id via an explicit searchBy mode

### DIFF
--- a/apps/ai-gateway/src/api/v1/find-resource/tests/find-resource.spec.ts
+++ b/apps/ai-gateway/src/api/v1/find-resource/tests/find-resource.spec.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, spyOn } from "bun:test";
-import { DbService, toPrefixTsQuery } from "../../../../harness/internal/dbService";
+import {
+	DbService,
+	idLookups,
+	INTEGER,
+	toPrefixTsQuery,
+	UUID,
+} from "../../../../harness/internal/dbService";
 import handleRequest from "../service";
 import { queryParamsSchema } from "../dto";
 
@@ -19,6 +25,26 @@ describe("toPrefixTsQuery", () => {
 		expect(toPrefixTsQuery("a & b | !c")).toBe("a:* & b:* & c:*");
 		expect(toPrefixTsQuery("'\"(")).toBeNull();
 		expect(toPrefixTsQuery("   ")).toBeNull();
+	});
+});
+
+describe("idLookups", () => {
+	it("matches an id the text search can never find", () => {
+		// `toPrefixTsQuery` turns this into hex prefix terms and compares them
+		// against the *name* column, so the id the planner handed the agent is
+		// the one input guaranteed to miss.
+		const id = "019f8c3d-1a2b-7c4d-8e5f-6a7b8c9d0e1f";
+		expect(toPrefixTsQuery(id)).not.toContain(id);
+		expect(idLookups([id], UUID)).toEqual([id]);
+		expect(idLookups(["users", "auth"])).toEqual(["users", "auth"]);
+	});
+
+	it("drops keywords a typed id column would reject", () => {
+		// Postgres errors on `uuid = 'auth'`, and the caller turns any error into
+		// an empty result — one ordinary word would blank the whole search.
+		expect(idLookups(["auth", "019f8c3d-1a2b-7c4d-8e5f-6a7b8c9d0e1f"], UUID))
+			.toEqual(["019f8c3d-1a2b-7c4d-8e5f-6a7b8c9d0e1f"]);
+		expect(idLookups(["DATABASE_URL", "42"], INTEGER)).toEqual(["42"]);
 	});
 });
 

--- a/apps/ai-gateway/src/harness/agents/discussion.ts
+++ b/apps/ai-gateway/src/harness/agents/discussion.ts
@@ -33,7 +33,7 @@ About Fluxify:
 Capabilities & Tools:
 1. "search_docs": Use this tool whenever the user asks about platform features, how a specific block works, or best practices. Pass a highly relevant keyword search query to retrieve documentation chunks.
 2. "get_route_details": Use this tool *only when necessary* if the user asks about the current route (the graph in canvas) they are viewing or working on — skip it if the "Current context" block below already gives you the details you need.
-3. "find_resource": Use this tool to find tables, databases, or API blocks within the workspace when the user queries about them. It also returns a route's or custom block's current canvas (its live block graph) when you pass its id. Skip it for the resource already named in "Current context" below.
+3. "find_resource": Use this tool to find tables, databases, or API blocks within the workspace when the user queries about them. It also returns a route's or custom block's current canvas (its live block graph) when you pass its id. If you already hold a resource's exact id, pass \`searchBy: "id"\` — the default keyword search matches names and descriptions and will never find an id. Skip it for the resource already named in "Current context" below.
 4. "get_artifact": Use this tool whenever the user asks what you built, changed, or implemented in an earlier run of this conversation ("what did you do in that route?", "why did you add that block?"). It returns the exact stored output of a past build.
 
 WHERE ARTIFACT IDS COME FROM:

--- a/apps/ai-gateway/src/harness/agents/planner.ts
+++ b/apps/ai-gateway/src/harness/agents/planner.ts
@@ -110,6 +110,7 @@ Other blocks may require secrets from **app configs**.
 **\`find_resource\`** — Search the database for existing resources (e.g., routes, app configs, integrations, custom blocks) relevant to the user's request. If a "Current context" block below already names the target resource, use that id directly and do NOT call this tool to re-find it — only use it for resources the current context doesn't cover.
 - Always search for the exact resource ID if you are modifying, updating, or deleting an existing resource that isn't already given to you.
 - Store the found resource IDs (e.g., \`routeId\`) and relevant details in the \`scratchpadNote\` so downstream agents have the exact IDs needed to perform their tasks. Do NOT guess IDs.
+- When you already hold an ID (from \`get_artifact\`, an earlier result, or the current context) and want that one record, pass \`searchBy: "id"\`. The default keyword search matches names and descriptions, so it will never find an ID.
 
 **\`get_artifact\`** — Reads back what an earlier run in this conversation actually built. Use it whenever the user's request refers to previous work ("change what you just built", "add auth to that route", "undo the block you added") instead of guessing from the summary text.
 - The ids come from tokens inside earlier assistant messages: \`:route{type="add" sub_artifact_id="abc123"}\` and \`:canvasChanges{parent_type="route" parent="..." artifact_id="def456"}\`. Pass the \`sub_artifact_id\` / \`artifact_id\` values verbatim; never invent one. A parent artifact id returns every output of that run.

--- a/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/promptHelpers.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/promptHelpers.ts
@@ -87,7 +87,7 @@ ${customBlocksTable}
    - Specify whether the canvas belongs to a \`route\` or \`custom_block\` in the \`targetType\` field.
    - Provide the exact ID in the \`targetId\` field.
 
-8. **Tools**: Use the 'search_docs' tool to understand specific block capabilities and how to write Javascript expressions. Use 'find_resource' to lookup integrations and existing route/custom block canvas (metadata.isNewRoute=true for new routes) — skip this for the canvas already summarized in "Current context" below. Use 'get_block_schemas' to fetch configuration schemas for any blocks you plan to use. Use 'get_agent_output' to fetch the configuration of a newly created route or custom block from a previous agent's output if it's not yet saved in the DB (the task description will provide the task IDs).
+8. **Tools**: Use the 'search_docs' tool to understand specific block capabilities and how to write Javascript expressions. Use 'find_resource' to lookup integrations and existing route/custom block canvas (metadata.isNewRoute=true for new routes) — skip this for the canvas already summarized in "Current context" below. When the task description already gives you a resource's exact ID, pass \`searchBy: "id"\`; the default keyword search will not find an ID. Use 'get_block_schemas' to fetch configuration schemas for any blocks you plan to use. Use 'get_agent_output' to fetch the configuration of a newly created route or custom block from a previous agent's output if it's not yet saved in the DB (the task description will provide the task IDs).
 
 ### Output Contract
 

--- a/apps/ai-gateway/src/harness/internal/dbService.ts
+++ b/apps/ai-gateway/src/harness/internal/dbService.ts
@@ -10,6 +10,7 @@ import {
 	agentHarnessSubArtifactsEntity,
 } from "@fluxify/server";
 import { eq, ilike, or, and, sql, inArray, type SQL } from "drizzle-orm";
+import type { PgColumn } from "drizzle-orm/pg-core";
 import { logger } from "@fluxify/common";
 import { FindResourceResult } from "../types";
 
@@ -48,6 +49,20 @@ export function toPrefixTsQuery(keyword: string): string | null {
 	return terms?.length ? terms.map((t) => `${t}:*`).join(" & ") : null;
 }
 
+export const UUID =
+	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+export const INTEGER = /^\d+$/;
+
+/**
+ * Which keywords are safe to compare against a typed id column. Postgres
+ * errors outright on `uuid = 'auth'` or `serial = 'auth'`, and the caller
+ * swallows errors into an empty result — so one ordinary word in the list
+ * would silently blank out the whole search.
+ */
+export function idLookups(keywords: string[], accept?: RegExp): string[] {
+	return accept ? keywords.filter((k) => accept.test(k)) : keywords;
+}
+
 export class DbService {
 	constructor() {}
 
@@ -73,16 +88,32 @@ export class DbService {
 		];
 	}
 
+	/**
+	 * An id the harness itself issued is the one input FTS is guaranteed to
+	 * miss: `toPrefixTsQuery` turns a uuid into hex prefix terms and matches
+	 * them against the *name* column. The planner hands ids to sub-agents in
+	 * task descriptions and writes them into `:resource{}` markup, so those
+	 * lookups came back empty and the agent told the user the resource was
+	 * gone. Match the id column directly alongside the text search.
+	 */
+	private idMatchers(
+		column: PgColumn,
+		keywords: string[],
+		accept?: RegExp,
+	): SQL[] {
+		return idLookups(keywords, accept).map((k) => sql`${column} = ${k}`);
+	}
+
 	async findRoutes(
 		projectId: string,
 		searchQuery: SearchInput,
 	): Promise<FindResourceResult[]> {
 		try {
-			const queries = this.tsQueries(searchQuery);
-			if (queries.length === 0) return [];
-
-			const matchers: SQL[] = [];
-			for (const q of queries) {
+			const matchers: SQL[] = this.idMatchers(
+				routesEntity.id,
+				this.normalizeKeywords(searchQuery),
+			);
+			for (const q of this.tsQueries(searchQuery)) {
 				matchers.push(
 					sql`to_tsvector('english', ${routesEntity.name}) @@ to_tsquery('english', ${q})`,
 				);
@@ -92,6 +123,7 @@ export class DbService {
 					sql`to_tsvector('english', translate(coalesce(${routesEntity.path}, ''), '/:-_', '    ')) @@ to_tsquery('english', ${q})`,
 				);
 			}
+			if (matchers.length === 0) return [];
 
 			const routes = await db
 				.select({
@@ -143,11 +175,12 @@ export class DbService {
 		searchQuery: SearchInput,
 	): Promise<FindResourceResult[]> {
 		try {
-			const queries = this.tsQueries(searchQuery);
-			if (queries.length === 0) return [];
-
-			const matchers: SQL[] = [];
-			for (const q of queries) {
+			const matchers: SQL[] = this.idMatchers(
+				appConfigEntity.id,
+				this.normalizeKeywords(searchQuery),
+				INTEGER,
+			);
+			for (const q of this.tsQueries(searchQuery)) {
 				matchers.push(
 					sql`to_tsvector('english', ${appConfigEntity.keyName}) @@ to_tsquery('english', ${q})`,
 				);
@@ -155,6 +188,7 @@ export class DbService {
 					sql`to_tsvector('english', coalesce(${appConfigEntity.description}, '')) @@ to_tsquery('english', ${q})`,
 				);
 			}
+			if (matchers.length === 0) return [];
 
 			const configs = await db
 				.select({
@@ -182,11 +216,12 @@ export class DbService {
 		searchQuery: SearchInput,
 	): Promise<FindResourceResult[]> {
 		try {
-			const queries = this.tsQueries(searchQuery);
-			if (queries.length === 0) return [];
-
-			const matchers: SQL[] = [];
-			for (const q of queries) {
+			const matchers: SQL[] = this.idMatchers(
+				integrationsEntity.id,
+				this.normalizeKeywords(searchQuery),
+				UUID,
+			);
+			for (const q of this.tsQueries(searchQuery)) {
 				matchers.push(
 					sql`to_tsvector('english', ${integrationsEntity.name}) @@ to_tsquery('english', ${q})`,
 				);
@@ -195,6 +230,7 @@ export class DbService {
 					sql`to_tsvector('english', coalesce(${integrationsEntity.group}, '') || ' ' || coalesce(${integrationsEntity.variant}, '') || ' ' || coalesce(${integrationsEntity.tags}, '')) @@ to_tsquery('english', ${q})`,
 				);
 			}
+			if (matchers.length === 0) return [];
 
 			const integrations = await db
 				.select({
@@ -229,7 +265,10 @@ export class DbService {
 			const keywords = this.normalizeKeywords(searchQuery);
 			if (keywords.length === 0) return [];
 
-			const matchers: SQL[] = [];
+			const matchers: SQL[] = this.idMatchers(
+				customBlocksListEntity.id,
+				keywords,
+			);
 			for (const k of keywords) {
 				matchers.push(ilike(customBlocksListEntity.name, `%${k}%`));
 				matchers.push(ilike(customBlocksListEntity.label, `%${k}%`));

--- a/apps/ai-gateway/src/harness/internal/dbService.ts
+++ b/apps/ai-gateway/src/harness/internal/dbService.ts
@@ -20,6 +20,14 @@ import { FindResourceResult } from "../types";
  */
 export type SearchInput = string | string[];
 
+/**
+ * `"id"` looks the input up as an exact resource id, `"keyword"` full-text
+ * searches names and descriptions. The caller says which — an id and a search
+ * term are different intents, and guessing from the string's shape hides that
+ * from both the model and the trace.
+ */
+export type SearchMode = "keyword" | "id";
+
 export interface SubArtifactRecord {
 	id: string;
 	artifactId: string;
@@ -77,8 +85,10 @@ export class DbService {
 		return [...seen];
 	}
 
-	/** Same, as prefix tsqueries — the FTS lookups all want these. */
-	private tsQueries(input: SearchInput): string[] {
+	/** Same, as prefix tsqueries — the FTS lookups all want these. Empty in id
+	 *  mode: an exact lookup should not also drag in fuzzy name matches. */
+	private tsQueries(input: SearchInput, mode: SearchMode): string[] {
+		if (mode === "id") return [];
 		return [
 			...new Set(
 				this.normalizeKeywords(input)
@@ -89,31 +99,38 @@ export class DbService {
 	}
 
 	/**
-	 * An id the harness itself issued is the one input FTS is guaranteed to
-	 * miss: `toPrefixTsQuery` turns a uuid into hex prefix terms and matches
-	 * them against the *name* column. The planner hands ids to sub-agents in
-	 * task descriptions and writes them into `:resource{}` markup, so those
-	 * lookups came back empty and the agent told the user the resource was
-	 * gone. Match the id column directly alongside the text search.
+	 * An id the harness itself issued is the one input FTS cannot resolve:
+	 * `toPrefixTsQuery` turns a uuid into hex prefix terms and matches them
+	 * against the *name* column. The planner hands ids to sub-agents in task
+	 * descriptions and writes them into `:resource{}` markup, so those lookups
+	 * came back empty and the agent told the user the resource was gone.
+	 *
+	 * Returned empty in keyword mode: the id column is only searched when the
+	 * caller asked for an id lookup, so a fuzzy search stays fuzzy and the
+	 * trace shows which of the two the agent meant.
 	 */
 	private idMatchers(
 		column: PgColumn,
 		keywords: string[],
+		mode: SearchMode,
 		accept?: RegExp,
 	): SQL[] {
+		if (mode !== "id") return [];
 		return idLookups(keywords, accept).map((k) => sql`${column} = ${k}`);
 	}
 
 	async findRoutes(
 		projectId: string,
 		searchQuery: SearchInput,
+		mode: SearchMode = "keyword",
 	): Promise<FindResourceResult[]> {
 		try {
 			const matchers: SQL[] = this.idMatchers(
 				routesEntity.id,
 				this.normalizeKeywords(searchQuery),
+				mode,
 			);
-			for (const q of this.tsQueries(searchQuery)) {
+			for (const q of this.tsQueries(searchQuery, mode)) {
 				matchers.push(
 					sql`to_tsvector('english', ${routesEntity.name}) @@ to_tsquery('english', ${q})`,
 				);
@@ -173,14 +190,16 @@ export class DbService {
 	async findAppConfigs(
 		projectId: string,
 		searchQuery: SearchInput,
+		mode: SearchMode = "keyword",
 	): Promise<FindResourceResult[]> {
 		try {
 			const matchers: SQL[] = this.idMatchers(
 				appConfigEntity.id,
 				this.normalizeKeywords(searchQuery),
+				mode,
 				INTEGER,
 			);
-			for (const q of this.tsQueries(searchQuery)) {
+			for (const q of this.tsQueries(searchQuery, mode)) {
 				matchers.push(
 					sql`to_tsvector('english', ${appConfigEntity.keyName}) @@ to_tsquery('english', ${q})`,
 				);
@@ -214,14 +233,16 @@ export class DbService {
 	async findIntegrations(
 		projectId: string,
 		searchQuery: SearchInput,
+		mode: SearchMode = "keyword",
 	): Promise<FindResourceResult[]> {
 		try {
 			const matchers: SQL[] = this.idMatchers(
 				integrationsEntity.id,
 				this.normalizeKeywords(searchQuery),
+				mode,
 				UUID,
 			);
-			for (const q of this.tsQueries(searchQuery)) {
+			for (const q of this.tsQueries(searchQuery, mode)) {
 				matchers.push(
 					sql`to_tsvector('english', ${integrationsEntity.name}) @@ to_tsquery('english', ${q})`,
 				);
@@ -260,6 +281,7 @@ export class DbService {
 	async findCustomBlocks(
 		projectId: string,
 		searchQuery: SearchInput,
+		mode: SearchMode = "keyword",
 	): Promise<FindResourceResult[]> {
 		try {
 			const keywords = this.normalizeKeywords(searchQuery);
@@ -268,11 +290,13 @@ export class DbService {
 			const matchers: SQL[] = this.idMatchers(
 				customBlocksListEntity.id,
 				keywords,
+				mode,
 			);
-			for (const k of keywords) {
+			for (const k of mode === "id" ? [] : keywords) {
 				matchers.push(ilike(customBlocksListEntity.name, `%${k}%`));
 				matchers.push(ilike(customBlocksListEntity.label, `%${k}%`));
 			}
+			if (matchers.length === 0) return [];
 
 			const customBlocks = await db
 				.select({

--- a/apps/ai-gateway/src/harness/tools/findResource.spec.ts
+++ b/apps/ai-gateway/src/harness/tools/findResource.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "bun:test";
+import { createFindResourceTool } from "./findResource";
+import type { DbService } from "../internal/dbService";
+import type { WorkflowMetadata } from "../types";
+
+const metadata = { projectId: "proj-1" } as WorkflowMetadata;
+
+const toolWith = (rows: any[], calls: any[][]) =>
+	createFindResourceTool(
+		{
+			findRoutes: async (...args: any[]) => {
+				calls.push(args);
+				return rows;
+			},
+		} as unknown as DbService,
+		metadata,
+	);
+
+describe("find_resource", () => {
+	it("forwards the caller's stated intent to the lookup", async () => {
+		// The mode is declared, not sniffed from the string's shape: the agent
+		// knows which it meant, and the trace should say so too.
+		const calls: any[][] = [];
+		await toolWith([], calls).invoke({
+			searchQuery: "019f8c3d-1a2b-7c4d-8e5f-6a7b8c9d0e1f",
+			resourceType: "route",
+			searchBy: "id",
+		});
+
+		expect(calls[0]).toEqual([
+			"proj-1",
+			["019f8c3d-1a2b-7c4d-8e5f-6a7b8c9d0e1f"],
+			"id",
+		]);
+	});
+
+	it("defaults to keyword search, including when the model sends null", async () => {
+		// The field is `.nullish()` per the schema rules, so null has to collapse
+		// to the same default an omitted field gets.
+		const calls: any[][] = [];
+		const tool = toolWith([], calls);
+		await tool.invoke({ searchQuery: "users", resourceType: "route" });
+		await tool.invoke({
+			searchQuery: "users",
+			resourceType: "route",
+			searchBy: null,
+		});
+
+		expect(calls.map((c) => c[2])).toEqual(["keyword", "keyword"]);
+	});
+
+	it("tells the agent an unknown id is not a cue to guess another one", async () => {
+		const out = await toolWith([], []).invoke({
+			searchQuery: "no-such-id",
+			resourceType: "route",
+			searchBy: "id",
+		});
+
+		expect(out).toContain("search by keyword");
+	});
+});

--- a/apps/ai-gateway/src/harness/tools/findResource.ts
+++ b/apps/ai-gateway/src/harness/tools/findResource.ts
@@ -2,7 +2,7 @@ import { tool } from "@langchain/core/tools";
 import { z } from "zod";
 import { logger } from "@fluxify/common";
 import type { WorkflowMetadata } from "../types";
-import type { DbService } from "../internal/dbService";
+import type { DbService, SearchMode } from "../internal/dbService";
 import { ResourceType } from "../types";
 
 /**
@@ -24,13 +24,15 @@ export const createFindResourceTool = (
 	metadata: WorkflowMetadata,
 ) => {
 	return tool(
-		async ({ searchQuery, resourceType, metadata: toolMetadata }) => {
+		async ({ searchQuery, resourceType, searchBy, metadata: toolMetadata }) => {
 			// Normalize to a keyword array; canvas/ID lookups use the first value.
 			const keywords = Array.isArray(searchQuery) ? searchQuery : [searchQuery];
 			const singleId = keywords[0] ?? "";
+			// `.nullish()` per the schema rules, so null has to collapse too.
+			const mode: SearchMode = searchBy === "id" ? "id" : "keyword";
 
 			logger.info(
-				`[Tools] Searching ${resourceType} for '${keywords.join(", ")}' in project ${metadata.projectId}`,
+				`[Tools] ${mode === "id" ? "Fetching" : "Searching"} ${resourceType} by ${mode} '${keywords.join(", ")}' in project ${metadata.projectId}`,
 			);
 
 			if (resourceType === "route_canvas") {
@@ -59,30 +61,39 @@ export const createFindResourceTool = (
 			let results: any[] = [];
 			switch (resourceType as ResourceType) {
 				case "route":
-					results = await dbService.findRoutes(metadata.projectId, keywords);
+					results = await dbService.findRoutes(
+						metadata.projectId,
+						keywords,
+						mode,
+					);
 					break;
 				case "app_config":
 					results = await dbService.findAppConfigs(
 						metadata.projectId,
 						keywords,
+						mode,
 					);
 					break;
 				case "integration":
 					results = await dbService.findIntegrations(
 						metadata.projectId,
 						keywords,
+						mode,
 					);
 					break;
 				case "custom_block":
 					results = await dbService.findCustomBlocks(
 						metadata.projectId,
 						keywords,
+						mode,
 					);
 					break;
 			}
 
 			if (!results || results.length === 0) {
-				return "No resources found.";
+				return mode === "id"
+					? "No resource with that ID. It may have been deleted, or the ID may belong to another project — search by keyword instead of guessing another ID."
+					: "No resources found.";
 			}
 
 			// Format as Markdown table
@@ -111,7 +122,13 @@ export const createFindResourceTool = (
 				searchQuery: z
 					.union([z.string(), z.array(z.string())])
 					.describe(
-						"One or more keywords to full-text search for (name, path, or description), or an exact resource ID if you already have one. Pass an array of related terms (e.g. ['user', 'auth', 'login']) to widen matching and avoid multiple retries. For 'route_canvas' and 'custom_block_canvas', pass a single resource ID.",
+						"What to look up. With searchBy='keyword' (default), one or more keywords matched against name, path and description — pass an array of related terms (e.g. ['user', 'auth', 'login']) to widen matching and avoid multiple retries. With searchBy='id', the exact resource ID. For 'route_canvas' and 'custom_block_canvas', pass a single resource ID.",
+					),
+				searchBy: z
+					.enum(["keyword", "id"])
+					.nullish()
+					.describe(
+						"'keyword' (default) fuzzy-searches names and descriptions. Use 'id' when you already have the resource's exact ID — from the plan, from your task description, or from an earlier tool result — and want that one record. An ID is not a keyword: fuzzy search will not find it.",
 					),
 				resourceType: z
 					.enum([

--- a/apps/ai-gateway/src/harness/tools/findResource.ts
+++ b/apps/ai-gateway/src/harness/tools/findResource.ts
@@ -111,7 +111,7 @@ export const createFindResourceTool = (
 				searchQuery: z
 					.union([z.string(), z.array(z.string())])
 					.describe(
-						"One or more keywords to full-text search for (name, path, or description). Pass an array of related terms (e.g. ['user', 'auth', 'login']) to widen matching and avoid multiple retries. For 'route_canvas' and 'custom_block_canvas', pass a single resource ID.",
+						"One or more keywords to full-text search for (name, path, or description), or an exact resource ID if you already have one. Pass an array of related terms (e.g. ['user', 'auth', 'login']) to widen matching and avoid multiple retries. For 'route_canvas' and 'custom_block_canvas', pass a single resource ID.",
 					),
 				resourceType: z
 					.enum([


### PR DESCRIPTION
Part of #139 · the by-id lookup deferred out of #165

## The bug

`find_resource` was full-text only. `toPrefixTsQuery` turns
`019f8c3d-1a2b-7c4d-8e5f-6a7b8c9d0e1f` into hex prefix terms and matches them
against the **name** and **path** columns — the id column was never searched at
all. So the one identifier the harness itself issues is the one input the tool
could not resolve.

That matters because ids are how the harness talks about resources internally:
the planner writes them into `:resource{identifier="…"}` and into the task
descriptions it hands sub-agents. The sub-agent looks the id up, gets
"No resources found", and either guesses a keyword or reports the user's own
resource as missing.

#165 fixed the user-facing half by resolving `:resource{}` mentions to
`route "List users" (id: …)`, so a name reaches the search. The
planner → sub-agent path still passes a bare id.

## The change

**`searchBy: "keyword" | "id"`** — the caller states which lookup it wants.

Matching on id shape instead would have left one tool quietly doing two jobs:
the prompt sells `find_resource` as fuzzy search, so a model holding an id has
no reason to believe passing it will work, and the log line and trace span read
identically either way. Declaring the mode fixes both — the model is told the
capability exists, and a run that resolved an id is now distinguishable from
one that searched for a name.

- `"id"` matches the id column only. `"keyword"` (default) is unchanged fuzzy
  search and does not probe the id column at all — a fuzzy search stays fuzzy.
- Typed id columns are guarded by shape (`uuid`, `serial`): Postgres errors
  outright on `uuid = 'auth'`, and these methods catch and return `[]`, so an
  unguarded matcher would let one bad keyword blank the entire search rather
  than merely miss. `routes` and `custom_blocks` have `varchar` ids and need no
  guard.
- An id lookup that finds nothing says so specifically and points the agent
  back to keyword search, rather than leaving it to guess another id.
- The three prompts that document the tool (planner, discussion, block builder)
  say when to reach for `"id"`.

Values go through drizzle's `sql` template as bound parameters (`$1`), same as
the existing `to_tsquery` clauses — no string concatenation into SQL.

## Verification

`bun test` 160 pass in ai-gateway · pre-commit 463 pass across 89 files ·
`tsgo --noEmit` clean · FTA gate passing.

New `findResource.spec.ts` covers the mode reaching the lookup, `null`
collapsing to the keyword default (the field is `.nullish()` per the schema
rules), and the not-found message. `idLookups` covers the column guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
