### PR TITLE
feat(rpc): define ops subjects, pick codec by measurement, guard max payload

### DIFF
--- a/apps/server/src/db/natsRpc.ts
+++ b/apps/server/src/db/natsRpc.ts
@@ -20,6 +20,16 @@ export type RpcRequest<T> = {
 	payload: T;
 };
 
+/**
+ * One responder per subject. Payload shapes are defined by each operation's
+ * own module; this file only owns the envelope around them.
+ */
+export const RPC_SUBJECTS = {
+	route: "fluxify.ops.route",
+	customBlock: "fluxify.ops.custom_block",
+	canvas: "fluxify.ops.canvas",
+} as const;
+
 export type RpcErrorCode =
 	| "VALIDATION_FAILED"
 	| "NOT_FOUND"
@@ -27,6 +37,7 @@ export type RpcErrorCode =
 	| "CONFLICT"
 	| "FORBIDDEN"
 	| "TIMEOUT"
+	| "PAYLOAD_TOO_LARGE"
 	| "INTERNAL";
 
 export type RpcResponse<T> =
@@ -36,10 +47,41 @@ export type RpcResponse<T> =
 			error: { code: RpcErrorCode; message: string; details?: unknown };
 	  };
 
-// Canvas payloads are the bulky ones. JSON is what the whole stack already
-// speaks and what makes a stuck request readable in `nats sub`; swap the codec
-// here (one place) if a measured round trip ever says otherwise.
+// Canvas payloads are the bulky ones. Measured round trip (encode+decode) on a
+// synthetic canvas, 200 iterations:
+//
+//   blocks/edges   JSON          JSON+gzip
+//   50/80          0.29ms  49KiB  0.37ms   2KiB
+//   250/400        1.22ms 245KiB  1.87ms   7KiB
+//   1000/1600      5.45ms 985KiB  8.05ms  29KiB
+//
+// Time is irrelevant next to the DB transaction on the other end; *size* is
+// not — plain JSON reaches NATS's 1MiB `max_payload` at around a thousand
+// blocks and the request is then dropped by the server, not by us. So: JSON,
+// gzipped once it gets big. (The bench data is repetitive, so the real ratio
+// will be worse than 33x — but even 5x moves the ceiling out of reach.)
+//
+// Small messages stay literally plain JSON on the wire, so `nats sub` is still
+// readable when something is stuck. Gzip's magic bytes tell the two apart, so
+// no framing byte is needed.
 const codec = JSONCodec<unknown>();
+const COMPRESS_ABOVE_BYTES = 32 * 1024;
+/** NATS server default is 1MiB; leave headroom for subject and headers. */
+export const MAX_PAYLOAD_BYTES = 1_000_000;
+
+// nats types its buffers as Uint8Array<ArrayBufferLike>, Bun's zlib wants
+// Uint8Array<ArrayBuffer>. Same bytes; the cast is the whole difference.
+const bytes = (b: Uint8Array) => b as Uint8Array<ArrayBuffer>;
+
+function encode(value: unknown): Uint8Array {
+	const raw = codec.encode(value);
+	return raw.length > COMPRESS_ABOVE_BYTES ? Bun.gzipSync(bytes(raw)) : raw;
+}
+
+function decode<T>(data: Uint8Array): T {
+	const gzipped = data[0] === 0x1f && data[1] === 0x8b;
+	return codec.decode(gzipped ? Bun.gunzipSync(bytes(data)) : data) as T;
+}
 
 /** default request deadline; a canvas apply is a transaction, not a lookup */
 export const RPC_TIMEOUT_MS = 15_000;
@@ -64,10 +106,20 @@ export async function rpcRequest<TReq, TRes>(
 ): Promise<TRes> {
 	const requestId = generateID();
 	const request: RpcRequest<TReq> = { caller, requestId, payload };
+	const body = encode(request);
+
+	// The server drops an oversized message and the caller just sees a timeout.
+	// Fail here instead, where we can say what actually happened.
+	if (body.length > MAX_PAYLOAD_BYTES)
+		throw new RpcError(
+			"PAYLOAD_TOO_LARGE",
+			`Request to ${subject} is ${body.length} bytes, over the ${MAX_PAYLOAD_BYTES} limit — split it into smaller batches`,
+			{ requestId, bytes: body.length },
+		);
 
 	let message;
 	try {
-		message = await natsConnection().request(subject, codec.encode(request), {
+		message = await natsConnection().request(subject, body, {
 			timeout: timeoutMs,
 		});
 	} catch (error) {
@@ -78,7 +130,7 @@ export async function rpcRequest<TReq, TRes>(
 		);
 	}
 
-	const response = codec.decode(message.data) as RpcResponse<TRes>;
+	const response = decode<RpcResponse<TRes>>(message.data);
 	if (!response?.ok) {
 		const err = response?.error;
 		throw new RpcError(
@@ -106,7 +158,7 @@ export function rpcRespond<TReq, TRes>(
 			let requestId = "unknown";
 			let response: RpcResponse<TRes>;
 			try {
-				const request = codec.decode(message.data) as RpcRequest<TReq>;
+				const request = decode<RpcRequest<TReq>>(message.data);
 				requestId = request?.requestId ?? "unknown";
 				response = {
 					ok: true,
@@ -132,7 +184,23 @@ export function rpcRespond<TReq, TRes>(
 					},
 				};
 			}
-			message.respond(codec.encode(response));
+			// Same reasoning as the request side: an oversized reply is dropped
+			// by the server and the caller sees a bare timeout. Send an error
+			// that fits instead — a huge canvas read is the realistic case.
+			let body = encode(response);
+			if (body.length > MAX_PAYLOAD_BYTES) {
+				logger.error(
+					`[RPC] ${subject} response too large (${requestId}): ${body.length} bytes`,
+				);
+				body = encode({
+					ok: false,
+					error: {
+						code: "PAYLOAD_TOO_LARGE",
+						message: `Response is ${body.length} bytes, over the ${MAX_PAYLOAD_BYTES} limit — request a narrower slice`,
+					},
+				} satisfies RpcResponse<never>);
+			}
+			message.respond(body);
 		}
 	})();
 	return async () => {

--- a/apps/server/src/db/tests/natsRpc.spec.ts
+++ b/apps/server/src/db/tests/natsRpc.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, mock } from "bun:test";
+import { JSONCodec } from "nats";
+
+const codec = JSONCodec<unknown>();
+let lastRequest: { subject: string; data: Uint8Array } | null = null;
+let reply: Uint8Array = codec.encode({ ok: true, data: null });
+
+mock.module("../nats", () => ({
+	natsConnection: () => ({
+		request: async (subject: string, data: Uint8Array) => {
+			lastRequest = { subject, data };
+			return { data: reply };
+		},
+	}),
+}));
+
+import { rpcRequest, RpcError, MAX_PAYLOAD_BYTES } from "../natsRpc";
+
+const caller = { userId: "u1", projectIds: ["p1"] };
+const isGzip = (b: Uint8Array) => b[0] === 0x1f && b[1] === 0x8b;
+/** decode the way a responder would, so the test checks the actual wire format */
+const readWire = (b: Uint8Array) =>
+	codec.decode(isGzip(b) ? Bun.gunzipSync(b) : b) as any;
+
+describe("natsRpc wire format", () => {
+	it("sends small payloads as plain readable JSON", async () => {
+		reply = codec.encode({ ok: true, data: { saved: true } });
+
+		const result = await rpcRequest("fluxify.ops.canvas", caller, { id: "r1" });
+
+		expect(isGzip(lastRequest!.data)).toBe(false);
+		const sent = readWire(lastRequest!.data);
+		expect(sent.caller).toEqual(caller);
+		expect(sent.payload).toEqual({ id: "r1" });
+		expect(sent.requestId).toBeTruthy();
+		expect(result).toEqual({ saved: true } as any);
+	});
+
+	it("gzips a big canvas and still round-trips it", async () => {
+		const blocks = Array.from({ length: 2000 }, (_, i) => ({
+			id: `blk_${i}`,
+			code: "return input.map(x => x);",
+		}));
+		reply = codec.encode({ ok: true, data: null });
+
+		await rpcRequest("fluxify.ops.canvas", caller, { blocks });
+
+		expect(isGzip(lastRequest!.data)).toBe(true);
+		expect(readWire(lastRequest!.data).payload.blocks).toHaveLength(2000);
+	});
+
+	it("reads a gzipped response", async () => {
+		reply = Bun.gzipSync(codec.encode({ ok: true, data: { big: "x" } }));
+
+		expect(await rpcRequest("fluxify.ops.canvas", caller, {})).toEqual({
+			big: "x",
+		} as any);
+	});
+
+	it("refuses an oversized request instead of letting it time out", async () => {
+		// random data so gzip cannot rescue it
+		const filler = Array.from({ length: 400_000 }, () =>
+			Math.random().toString(36).slice(2, 8),
+		);
+
+		const err = await rpcRequest("fluxify.ops.canvas", caller, {
+			filler,
+		}).catch((e) => e);
+
+		expect(err).toBeInstanceOf(RpcError);
+		expect(err.code).toBe("PAYLOAD_TOO_LARGE");
+		expect(err.details.bytes).toBeGreaterThan(MAX_PAYLOAD_BYTES);
+	});
+
+	it("turns an error response into a typed throw", async () => {
+		reply = codec.encode({
+			ok: false,
+			error: { code: "PARENT_NOT_FOUND", message: "Route not found" },
+		});
+
+		const err = await rpcRequest("fluxify.ops.canvas", caller, {}).catch(
+			(e) => e,
+		);
+
+		expect(err.code).toBe("PARENT_NOT_FOUND");
+		expect(err.message).toBe("Route not found");
+	});
+});


### PR DESCRIPTION
Closes #173.

#178 landed the envelope, the typed client and the never-throw-across-the-wire responder. This finishes the three open points from the issue: the subjects, the codec decision, and `max_payload`.

## Subjects

`RPC_SUBJECTS` names `fluxify.ops.route`, `fluxify.ops.custom_block` and `fluxify.ops.canvas`. Payload shapes belong to each operation's own module; this file only owns the envelope around them. **Nothing responds on any of these yet** — that is #174/#175. `natsRpc.ts` stays dead code until then.

## Codec

The issue asked for a measured round trip rather than a guess. Encode + decode, 200 iterations, on a synthetic canvas with realistic block config:

| blocks / edges | JSON | JSON + gzip |
|---|---|---|
| 50 / 80 | 0.29 ms, 49 KiB | 0.37 ms, 2 KiB |
| 250 / 400 | 1.22 ms, 245 KiB | 1.87 ms, 7 KiB |
| 1000 / 1600 | 5.45 ms, **985 KiB** | 8.05 ms, 29 KiB |

Time was never the interesting axis — a few milliseconds is nothing against the DB transaction on the other end. Size is. Plain JSON reaches the NATS default 1 MiB `max_payload` at around a thousand blocks, and past that the *server* drops the message, so the caller sees a bare 15 s timeout with nothing explaining it.

So: JSON, gzipped once it passes 32 KiB. Gzip's magic bytes distinguish the two encodings, so there is no framing byte and small messages stay literally plain JSON on the wire — `nats sub` is still readable when something is stuck, which was the main reason to keep JSON in the first place.

No new dependency: `Bun.gzipSync`/`gunzipSync`.

**Caveat on those numbers:** the bench data is repetitive, so 33× is flattering and real canvases will compress worse. The conclusion is not sensitive to it — even 5× moves the ceiling past anything realistic. The table is in a comment above the codec so this doesn't have to be re-derived later.

## max_payload

`MAX_PAYLOAD_BYTES = 1_000_000` (1 MiB minus headroom for subject and headers). Both directions check the encoded size and raise a typed `PAYLOAD_TOO_LARGE` instead of letting the message get dropped:

- **request** — throws before publishing, with the byte count in `details`.
- **response** — replaces the oversized reply with an error that fits, and logs the size with the `requestId`. This is the one that actually matters: a large canvas *read* is the realistic way to hit the ceiling, and without it the harness would just hang.

The server's own `max_payload` is left at the default; the guard is in code so the error is legible rather than a silent drop.

## Testing

New `db/tests/natsRpc.spec.ts` — 5 tests over the real wire format, decoded independently in the test rather than through the module's own helpers: small payload stays uncompressed and carries the envelope; a 2000-block payload gzips and round-trips intact; a gzipped *response* decodes; an oversized request throws `PAYLOAD_TOO_LARGE` instead of timing out; an `ok:false` reply becomes a typed throw.

`bun test` in `apps/server`: 232 pass, 0 fail. Lint clean across all 8 packages.

Not covered: anything against a real NATS server — the connection is stubbed. The gzip threshold and the size guard are the logic worth pinning; the transport itself is the library's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
