### PR TITLE
fix(harness): stop persistence failures from destroying a successful run

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -145,6 +145,23 @@ Also: native `withStructuredOutput` failures are caught and fall through to the 
 2. **Hide Save Button in Readonly Mode:** The header Save button must be conditionally rendered (`{!readOnly && <Button ...>Save</Button>}`) so no save trigger is accessible in read-only mode.
 3. **Keep Elements Selectable:** Set `elementsSelectable={true}` on `<ReactFlow>` so users can still select nodes and open side panels to inspect block configurations in read-only mode, while keeping `nodesDraggable={!readOnly}`, `nodesConnectable={!readOnly}`, and `deleteKeyCode={null}` disabled.
 
+### Resolving a Merge Conflict in the GitHub Web Editor Ships Broken Code
+**Issue:** `main` broke after two PRs that touched the same function were merged — `find_resource` threw `ReferenceError: searchBy is not defined` on every call, for every agent holding the tool. CI reported only a failing lint job.
+**Cause:** The conflict was resolved in GitHub's web editor. That path runs **no** local hooks, so the pre-commit chain (lint → FTA analyze → selective tests) never executed. The resolution kept both sides' *bodies* — one PR's wrapper, the other's new logic — but dropped an identifier from the destructuring pattern the second PR had added. Nothing on the server catches a free identifier.
+**Fix & Best Practices:**
+1. **Never resolve a conflict in the GitHub web editor when both sides touched the same function.** Pull the branch, resolve locally, let the pre-commit hook run, then push.
+2. After any merge you resolved by hand, run `bun run --cwd apps/<app> lint` (`tsgo --noEmit`) on `main` before assuming it is green. A failing lint job may be hiding a runtime break, not a style nit.
+3. When two PRs edit one function, expect the conflict to land on the *signature*: verify every parameter each side added still exists in the merged destructuring/argument list.
+
+### Drizzle `sql` Template — Interpolation Is Parameterized, `sql.raw()` Is Not
+**Issue:** Reviewing whether user/LLM-supplied search terms in `harness/internal/dbService.ts` could be injected.
+**Cause/behaviour (verified in `node_modules`, not assumed):** In the `sql` tagged template, literal pieces become `StringChunk`s and every **interpolated value** falls through to `escapeParam(idx, chunk)` → a `$1`-style bound parameter. A `Column` interpolates as an escaped identifier. `sql.raw()` is the **only** path that concatenates text into the query.
+**Rules:**
+1. `sql\`${column} = ${userValue}\`` is safe — never hand-quote or hand-escape the value, that only creates a double-escaping bug.
+2. Treat any `sql.raw()` on a request-derived string as an injection finding.
+3. Two things parameterization does **not** cover: values that are *syntax* for another parser (a `to_tsquery` string is bound safely but can still be a malformed tsquery → a runtime error), and `ilike(col, \`%${k}%\`)`, where user `%`/`_` act as LIKE wildcards. Bound ≠ harmless — bound means "cannot escape the value slot".
+4. Postgres also errors outright on a type mismatch against a typed id column (`uuid = 'auth'`, `serial = 'auth'`). Where the caller swallows errors into `[]`, one ordinary keyword blanks the entire search — an availability bug, so guard id comparisons with a shape check before they reach the query.
+
 ---
 
 ## Documentation Writing Rules

--- a/apps/ai-gateway/src/harness/agents/summarizer.spec.ts
+++ b/apps/ai-gateway/src/harness/agents/summarizer.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "bun:test";
+import { SummarizerAgent } from "./summarizer";
+import type { GlobalGraphState } from "../types";
+
+function stateWith(harnessService: any): GlobalGraphState {
+	return {
+		orchestratorState: {
+			tasks: [{ id: "t-1", title: "Create route", status: "completed" }],
+			subAgentResults: { "t-1": { action: "create", data: { path: "/x" } } },
+		},
+		internal: {
+			harnessService,
+			metadata: { runId: "run-1" },
+		},
+		agentWrapper: {
+			invokeAgent: async () => ({ content: "Built the route." }),
+		},
+	} as unknown as GlobalGraphState;
+}
+
+describe("summarizer artifact persistence", () => {
+	it("still returns the summary when the artifact write fails", async () => {
+		// The build's results are already applied by the time this node runs —
+		// throwing here would fail the whole run and lose them.
+		const result = await new SummarizerAgent(
+			stateWith({
+				createArtifact: async () => {
+					throw new Error("connection terminated unexpectedly");
+				},
+			}),
+		).execute();
+
+		expect(result.summarizerState?.markdown).toBe("Built the route.");
+		expect(result.summarizerState?.artifactId).toBeUndefined();
+	});
+
+	it("drops the chip for a sub-artifact that failed to persist", async () => {
+		// A token whose id was never written would render a broken chip, so the
+		// summary degrades to prose rather than referencing it.
+		const result = await new SummarizerAgent(
+			stateWith({
+				createArtifact: async () => "art-1",
+				createSubArtifact: async () => {
+					throw new Error("deadlock detected");
+				},
+			}),
+		).execute();
+
+		expect(result.summarizerState?.markdown).toBe("Built the route.");
+	});
+});

--- a/apps/ai-gateway/src/harness/agents/summarizer.ts
+++ b/apps/ai-gateway/src/harness/agents/summarizer.ts
@@ -1,3 +1,4 @@
+import { logger } from "@fluxify/common";
 import { BaseAgent } from "./base";
 import { type GlobalGraphState, AgentNode } from "../types";
 import { dispatchAgentEvent } from "../callbacks";
@@ -58,73 +59,83 @@ export class SummarizerAgent extends BaseAgent {
 		const changes: ChangeRef[] = [];
 		let artifactId: string | undefined;
 
-		if (harnessService && runId) {
-			artifactId = await harnessService.createArtifact({ runId });
-			let newRouteSubArtifactId: string | undefined;
+		// A DB blip here used to throw out of the last node in the graph and fail
+		// the whole run — losing a build whose results are sitting in state. The
+		// chips are a nicety; a summary without them beats no summary at all.
+		try {
+			if (harnessService && runId) {
+				artifactId = await harnessService.createArtifact({ runId });
+				let newRouteSubArtifactId: string | undefined;
 
-			for (const task of tasks) {
-				// A failed task's last (rejected) output is still sitting in
-				// subAgentResults — persisting it would show the user a chip for work
-				// that was never applied.
-				if (task.status === "failed") continue;
-				const result = (results as Record<string, any>)[task.id];
-				if (!result) continue;
+				for (const task of tasks) {
+					// A failed task's last (rejected) output is still sitting in
+					// subAgentResults — persisting it would show the user a chip for work
+					// that was never applied.
+					if (task.status === "failed") continue;
+					const result = (results as Record<string, any>)[task.id];
+					if (!result) continue;
 
-				if (isRouteConfigResult(result)) {
-					const type =
-						result.action === "create"
-							? "add"
-							: result.action === "delete"
-								? "delete"
-								: "changes";
-					const subId = await harnessService.createSubArtifact({
-						artifactId,
-						runId,
-						subAgentId: task.id,
-						kind: "route",
-						action: type,
-						payload: result,
-					});
-					if (type === "add") newRouteSubArtifactId = subId;
-					const label =
-						`${result.data?.method ?? ""} ${result.data?.path ?? task.title}`.trim();
-					changes.push({
-						label: label || task.title,
-						actionLabel: type,
-						agentRole: "Route configuration",
-						token: `:route{type="${type}" sub_artifact_id="${subId}"}`,
-					});
-				} else if (isBlockBuilderResult(result)) {
-					const subId = await harnessService.createSubArtifact({
-						artifactId,
-						runId,
-						subAgentId: task.id,
-						kind: "canvas",
-						action: "changes",
-						payload: result,
-					});
-					let parentType: string;
-					let parentRef: string;
-					if (result.targetType === "route" && result.targetId) {
-						parentType = "route";
-						parentRef = result.targetId;
-					} else if (result.targetType === "custom_block" && result.targetId) {
-						parentType = "custom_block";
-						parentRef = result.targetId;
-					} else {
-						// No existing DB record => the canvas belongs to a route created
-						// in this run (parent_type=artifact references the route sub-artifact).
-						parentType = "artifact";
-						parentRef = newRouteSubArtifactId ?? subId;
+					if (isRouteConfigResult(result)) {
+						const type =
+							result.action === "create"
+								? "add"
+								: result.action === "delete"
+									? "delete"
+									: "changes";
+						const subId = await harnessService.createSubArtifact({
+							artifactId,
+							runId,
+							subAgentId: task.id,
+							kind: "route",
+							action: type,
+							payload: result,
+						});
+						if (type === "add") newRouteSubArtifactId = subId;
+						const label =
+							`${result.data?.method ?? ""} ${result.data?.path ?? task.title}`.trim();
+						changes.push({
+							label: label || task.title,
+							actionLabel: type,
+							agentRole: "Route configuration",
+							token: `:route{type="${type}" sub_artifact_id="${subId}"}`,
+						});
+					} else if (isBlockBuilderResult(result)) {
+						const subId = await harnessService.createSubArtifact({
+							artifactId,
+							runId,
+							subAgentId: task.id,
+							kind: "canvas",
+							action: "changes",
+							payload: result,
+						});
+						let parentType: string;
+						let parentRef: string;
+						if (result.targetType === "route" && result.targetId) {
+							parentType = "route";
+							parentRef = result.targetId;
+						} else if (result.targetType === "custom_block" && result.targetId) {
+							parentType = "custom_block";
+							parentRef = result.targetId;
+						} else {
+							// No existing DB record => the canvas belongs to a route created
+							// in this run (parent_type=artifact references the route sub-artifact).
+							parentType = "artifact";
+							parentRef = newRouteSubArtifactId ?? subId;
+						}
+						changes.push({
+							label: task.title,
+							actionLabel: "changes",
+							agentRole: "Canvas builder",
+							token: `:canvasChanges{parent_type="${parentType}" parent="${parentRef}" artifact_id="${subId}"}`,
+						});
 					}
-					changes.push({
-						label: task.title,
-						actionLabel: "changes",
-						agentRole: "Canvas builder",
-						token: `:canvasChanges{parent_type="${parentType}" parent="${parentRef}" artifact_id="${subId}"}`,
-					});
 				}
 			}
+		} catch (error) {
+			logger.error("[Summarizer] Failed to persist run artifacts", {
+				runId,
+				error,
+			});
 		}
 
 		const changesTable = changes.length

--- a/apps/ai-gateway/src/harness/callbacks.spec.ts
+++ b/apps/ai-gateway/src/harness/callbacks.spec.ts
@@ -8,6 +8,7 @@ import type { RedisService } from "./internal/redisService";
 /** Collects every event the callbacks emit, in order. */
 function harness() {
 	const events: HarnessStreamEvent[] = [];
+	const liveStateSaves: any[] = [];
 	const callbacks = new HarnessCallbacks({
 		state: {},
 		conversationId: "conv-1",
@@ -15,7 +16,9 @@ function harness() {
 		userId: null, // skips the NATS publish
 		harnessService: {
 			upsertStep: async () => ({ id: "step-1" }),
-			saveLiveState: async () => undefined,
+			saveLiveState: async (input: any) => {
+				liveStateSaves.push(input);
+			},
 		} as unknown as HarnessService,
 		redisService: {
 			appendEvent: async (event: HarnessStreamEvent) => {
@@ -23,7 +26,7 @@ function harness() {
 			},
 		} as unknown as RedisService,
 	});
-	return { callbacks, events };
+	return { callbacks, events, liveStateSaves };
 }
 
 describe("harness event contract", () => {
@@ -110,6 +113,29 @@ describe("harness event contract", () => {
 			nodeStatus: "running",
 			executionType: "agent",
 			plainTextMessage: "routing query",
+		});
+	});
+
+	it("saves live state once per node end, and only for nodes a resume reads", async () => {
+		// The snapshot carries every canvas the run has produced, so writing it on
+		// both ends of all ~20 nodes was load nobody read back.
+		const { callbacks, liveStateSaves } = harness();
+		const task = { id: "t-7", title: "T", status: "running" } as any;
+
+		await callbacks.onBefore(AgentNode.PLANNER, { input: {} });
+		await callbacks.onAfter(AgentNode.PLANNER, { output: {} });
+		await callbacks.onBefore(AgentNode.BLOCK_BUILDER, {
+			input: { activeTask: task },
+		});
+		await callbacks.onAfter(AgentNode.BLOCK_BUILDER, {
+			input: { activeTask: task },
+			output: {},
+		});
+
+		expect(liveStateSaves).toHaveLength(1);
+		expect(liveStateSaves[0]).toMatchObject({
+			runId: "run-1",
+			currentState: "running",
 		});
 	});
 

--- a/apps/ai-gateway/src/harness/callbacks.ts
+++ b/apps/ai-gateway/src/harness/callbacks.ts
@@ -40,6 +40,13 @@ const GRAPH_NODES: ReadonlySet<string> = new Set<string>(
 	Object.values(AgentNode),
 );
 
+/** Nodes whose accumulated state a later run pass actually reads back — i.e.
+ *  the ones a HITL resume rehydrates from. See `onAfter`. */
+const RESUMABLE_NODES: ReadonlySet<string> = new Set<string>([
+	AgentNode.PLANNER,
+	AgentNode.HUMAN_IN_THE_LOOP,
+]);
+
 export interface HarnessCallbackContext {
 	state: Partial<GlobalGraphState>;
 	conversationId: string;
@@ -201,7 +208,7 @@ export class HarnessCallbacks {
 		const input = (eventData?.input ?? {}) as Partial<GlobalGraphState>;
 		const taskId = input.activeTask?.id;
 
-		const step = await this.harnessService.upsertStep(
+		await this.harnessService.upsertStep(
 			{
 				runId: this.runId,
 				conversationId: this.conversationId,
@@ -211,17 +218,6 @@ export class HarnessCallbacks {
 				status: "running",
 			},
 			true, // background
-		);
-
-		await this.harnessService.saveLiveState(
-			{
-				runId: this.runId,
-				conversationId: this.conversationId,
-				currentState: "running",
-				activeStepId: step?.id,
-				graphState: this.mergedState,
-			},
-			true,
 		);
 
 		this.emit(
@@ -254,15 +250,23 @@ export class HarnessCallbacks {
 			true,
 		);
 
-		await this.harnessService.saveLiveState(
-			{
-				runId: this.runId,
-				conversationId: this.conversationId,
-				currentState: "running",
-				graphState: this.mergedState,
-			},
-			true,
-		);
+		// Only a resumable node's state is ever read back: `loadWorkingMemory` has
+		// exactly one caller — rehydrating a run that parked for plan review — and
+		// every terminal path (finalize / interrupt / fail) saves the full state
+		// itself. Writing the whole accumulated state (every canvas the run has
+		// produced, growing all run) twice per node was load nobody read, and
+		// `awaitAllPendingBackgroundTasks` waits for all of it before the run ends.
+		if (RESUMABLE_NODES.has(node)) {
+			await this.harnessService.saveLiveState(
+				{
+					runId: this.runId,
+					conversationId: this.conversationId,
+					currentState: "running",
+					graphState: this.mergedState,
+				},
+				true,
+			);
+		}
 
 		const payload = this.buildPayload(node, output, input);
 		this.emit(

--- a/apps/ai-gateway/src/harness/index.ts
+++ b/apps/ai-gateway/src/harness/index.ts
@@ -331,7 +331,18 @@ export class FluxifyHarness {
 			);
 
 			await callbacks.flush();
-			await this.finalizeRun(ctx, harnessService, userId, budget, finalState);
+			// The graph is already done here. `finalizeRun` is bookkeeping, and a DB
+			// blip inside it must not fall into the catch below and re-brand a
+			// finished run as failed — the user's build landed either way.
+			try {
+				await this.finalizeRun(ctx, harnessService, userId, budget, finalState);
+			} catch (error) {
+				logger.error("[FluxifyHarness] Failed to finalize a completed run", {
+					conversationId: ctx.conversationId,
+					runId: ctx.runId,
+					error,
+				});
+			}
 		} catch (error) {
 			await callbacks.flush().catch(() => {});
 


### PR DESCRIPTION
Closes #151. Three independent spots where a database hiccup cost the user a build that had already succeeded.

## B6 — an artifact write failure lost the whole build

`summarizer.ts` called `createArtifact` / `createSubArtifact` with no try/catch, and `HarnessService` deliberately does not swallow for those two (unlike every other method there). It runs in the **last** node of the graph, so a transient error threw out to the graph catch, hit `failRun`, and discarded results that were sitting in state and already applied.

Now wrapped. The chips are a nicety; a summary without them beats no summary. Whatever persisted before the failure keeps its chip — those ids are real.

## B7 — `finalizeRun` could turn a success into a failure

It ran inside the main `try`, and `updateRun` rethrows on the non-background path. A DB blip while writing the terminal row landed in that same catch and re-branded a completed run `failed`. Its failure is now logged, not fatal.

## L3 — live-state writes on the hot path

`saveLiveState` ran on **both** `onBefore` and `onAfter` of every node, and each write serialises the whole accumulated state — including `orchestratorState.subAgentResults`, i.e. every canvas the run has produced. Two growing writes per node, 20+ nodes per run, and `awaitAllPendingBackgroundTasks` waits for all of it before the run can end.

`loadWorkingMemory` has exactly one caller — rehydrating a run that parked for plan review — and every terminal path (finalize / interrupt / fail) saves the full state itself. So the per-node write is now `onAfter` only, and only for the nodes a resume actually reads back.

Incidental: the `activeStepId` that `onBefore` passed was always `undefined` — `upsertStep` runs in background mode there and returns `null`.

## Not regressed

`isUserInterrupt(error) && abortController.signal.aborted` is untouched — provider-side timeouts surface as `AbortError` too, and that `&&` is what keeps them classified as failures.

## Checks

New `summarizer.spec.ts` (2): the summary still ships when `createArtifact` throws, and when a `createSubArtifact` throws mid-loop. Extended `callbacks.spec.ts` (1): exactly one live-state save across a planner and a block-builder node pair.

`bun test` 180 pass in ai-gateway · pre-commit 483 pass across 92 files · `tsgo --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
