### PR TITLE
fix(harness): name the failed dependency by title, not task id

### DIFF
--- a/apps/ai-gateway/src/harness/agents/orchestrator.spec.ts
+++ b/apps/ai-gateway/src/harness/agents/orchestrator.spec.ts
@@ -51,13 +51,15 @@ describe("OrchestratorAgent", () => {
 
 	it("fails dependents of a failed task instead of dispatching them", async () => {
 		const a = task("a");
+		a.title = "Create the orders route";
 		a.status = "failed";
 		const b = task("b", ["a"]);
 		const c = task("c", ["b"]); // transitive
 
 		expect(await dispatch([a, b, c])).toEqual([]);
 		expect([b.status, c.status]).toEqual(["failed", "failed"]);
-		expect(b.supervisorReviews).toContain("a");
+		// The summarizer shows this to the user, so it names the task, not its id.
+		expect(b.supervisorReviews).toContain("Create the orders route");
 	});
 
 	it("still dispatches siblings of a failed task", async () => {

--- a/apps/ai-gateway/src/harness/agents/orchestrator.ts
+++ b/apps/ai-gateway/src/harness/agents/orchestrator.ts
@@ -47,7 +47,10 @@ export class OrchestratorAgent extends BaseAgent {
 				);
 				if (!failedDep) continue;
 				task.status = "failed";
-				task.supervisorReviews = `Skipped — it depends on task ${failedDep}, which failed.`;
+				// The summarizer puts this reason in front of the user verbatim, so
+				// name the dependency the way the plan did — a raw task id means
+				// nothing to someone who never saw the task graph.
+				task.supervisorReviews = `Skipped — it depends on "${byId.get(failedDep)?.title ?? failedDep}", which failed.`;
 				changed = true;
 			}
 		}


### PR DESCRIPTION
When a task fails, the orchestrator cascades the failure to its dependents and writes a skip reason. That reason lands verbatim in the summarizer's "Parts that did NOT get done" section, which the summarizer is instructed to relay to the user — so the user was being told their work was skipped because of `task t-3`, an id they have never seen.

Now it names the dependency the way the plan did: `Skipped — it depends on "Create the orders route", which failed.`

Existing orchestrator spec tightened: the helper set `title === id`, so it could not tell the two apart. It now gives the failed task a distinct title and asserts on that.

pre-commit: 483 pass across 92 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)