### PR TITLE
feat(rpc): expose canvas operations on fluxify.ops.canvas

### DIFF
--- a/apps/server/src/modules/canvas/rpc.ts
+++ b/apps/server/src/modules/canvas/rpc.ts
@@ -1,0 +1,81 @@
+import { z } from "zod";
+import {
+	RPC_SUBJECTS,
+	RpcError,
+	rpcRespond,
+	type RpcCaller,
+} from "../../db/natsRpc";
+import { BadRequestError } from "../../errors/badRequestError";
+import { ConflictError } from "../../errors/conflictError";
+import { NotFoundError } from "../../errors/notFoundError";
+import { ValidationError } from "../../errors/validationError";
+import { getCanvas, saveCanvas } from "./service";
+import { canvasChangesSchema, canvasParentTypeSchema } from "./types";
+
+/**
+ * `fluxify.ops.canvas` — one way to change a canvas, whatever it belongs to.
+ * A thin adapter: validate, map the domain error to a wire code, delegate.
+ * All persistence lives in the canvas service, shared with the HTTP endpoints.
+ */
+const requestSchema = z.object({
+	source: canvasParentTypeSchema,
+	sourceId: z.string(),
+	/** omit to read the canvas back instead of writing it */
+	actionsToPerform: canvasChangesSchema.shape.actionsToPerform.nullish(),
+	changes: canvasChangesSchema.shape.changes.nullish(),
+});
+
+export type CanvasOpsRequest = z.input<typeof requestSchema>;
+
+/**
+ * Domain errors are the service's contract; wire codes are this transport's.
+ * Anything unmapped stays an exception and `rpcRespond` reports it INTERNAL —
+ * an unrecognised failure should look like a bug, not a client mistake.
+ */
+function toRpcError(error: unknown): unknown {
+	if (error instanceof NotFoundError)
+		return new RpcError("PARENT_NOT_FOUND", error.message);
+	if (error instanceof ConflictError)
+		return new RpcError("CONFLICT", error.message);
+	if (error instanceof ValidationError)
+		return new RpcError("VALIDATION_FAILED", error.message, error.errors);
+	if (error instanceof BadRequestError)
+		return new RpcError("VALIDATION_FAILED", error.message);
+	return error;
+}
+
+export async function handleCanvasOp(payload: unknown, caller: RpcCaller) {
+	const parsed = requestSchema.safeParse(payload);
+	if (!parsed.success)
+		throw new RpcError(
+			"VALIDATION_FAILED",
+			"Malformed canvas operation",
+			parsed.error.issues.map((i) => ({
+				field: i.path.join("."),
+				message: i.message,
+			})),
+		);
+
+	const { source, sourceId, actionsToPerform, changes } = parsed.data;
+	const parent = { type: source, id: sourceId };
+	try {
+		if (!actionsToPerform && !changes)
+			return await getCanvas(parent, caller.projectIds);
+
+		await saveCanvas(
+			parent,
+			{
+				actionsToPerform: actionsToPerform ?? { blocks: [], edges: [] },
+				changes: changes ?? { blocks: [], edges: [] },
+			},
+			caller.projectIds,
+		);
+		return null;
+	} catch (error) {
+		throw toRpcError(error);
+	}
+}
+
+export function registerCanvasResponder() {
+	return rpcRespond(RPC_SUBJECTS.canvas, handleCanvasOp);
+}

--- a/apps/server/src/modules/canvas/service.ts
+++ b/apps/server/src/modules/canvas/service.ts
@@ -1,5 +1,5 @@
 import { BlockTypes } from "@fluxify/blocks";
-import { db } from "../../db";
+import { db, type DbTransactionType } from "../../db";
 import { BadRequestError } from "../../errors/badRequestError";
 import { NotFoundError } from "../../errors/notFoundError";
 import {
@@ -32,6 +32,39 @@ const NOT_FOUND = {
 } as const;
 
 /**
+ * An edge whose endpoint is neither in this payload nor already stored would
+ * otherwise surface as a raw foreign key violation. Catch it here so every
+ * caller gets the same readable error naming the block.
+ */
+async function assertEdgeTargetsExist(
+	parent: CanvasParent,
+	data: CanvasChanges,
+	deleteBlockIds: string[],
+	tx?: DbTransactionType,
+) {
+	const incoming = new Set(data.changes.blocks.map((b) => b.id));
+	const referenced = new Set<string>();
+	for (const edge of data.changes.edges) {
+		for (const id of [edge.from, edge.to])
+			if (!incoming.has(id)) referenced.add(id);
+	}
+	if (referenced.size === 0) return;
+
+	// ponytail: reads every block of the canvas. Fine at canvas sizes; narrow to
+	// a `where id in (...)` if a canvas ever gets big enough to notice.
+	const stored = await getBlocks(parent, tx);
+	const known = new Set(stored.map((b) => b.id));
+	for (const id of deleteBlockIds) known.delete(id);
+
+	const missing = [...referenced].filter((id) => !known.has(id));
+	if (missing.length > 0) {
+		throw new BadRequestError(
+			`Edge references unknown block(s): ${missing.join(", ")}`,
+		);
+	}
+}
+
+/**
  * The single source of truth for canvas mutations. Every caller — both HTTP
  * endpoints and the internal ops bus — goes through here, so a canvas is
  * changed exactly one way whatever it hangs off.
@@ -54,6 +87,7 @@ export async function saveCanvas(
 		.map((c) => c.id);
 
 	await db.transaction(async (tx) => {
+		await assertEdgeTargetsExist(parent, data, deleteBlockIds, tx);
 		await upsertBlocks(
 			data.changes.blocks.map((block) => ({ ...block, ...keys })),
 			tx,

--- a/apps/server/src/modules/canvas/tests/rpc.spec.ts
+++ b/apps/server/src/modules/canvas/tests/rpc.spec.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, mock, spyOn, beforeEach } from "bun:test";
+
+mock.module("../../../db", () => ({
+	db: { transaction: async (cb: any) => await cb(null) },
+}));
+
+mock.module("../../../db/redis", () => ({
+	publishMessage: async () => {},
+	CHAN_ON_ROUTE_CHANGE: "chan:on-route-change",
+	CHAN_ON_CUSTOM_BLOCK_CHANGE: "chan:on-custom-block-change",
+}));
+
+import * as repository from "../repository";
+import { handleCanvasOp } from "../rpc";
+import { RpcError } from "../../../db/natsRpc";
+import httpSaveRouteCanvas from "../../../api/v1/routes/save-canvas-state/service";
+
+const payload = {
+	actionsToPerform: {
+		blocks: [{ id: "gone", action: "delete" as const }],
+		edges: [],
+	},
+	changes: {
+		blocks: [
+			{ id: "b1", type: "entrypoint", data: {}, position: { x: 1, y: 2 } },
+			{ id: "b2", type: "response", data: {}, position: { x: 3, y: 4 } },
+		],
+		edges: [{ id: "e1", from: "b1", to: "b2", fromHandle: "a", toHandle: "b" }],
+	},
+};
+
+const parentExists = spyOn(repository, "parentExists");
+const upsertBlocks = spyOn(repository, "upsertBlocks");
+const upsertEdges = spyOn(repository, "upsertEdges");
+const getBlocks = spyOn(repository, "getBlocks");
+
+/** everything saveCanvas writes, in order — the observable database state */
+const writes = () =>
+	[upsertBlocks, upsertEdges].map((spy) => spy.mock.calls[0]?.[0]);
+
+describe("fluxify.ops.canvas responder", () => {
+	beforeEach(() => {
+		for (const spy of [upsertBlocks, upsertEdges, getBlocks]) spy.mockClear();
+		spyOn(repository, "deleteBlocks").mockResolvedValue(undefined);
+		spyOn(repository, "deleteEdges").mockResolvedValue(undefined);
+		spyOn(repository, "getBlocksCountByType").mockResolvedValue([]);
+		spyOn(repository, "touchParent").mockResolvedValue(undefined);
+		upsertBlocks.mockResolvedValue(undefined);
+		upsertEdges.mockResolvedValue(undefined);
+		getBlocks.mockResolvedValue([] as any);
+		parentExists.mockResolvedValue(true);
+	});
+
+	// the definition of done for #175: two doors, one function
+	it("writes exactly what the HTTP endpoint writes for the same payload", async () => {
+		await handleCanvasOp(
+			{ source: "route", sourceId: "r-1", ...payload },
+			{ userId: "u1", projectIds: ["p1"] },
+		);
+		const viaBus = writes();
+
+		upsertBlocks.mockClear();
+		upsertEdges.mockClear();
+		await httpSaveRouteCanvas("r-1", payload, [{ projectId: "p1" } as any]);
+
+		expect(writes()).toEqual(viaBus);
+	});
+
+	it("reads the canvas back when no changes are given", async () => {
+		spyOn(repository, "getEdges").mockResolvedValue([] as any);
+		getBlocks.mockResolvedValue([
+			{ id: "b1", type: "entrypoint", data: {}, position: { x: 1, y: 2 } },
+		] as any);
+
+		const result = await handleCanvasOp(
+			{ source: "route", sourceId: "r-1" },
+			{ userId: "u1", projectIds: ["p1"] },
+		);
+
+		expect((result as any).blocks).toHaveLength(1);
+		expect(upsertBlocks).not.toHaveBeenCalled();
+	});
+
+	it("fails with PARENT_NOT_FOUND when the parent is not visible", async () => {
+		parentExists.mockResolvedValue(false);
+
+		const err = await handleCanvasOp(
+			{ source: "route", sourceId: "nope", ...payload },
+			{ userId: "u1", projectIds: ["p1"] },
+		).catch((e) => e);
+
+		expect(err).toBeInstanceOf(RpcError);
+		expect(err.code).toBe("PARENT_NOT_FOUND");
+		expect(upsertBlocks).not.toHaveBeenCalled();
+	});
+
+	it("rejects an edge pointing at a block that does not exist", async () => {
+		const err = await handleCanvasOp(
+			{
+				source: "route",
+				sourceId: "r-1",
+				actionsToPerform: { blocks: [], edges: [] },
+				changes: {
+					blocks: payload.changes.blocks,
+					edges: [{ id: "e9", from: "b1", to: "ghost" }],
+				},
+			},
+			{ userId: "u1", projectIds: ["p1"] },
+		).catch((e) => e);
+
+		expect(err.code).toBe("VALIDATION_FAILED");
+		expect(err.message).toContain("ghost");
+		expect(upsertBlocks).not.toHaveBeenCalled();
+	});
+
+	it("accepts an edge pointing at an already-stored block", async () => {
+		getBlocks.mockResolvedValue([{ id: "stored" }] as any);
+
+		await handleCanvasOp(
+			{
+				source: "route",
+				sourceId: "r-1",
+				actionsToPerform: { blocks: [], edges: [] },
+				changes: {
+					blocks: payload.changes.blocks,
+					edges: [{ id: "e9", from: "b1", to: "stored" }],
+				},
+			},
+			{ userId: "u1", projectIds: ["p1"] },
+		);
+
+		expect(upsertEdges).toHaveBeenCalled();
+	});
+
+	it("rejects a malformed operation with field details", async () => {
+		const err = await handleCanvasOp(
+			{ source: "nonsense", sourceId: "r-1" },
+			{ userId: "u1", projectIds: ["p1"] },
+		).catch((e) => e);
+
+		expect(err.code).toBe("VALIDATION_FAILED");
+		expect(err.details).toBeTruthy();
+	});
+});

--- a/apps/server/src/modules/canvas/tests/service.spec.ts
+++ b/apps/server/src/modules/canvas/tests/service.spec.ts
@@ -42,6 +42,8 @@ describe("canvas saveCanvas", () => {
 	beforeEach(() => {
 		published.length = 0;
 		spyOn(repository, "getBlocksCountByType").mockResolvedValue([]);
+		// e1 points at b2, which the fixture leaves already stored
+		spyOn(repository, "getBlocks").mockResolvedValue([{ id: "b2" }] as any);
 		spyOn(repository, "touchParent").mockResolvedValue(undefined);
 		for (const spy of [upsertBlocks, upsertEdges, delBlocks, delEdges]) {
 			spy.mockClear();

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -109,6 +109,11 @@ async function main() {
 		await loadProjectSettings();
 		const { startCompileWorker } = await import("./modules/compiler/consumer");
 		await startCompileWorker();
+
+		// Internal ops bus. Lives here for the same reason as the compile worker:
+		// this is the process that owns the database connection.
+		const { registerCanvasResponder } = await import("./modules/canvas/rpc");
+		registerCanvasResponder();
 	}
 
 	if (builtinWorkerEnabled) {


### PR DESCRIPTION
Closes #175.

The first responder on the bus. #178 unified canvas storage behind one mutation service and #179 defined the envelope, subjects and codec — this registers `fluxify.ops.canvas` on top of both.

## The handler

`modules/canvas/rpc.ts` is deliberately thin: parse, map the domain error to a wire code, delegate to `saveCanvas`/`getCanvas`. It contains no persistence logic, which is the point — the HTTP `save-canvas` endpoints and this subject are two doors into the same function rather than two implementations that drift.

Request shape is the issue's, with one addition: **omitting `actionsToPerform` and `changes` reads the canvas back** instead of writing it. A caller that is about to modify a canvas needs to see it first, and a separate read subject for the same resource would have been a second thing to keep in sync.

Error mapping: `NotFoundError` → `PARENT_NOT_FOUND`, `ConflictError` → `CONFLICT`, `ValidationError`/`BadRequestError` → `VALIDATION_FAILED` (with field details where they exist). Anything unmapped is left to `rpcRespond`, which reports it `INTERNAL` — an unrecognised failure should look like a bug, not a client mistake.

Registered in `server.ts` next to the compile worker, for the same reason: that is the process that owns the database connection.

## Edge validation went in the service, not the responder

The issue asks that an edge referencing a block which is neither in `changes.blocks` nor already stored fail as `VALIDATION_FAILED` rather than a raw foreign key error. That is a canvas rule, not a transport rule, so it lives in `saveCanvas` — **the HTTP endpoints get it too**, and it stays inside the existing transaction, so a rejected payload still touches nothing.

It only queries stored blocks when an edge actually references a block outside the payload, so the common case (an edge and its endpoints saved together) costs nothing. When it does query, it reads every block of the canvas; there is a `ponytail:` comment marking that ceiling and the `where id in (...)` upgrade.

## Testing

`modules/canvas/tests/rpc.spec.ts` — 6 tests. The first is the issue's definition of done: the same payload is run through the bus handler and through the HTTP route service, and the resulting repository writes are asserted equal. The rest cover read-back, `PARENT_NOT_FOUND` on an invisible parent, an edge pointing at a ghost block, an edge pointing at an already-stored block, and a malformed operation returning field details.

One existing assertion in `service.spec.ts` needed a stub: its fixture has an edge whose target was never in `changes.blocks`, which the new validation correctly catches. The block is now stubbed as already stored, which is what that fixture always meant.

`bun test` in `apps/server`: 238 pass, 0 fail. Pre-commit lint clean across all packages.

Not covered: anything against a real NATS server. The handler is tested directly; `rpcRespond` was covered in #179.

## Still open

`fluxify.ops.route` and `fluxify.ops.custom_block` (#174) have no responder yet, and nothing calls this subject until the harness cuts over (#177).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
