### PR TITLE
fix(harness): route config agent now outputs the route name

### DIFF
--- a/apps/ai-gateway/src/harness/agents/sub-agents/routeConfig.spec.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/routeConfig.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "bun:test";
+import { validateAgentOutput } from "./routeConfig";
+import type { GlobalGraphState, SubAgentResult } from "../../types";
+
+const check = (result: SubAgentResult) =>
+	validateAgentOutput(result, "t-1", {} as GlobalGraphState);
+
+describe("routeConfig validateAgentOutput", () => {
+	it("rejects a create that forgot the route name", () => {
+		expect(
+			check({ action: "create", data: { method: "POST", path: "/orders" } }),
+		).toContain("data.name");
+		// Whitespace is not a name either.
+		expect(
+			check({ action: "create", data: { name: "  ", path: "/orders" } }),
+		).toContain("data.name");
+	});
+
+	it("accepts a create that names the route", () => {
+		expect(
+			check({
+				action: "create",
+				data: { name: "Create Order", method: "POST", path: "/orders" },
+			}),
+		).toBeNull();
+	});
+
+	it("does not force a name on update-partial or delete", () => {
+		expect(
+			check({ action: "update-partial", routeId: "r-1", data: { path: "/o" } }),
+		).toBeNull();
+		expect(check({ action: "delete", routeId: "r-1" })).toBeNull();
+	});
+});

--- a/apps/ai-gateway/src/harness/agents/sub-agents/routeConfig.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/routeConfig.ts
@@ -16,6 +16,12 @@ const routeConfigSchema = z.object({
 		.describe("The UUID of the route. Leave empty for create action."),
 	data: z
 		.object({
+			name: z
+				.string()
+				.nullish()
+				.describe(
+					"Short human-readable name for the route, e.g. 'Create Order'. Required when creating.",
+				),
 			method: z.string().nullish(),
 			path: z.string().nullish(),
 			bodySchema: z.any().nullish(),
@@ -128,7 +134,9 @@ Fluxify uses a specific JSON format for schemas. DO NOT output standard JSON Sch
 2. If you need to search for documentation about Javascript APIs, Scripting, or other Fluxify concepts, use the \`search_docs\` tool provided to you.
 3. If you need to know the details of an existing route configuration to perform an update or deletion, use the \`get_route_details\` tool provided to you — unless the "Current context" block below already describes that exact route.
 4. Determine if the action is \`create\`, \`delete\`, or \`update-partial\`.
-5. If creating or updating a route, define the \`method\`, \`path\`, and relevant schemas in the \`data\` object.
+5. If creating or updating a route, define the \`name\`, \`method\`, \`path\`, and relevant schemas in the \`data\` object.
+   - \`name\` is REQUIRED for \`create\`. It is the label the user sees in the routes list, so write it in Title Case describing the operation — "Create Order", "List Users", "Delete Product By Id". Never leave it empty, never emit the path as the name.
+   - For \`update-partial\`, only include \`name\` if the task actually asks to rename the route.
 6. **DO NOT generate a UUID for new routes.** Leave \`routeId\` empty/undefined when the action is \`create\`. The system will generate it.
 7. If the action is \`update-partial\` or \`delete\`, you MUST include the \`routeId\` extracted from the task context.
 8. Make sure to generate the schemas (\`bodySchema\`, \`querySchema\`, \`paramsSchema\`) exactly following the custom \`ValidationSchemaZod\` format above. 
@@ -209,6 +217,13 @@ export const validateAgentOutput: import("../../types").AgentOutputValidator = (
 
 	if (typedResult.action !== "delete" && !typedResult.data) {
 		return `Action '${typedResult.action}' requires a 'data' object with configuration details.`;
+	}
+
+	// The routes list shows `name`, not the path. A create that omits it lands a
+	// nameless row the user has to go and fix by hand, so bounce it back here
+	// rather than let the supervisor pass it.
+	if (typedResult.action === "create" && !typedResult.data?.name?.trim()) {
+		return "Action 'create' requires a non-empty 'data.name' — a short Title Case label for the route, e.g. 'Create Order'.";
 	}
 
 	return null; // Valid

--- a/apps/ai-gateway/src/harness/types.ts
+++ b/apps/ai-gateway/src/harness/types.ts
@@ -125,6 +125,7 @@ export interface RouteConfigAgentResult {
 	action: "create" | "delete" | "update-partial";
 	routeId?: string;
 	data?: {
+		name?: string;
 		method?: string;
 		path?: string;
 		bodySchema?: any;


### PR DESCRIPTION
## Why

The route config agent generated everything a route needs — method, path, body/query/params schemas — but never a `name`. Routes have a `name` column and it is what the routes list shows, so every AI-created route landed unnamed and the user had to go rename it by hand.

## What

- `name` added to the agent's structured output schema (`data.name`) and to `RouteConfigAgentResult`.
- Prompt step 5 now demands it on `create`: a short Title Case label describing the operation ("Create Order", "List Users"), explicitly not the path. On `update-partial` it is only sent when the task actually asks for a rename.
- `validateAgentOutput` rejects a `create` whose `data.name` is missing or blank, so the supervisor bounces the task back for a retry instead of letting a nameless route through.

## Checks

`bun test apps/ai-gateway/src/harness/agents/sub-agents/routeConfig.spec.ts` (new, 3 tests) and the full pre-commit chain: lint clean, 486 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
