### PR TITLE
fix(harness): restore searchBy dropped by the #165/#166 merge

### DIFF
--- a/apps/ai-gateway/src/harness/tools/findResource.ts
+++ b/apps/ai-gateway/src/harness/tools/findResource.ts
@@ -24,7 +24,7 @@ export const createFindResourceTool = (
 	metadata: WorkflowMetadata,
 ) => {
 	return fencedTool(
-		async ({ searchQuery, resourceType, metadata: toolMetadata }) => {
+		async ({ searchQuery, resourceType, searchBy, metadata: toolMetadata }) => {
 			// Normalize to a keyword array; canvas/ID lookups use the first value.
 			const keywords = Array.isArray(searchQuery) ? searchQuery : [searchQuery];
 			const singleId = keywords[0] ?? "";


### PR DESCRIPTION
Fixes `main` — one line, broken by the conflict resolution between #165 and #166.

## What happened

Both PRs touched the same call in `findResource.ts`: #165 wrapped it in
`fencedTool`, #166 added the `searchBy` parameter. The resolution kept both
sides' *bodies* — `fencedTool(` from #165, `mode` from #166 — but the
destructuring pattern came through without `searchBy`:

```ts
async ({ searchQuery, resourceType, metadata: toolMetadata }) => {
	…
	const mode: SearchMode = searchBy === "id" ? "id" : "keyword"; // undefined
```

## Why it matters more than the failing lint job

`searchBy` is a free identifier now, so `find_resource` throws a
`ReferenceError` before it does anything — on every call, for every agent
that has the tool. `tsgo --noEmit` on current `main`:

```
src/harness/tools/findResource.ts(32,29): error TS2304: Cannot find name 'searchBy'.
```

and `findResource.spec.ts` fails 3/3.

Nothing else was lost in the merge — the schema field, the four call sites and
the not-found message all came through intact.

## After

`tsgo --noEmit` clean · `bun test` 177 pass in ai-gateway · pre-commit 480 pass
across 91 files.

The pre-commit hook would have caught this, but a conflict resolved in the
GitHub web editor never runs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
