### PR TITLE
feat(rpc): expose route and custom block operations on the ops bus

### DIFF
--- a/apps/server/src/api/v1/custom-blocks/create/service.ts
+++ b/apps/server/src/api/v1/custom-blocks/create/service.ts
@@ -7,14 +7,19 @@ import {
 	checkProjectExist,
 } from "./repository";
 import { ConflictError } from "../../../../errors/conflictError";
-import { db } from "../../../../db";
+import { db, type DbTransactionType } from "../../../../db";
 import { generateID } from "@fluxify/lib";
 import { NotFoundError } from "../../../../errors/notFoundError";
 
+/**
+ * `outer` joins a transaction already in progress, so the ops bus can create a
+ * custom block and its canvas atomically.
+ */
 export default async function handleRequest(
 	data: z.infer<typeof requestBodySchema>,
+	outer?: DbTransactionType,
 ): Promise<z.infer<typeof responseSchema>> {
-	const result = await db.transaction(async (tx) => {
+	const result = await (outer ?? db).transaction(async (tx) => {
 		const projectExist = await checkProjectExist(data.projectId, tx);
 		if (!projectExist) {
 			throw new NotFoundError(

--- a/apps/server/src/api/v1/routes/create/service.ts
+++ b/apps/server/src/api/v1/routes/create/service.ts
@@ -7,17 +7,23 @@ import {
   checkProjectExist,
 } from "./repository";
 import { ConflictError } from "../../../../errors/conflictError";
-import { db } from "../../../../db";
+import { db, DbTransactionType } from "../../../../db";
 import { CHAN_ON_ROUTE_CHANGE, publishMessage } from "../../../../db/redis";
 import { generateID } from "@fluxify/lib";
 import { NotFoundError } from "../../../../errors/notFoundError";
 import { HttpMethod } from "../../../../db/schema";
 
+/**
+ * `outer` joins a transaction already in progress, so the ops bus can create a
+ * route and its canvas atomically. The change signal is then the caller's to
+ * publish once that transaction commits.
+ */
 export default async function handleRequest(
   userId: string,
-  data: z.infer<typeof requestBodySchema>
+  data: z.infer<typeof requestBodySchema>,
+  outer?: DbTransactionType
 ): Promise<z.infer<typeof responseSchema>> {
-  const result = await db.transaction(async (tx) => {
+  const result = await (outer ?? db).transaction(async (tx) => {
     const projectExist = await checkProjectExist(data.projectId, tx);
     if (!projectExist) {
       throw new NotFoundError(
@@ -43,6 +49,6 @@ export default async function handleRequest(
       id: newRouteId,
     };
   });
-  await publishMessage(CHAN_ON_ROUTE_CHANGE, result.id);
+  if (!outer) await publishMessage(CHAN_ON_ROUTE_CHANGE, result.id);
   return result;
 }

--- a/apps/server/src/modules/canvas/rpc.ts
+++ b/apps/server/src/modules/canvas/rpc.ts
@@ -1,14 +1,6 @@
 import { z } from "zod";
-import {
-	RPC_SUBJECTS,
-	RpcError,
-	rpcRespond,
-	type RpcCaller,
-} from "../../db/natsRpc";
-import { BadRequestError } from "../../errors/badRequestError";
-import { ConflictError } from "../../errors/conflictError";
-import { NotFoundError } from "../../errors/notFoundError";
-import { ValidationError } from "../../errors/validationError";
+import { RPC_SUBJECTS, rpcRespond, type RpcCaller } from "../../db/natsRpc";
+import { toRpcError, validationFailed } from "../ops/caller";
 import { getCanvas, saveCanvas } from "./service";
 import { canvasChangesSchema, canvasParentTypeSchema } from "./types";
 
@@ -27,34 +19,9 @@ const requestSchema = z.object({
 
 export type CanvasOpsRequest = z.input<typeof requestSchema>;
 
-/**
- * Domain errors are the service's contract; wire codes are this transport's.
- * Anything unmapped stays an exception and `rpcRespond` reports it INTERNAL —
- * an unrecognised failure should look like a bug, not a client mistake.
- */
-function toRpcError(error: unknown): unknown {
-	if (error instanceof NotFoundError)
-		return new RpcError("PARENT_NOT_FOUND", error.message);
-	if (error instanceof ConflictError)
-		return new RpcError("CONFLICT", error.message);
-	if (error instanceof ValidationError)
-		return new RpcError("VALIDATION_FAILED", error.message, error.errors);
-	if (error instanceof BadRequestError)
-		return new RpcError("VALIDATION_FAILED", error.message);
-	return error;
-}
-
 export async function handleCanvasOp(payload: unknown, caller: RpcCaller) {
 	const parsed = requestSchema.safeParse(payload);
-	if (!parsed.success)
-		throw new RpcError(
-			"VALIDATION_FAILED",
-			"Malformed canvas operation",
-			parsed.error.issues.map((i) => ({
-				field: i.path.join("."),
-				message: i.message,
-			})),
-		);
+	if (!parsed.success) throw validationFailed(parsed.error.issues);
 
 	const { source, sourceId, actionsToPerform, changes } = parsed.data;
 	const parent = { type: source, id: sourceId };

--- a/apps/server/src/modules/canvas/service.ts
+++ b/apps/server/src/modules/canvas/service.ts
@@ -68,13 +68,18 @@ async function assertEdgeTargetsExist(
  * The single source of truth for canvas mutations. Every caller — both HTTP
  * endpoints and the internal ops bus — goes through here, so a canvas is
  * changed exactly one way whatever it hangs off.
+ *
+ * Pass `outer` to join a transaction already in progress — that is how
+ * "create the parent and its canvas or neither" is possible on the ops bus.
+ * The change signal is then the outer caller's to publish, after it commits.
  */
 export async function saveCanvas(
 	parent: CanvasParent,
 	data: CanvasChanges,
 	projectIds: string[] = [],
+	outer?: DbTransactionType,
 ) {
-	if (!(await parentExists(parent, projectIds))) {
+	if (!(await parentExists(parent, projectIds, outer))) {
 		throw new NotFoundError(NOT_FOUND[parent.type]);
 	}
 
@@ -86,7 +91,8 @@ export async function saveCanvas(
 		.filter((c) => c.action === "delete")
 		.map((c) => c.id);
 
-	await db.transaction(async (tx) => {
+	// a tx nests as a savepoint, so the outer transaction still decides the outcome
+	await (outer ?? db).transaction(async (tx) => {
 		await assertEdgeTargetsExist(parent, data, deleteBlockIds, tx);
 		await upsertBlocks(
 			data.changes.blocks.map((block) => ({ ...block, ...keys })),
@@ -113,7 +119,7 @@ export async function saveCanvas(
 		}
 	});
 
-	await publishMessage(CHANGE_CHANNEL[parent.type], parent.id);
+	if (!outer) await publishMessage(CHANGE_CHANNEL[parent.type], parent.id);
 }
 
 export async function getCanvas(

--- a/apps/server/src/modules/ops/caller.ts
+++ b/apps/server/src/modules/ops/caller.ts
@@ -1,0 +1,56 @@
+import type { User } from "better-auth";
+import { RpcError, type RpcCaller } from "../../db/natsRpc";
+import { BadRequestError } from "../../errors/badRequestError";
+import { ConflictError } from "../../errors/conflictError";
+import { ForbiddenError } from "../../errors/forbidError";
+import { NotFoundError } from "../../errors/notFoundError";
+import { ValidationError } from "../../errors/validationError";
+import type { AuthACL } from "../../db/schema";
+
+/**
+ * The bus is internal, so the envelope's `caller` is trusted for identity —
+ * authorization already happened at the edge that produced it. `projectIds` is
+ * the scope that survived that check, so it maps to creator-level ACL entries
+ * and the existing services enforce it exactly as they do for HTTP.
+ */
+export function callerAcl(caller: RpcCaller): AuthACL[] {
+	return caller.projectIds.map((projectId) => ({
+		projectId,
+		role: "creator" as const,
+	}));
+}
+
+/** the services that take a better-auth user only ever read `isSystemAdmin` */
+export function callerUser(caller: RpcCaller) {
+	return { id: caller.userId, isSystemAdmin: false } as User & {
+		isSystemAdmin: boolean;
+	};
+}
+
+/**
+ * Domain errors are the services' contract; wire codes are this transport's.
+ * Anything unmapped stays an exception and `rpcRespond` reports it INTERNAL —
+ * an unrecognised failure should look like a bug, not a client mistake.
+ */
+export function toRpcError(error: unknown): unknown {
+	if (error instanceof NotFoundError)
+		return new RpcError("PARENT_NOT_FOUND", error.message);
+	if (error instanceof ConflictError)
+		return new RpcError("CONFLICT", error.message);
+	if (error instanceof ForbiddenError)
+		return new RpcError("FORBIDDEN", error.message);
+	if (error instanceof ValidationError)
+		return new RpcError("VALIDATION_FAILED", error.message, error.errors);
+	if (error instanceof BadRequestError)
+		return new RpcError("VALIDATION_FAILED", error.message);
+	return error;
+}
+
+/** a zod failure in the shape the wire contract expects */
+export function validationFailed(issues: { path: PropertyKey[]; message: string }[]) {
+	return new RpcError(
+		"VALIDATION_FAILED",
+		"Malformed operation",
+		issues.map((i) => ({ field: i.path.join("."), message: i.message })),
+	);
+}

--- a/apps/server/src/modules/ops/customBlock.ts
+++ b/apps/server/src/modules/ops/customBlock.ts
@@ -1,0 +1,72 @@
+import { z } from "zod";
+import { db } from "../../db";
+import { RPC_SUBJECTS, rpcRespond, type RpcCaller } from "../../db/natsRpc";
+import {
+	CHAN_ON_CUSTOM_BLOCK_CHANGE,
+	publishMessage,
+} from "../../db/redis";
+import { canAccessProject } from "../../lib/acl";
+import { ForbiddenError } from "../../errors/forbidError";
+import createCustomBlock from "../../api/v1/custom-blocks/create/service";
+import updateCustomBlock from "../../api/v1/custom-blocks/update/service";
+import deleteCustomBlock from "../../api/v1/custom-blocks/delete/service";
+import { requestBodySchema as createSchema } from "../../api/v1/custom-blocks/create/dto";
+import { requestBodySchema as modifySchema } from "../../api/v1/custom-blocks/update/dto";
+import { saveCanvas } from "../canvas/service";
+import { canvasChangesSchema } from "../canvas/types";
+import { callerAcl, callerUser, toRpcError, validationFailed } from "./caller";
+
+/** `fluxify.ops.custom_block` — same shape as the route subject, same rules. */
+const requestSchema = z.discriminatedUnion("action", [
+	z.object({
+		action: z.literal("create"),
+		data: createSchema,
+		canvas: canvasChangesSchema.nullish(),
+	}),
+	z.object({
+		action: z.literal("modify"),
+		id: z.string(),
+		data: modifySchema,
+	}),
+	z.object({ action: z.literal("delete"), id: z.string() }),
+]);
+
+export type CustomBlockOpsRequest = z.input<typeof requestSchema>;
+
+export async function handleCustomBlockOp(payload: unknown, caller: RpcCaller) {
+	const parsed = requestSchema.safeParse(payload);
+	if (!parsed.success) throw validationFailed(parsed.error.issues);
+
+	const op = parsed.data;
+	const acl = callerAcl(caller);
+	const user = callerUser(caller);
+	try {
+		if (op.action === "delete") return await deleteCustomBlock(op.id, user, acl);
+		if (op.action === "modify")
+			return await updateCustomBlock(op.id, op.data, user, acl);
+
+		// the HTTP endpoint gets this from middleware; the bus has to do it itself
+		if (!canAccessProject(acl, op.data.projectId, "creator"))
+			throw new ForbiddenError();
+
+		const result = await db.transaction(async (tx) => {
+			const created = await createCustomBlock(op.data, tx);
+			if (op.canvas)
+				await saveCanvas(
+					{ type: "custom_block", id: created.id },
+					op.canvas,
+					caller.projectIds,
+					tx,
+				);
+			return created;
+		});
+		await publishMessage(CHAN_ON_CUSTOM_BLOCK_CHANGE, result.id);
+		return result;
+	} catch (error) {
+		throw toRpcError(error);
+	}
+}
+
+export function registerCustomBlockResponder() {
+	return rpcRespond(RPC_SUBJECTS.customBlock, handleCustomBlockOp);
+}

--- a/apps/server/src/modules/ops/route.ts
+++ b/apps/server/src/modules/ops/route.ts
@@ -1,0 +1,78 @@
+import { z } from "zod";
+import { db } from "../../db";
+import { RPC_SUBJECTS, rpcRespond, type RpcCaller } from "../../db/natsRpc";
+import { CHAN_ON_ROUTE_CHANGE, publishMessage } from "../../db/redis";
+import { canAccessProject } from "../../lib/acl";
+import { ForbiddenError } from "../../errors/forbidError";
+import createRoute from "../../api/v1/routes/create/service";
+import updateRoute from "../../api/v1/routes/update-partial/service";
+import deleteRoute from "../../api/v1/routes/delete/service";
+import { requestBodySchema as createSchema } from "../../api/v1/routes/create/dto";
+import { requestBodySchema as modifySchema } from "../../api/v1/routes/update-partial/dto";
+import { saveCanvas } from "../canvas/service";
+import { canvasChangesSchema } from "../canvas/types";
+import { callerAcl, toRpcError, validationFailed } from "./caller";
+
+/**
+ * `fluxify.ops.route` — a transport for the existing route services, not a
+ * second implementation. The DTOs are the HTTP ones, so validation rules
+ * (including the non-empty `name` the routes list depends on) cannot drift.
+ */
+const requestSchema = z.discriminatedUnion("action", [
+	z.object({
+		action: z.literal("create"),
+		data: createSchema,
+		/** optional, create only — written in the same transaction as the route */
+		canvas: canvasChangesSchema.nullish(),
+	}),
+	z.object({
+		action: z.literal("modify"),
+		id: z.string(),
+		data: modifySchema,
+	}),
+	z.object({ action: z.literal("delete"), id: z.string() }),
+]);
+
+export type RouteOpsRequest = z.input<typeof requestSchema>;
+
+export async function handleRouteOp(payload: unknown, caller: RpcCaller) {
+	const parsed = requestSchema.safeParse(payload);
+	if (!parsed.success) throw validationFailed(parsed.error.issues);
+
+	const op = parsed.data;
+	const acl = callerAcl(caller);
+	try {
+		if (op.action === "delete") {
+			await deleteRoute(op.id, acl);
+			return { id: op.id };
+		}
+		if (op.action === "modify") return await updateRoute(op.id, op.data, acl);
+
+		// create: the HTTP route relies on middleware for this check, so the bus
+		// has to make it itself before anything is written.
+		if (!canAccessProject(acl, op.data.projectId, "creator"))
+			throw new ForbiddenError();
+
+		const result = await db.transaction(async (tx) => {
+			const created = await createRoute(caller.userId, op.data, tx);
+			if (op.canvas)
+				await saveCanvas(
+					{ type: "route", id: created.id },
+					op.canvas,
+					caller.projectIds,
+					tx,
+				);
+			return created;
+		});
+		// published here, not by the services: they were told to join a
+		// transaction, so only this scope knows whether it committed.
+		await publishMessage(CHAN_ON_ROUTE_CHANGE, result.id);
+		return result;
+	} catch (error) {
+		throw toRpcError(error);
+	}
+}
+
+export function registerRouteResponder() {
+	return rpcRespond(RPC_SUBJECTS.route, handleRouteOp);
+}

--- a/apps/server/src/modules/ops/tests/customBlock.spec.ts
+++ b/apps/server/src/modules/ops/tests/customBlock.spec.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, mock, spyOn, beforeEach, afterAll } from "bun:test";
+
+// see route.spec.ts for why the delegated services use spyOn, not mock.module
+import * as createService from "../../../api/v1/custom-blocks/create/service";
+import * as modifyService from "../../../api/v1/custom-blocks/update/service";
+import * as deleteService from "../../../api/v1/custom-blocks/delete/service";
+import * as canvasService from "../../canvas/service";
+
+const TX = { marker: "outer-tx" };
+mock.module("../../../db", () => ({
+	// a bun mock, not a plain function: other specs sharing this module mock
+	// reach for .mockImplementation on it
+	db: { transaction: mock(async (cb: any) => await cb(TX)) },
+}));
+
+const published: string[] = [];
+mock.module("../../../db/redis", () => ({
+	publishMessage: async (chan: string) => {
+		published.push(chan);
+	},
+	CHAN_ON_ROUTE_CHANGE: "chan:on-route-change",
+	CHAN_ON_CUSTOM_BLOCK_CHANGE: "chan:on-custom-block-change",
+}));
+
+const calls: any = {};
+
+import { handleCustomBlockOp } from "../customBlock";
+
+import { RpcError } from "../../../db/natsRpc";
+
+const projectId = "0199a000-0000-7000-8000-000000000000";
+const owner = { userId: "u1", projectIds: [projectId] };
+const blockData = { name: "send_sms", label: "Send SMS", projectId };
+const canvas = {
+	actionsToPerform: { blocks: [], edges: [] },
+	changes: {
+		blocks: [
+			{ id: "b1", type: "entrypoint", data: {}, position: { x: 0, y: 0 } },
+		],
+		edges: [],
+	},
+};
+
+// Installed per test, never at module scope: every file loads before any test
+// runs, so a spy created at load time would be in place for the spied
+// services' own specs too.
+const spies: any[] = [];
+const stub = (mod: any, key: string, impl: any) => {
+	const spy = spyOn(mod, key).mockImplementation(impl);
+	spies.push(spy);
+	return spy;
+};
+
+describe("fluxify.ops.custom_block", () => {
+	// a spy on a default export outlives this file otherwise, and every service
+	// stubbed here has its own spec
+	afterAll(() => {
+		for (const spy of spies) spy.mockRestore();
+	});
+
+	beforeEach(() => {
+		for (const key of Object.keys(calls)) delete calls[key];
+		published.length = 0;
+
+		stub(createService, "default", 
+			async (data: any, tx: any) => {
+				calls.create = { data, tx };
+				return { id: "cb-new" };
+			},
+		);
+		stub(modifyService, "default", 
+			async (id: any, data: any, user: any, acl: any) => {
+				calls.modify = { id, data, user, acl };
+				return { id };
+			},
+		);
+		stub(deleteService, "default", 
+			async (id: any, user: any, acl: any) => {
+				calls.remove = { id, user, acl };
+				return { id };
+			},
+		);
+		stub(canvasService, "saveCanvas", 
+			async (parent: any, data: any, projectIds: any, tx: any) => {
+				calls.canvas = { parent, data, projectIds, tx };
+			},
+		);
+	});
+
+	it("creates a custom block and its canvas in one transaction", async () => {
+		const result = await handleCustomBlockOp(
+			{ action: "create", data: blockData, canvas },
+			owner,
+		);
+
+		expect(result).toEqual({ id: "cb-new" } as any);
+		// one handle shared by both — that is what makes it atomic
+		expect(calls.create.tx).toBeDefined();
+		expect(calls.canvas.tx).toBe(calls.create.tx);
+		expect(calls.canvas.parent).toEqual({ type: "custom_block", id: "cb-new" });
+		expect(published).toEqual(["chan:on-custom-block-change"]);
+	});
+
+	it("refuses to create in a project the caller cannot reach", async () => {
+		const err = await handleCustomBlockOp(
+			{ action: "create", data: blockData },
+			{ userId: "u1", projectIds: ["other"] },
+		).catch((e) => e);
+
+		expect(err).toBeInstanceOf(RpcError);
+		expect(err.code).toBe("FORBIDDEN");
+		expect(calls.create).toBeUndefined();
+	});
+
+	it("rejects a name the block registry cannot hold", async () => {
+		const err = await handleCustomBlockOp(
+			{ action: "create", data: { ...blockData, name: "Send SMS!" } },
+			owner,
+		).catch((e) => e);
+
+		expect(err.code).toBe("VALIDATION_FAILED");
+		expect(err.details[0].field).toBe("data.name");
+	});
+
+	it("modifies partially and passes the caller through", async () => {
+		await handleCustomBlockOp(
+			{ action: "modify", id: "cb-1", data: { label: "New" } },
+			owner,
+		);
+
+		expect(calls.modify.data).toEqual({ label: "New" });
+		expect(calls.modify.user.id).toBe("u1");
+		expect(calls.modify.user.isSystemAdmin).toBe(false);
+		expect(calls.modify.acl).toEqual([{ projectId, role: "creator" }]);
+	});
+
+	it("deletes through the existing service", async () => {
+		await handleCustomBlockOp({ action: "delete", id: "cb-1" }, owner);
+		expect(calls.remove.id).toBe("cb-1");
+	});
+});

--- a/apps/server/src/modules/ops/tests/route.spec.ts
+++ b/apps/server/src/modules/ops/tests/route.spec.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, mock, spyOn, beforeEach, afterAll } from "bun:test";
+
+// The delegated services are stubbed with spyOn, not mock.module: module mocks
+// are global for the whole run and would follow these fakes into those
+// services' own specs.
+import * as createService from "../../../api/v1/routes/create/service";
+import * as modifyService from "../../../api/v1/routes/update-partial/service";
+import * as deleteService from "../../../api/v1/routes/delete/service";
+import * as canvasService from "../../canvas/service";
+
+/** the transaction handle the ops handler must hand down to both services */
+const TX = { marker: "outer-tx" };
+mock.module("../../../db", () => ({
+	// a bun mock, not a plain function: other specs sharing this module mock
+	// reach for .mockImplementation on it
+	db: { transaction: mock(async (cb: any) => await cb(TX)) },
+}));
+
+const published: string[] = [];
+mock.module("../../../db/redis", () => ({
+	publishMessage: async (chan: string) => {
+		published.push(chan);
+	},
+	CHAN_ON_ROUTE_CHANGE: "chan:on-route-change",
+	CHAN_ON_CUSTOM_BLOCK_CHANGE: "chan:on-custom-block-change",
+}));
+
+const calls: any = {};
+let canvasFails = false;
+
+
+import { handleRouteOp } from "../route";
+
+import { RpcError } from "../../../db/natsRpc";
+import { NotFoundError } from "../../../errors/notFoundError";
+
+const caller = { userId: "u1", projectIds: ["p1"] };
+const routeData = {
+	name: "list users",
+	path: "/users",
+	method: "GET" as const,
+	projectId: "0199a000-0000-7000-8000-000000000000",
+};
+const canvas = {
+	actionsToPerform: { blocks: [], edges: [] },
+	changes: {
+		blocks: [
+			{ id: "b1", type: "entrypoint", data: {}, position: { x: 0, y: 0 } },
+		],
+		edges: [],
+	},
+};
+
+// Installed per test, never at module scope: every file loads before any test
+// runs, so a spy created at load time would be in place for the spied
+// services' own specs too.
+const spies: any[] = [];
+const stub = (mod: any, key: string, impl: any) => {
+	const spy = spyOn(mod, key).mockImplementation(impl);
+	spies.push(spy);
+	return spy;
+};
+
+describe("fluxify.ops.route", () => {
+	// a spy on a default export outlives this file otherwise, and every service
+	// stubbed here has its own spec
+	afterAll(() => {
+		for (const spy of spies) spy.mockRestore();
+	});
+
+	beforeEach(() => {
+		for (const key of Object.keys(calls)) delete calls[key];
+		published.length = 0;
+		canvasFails = false;
+
+		stub(createService, "default", 
+			async (userId: any, data: any, tx: any) => {
+				calls.create = { userId, data, tx };
+				return { id: "r-new" };
+			},
+		);
+		stub(modifyService, "default", 
+			async (id: any, data: any, acl: any) => {
+				calls.modify = { id, data, acl };
+				return { id } as any;
+			},
+		);
+		stub(deleteService, "default", 
+			async (id: any, acl: any) => {
+				calls.remove = { id, acl };
+				return "";
+			},
+		);
+		stub(canvasService, "saveCanvas", 
+			async (parent: any, data: any, projectIds: any, tx: any) => {
+				calls.canvas = { parent, data, projectIds, tx };
+				if (canvasFails) throw new Error("canvas boom");
+			},
+		);
+	});
+
+	it("creates a route and its canvas in one transaction", async () => {
+		const result = await handleRouteOp(
+			{ action: "create", data: routeData, canvas },
+			{ userId: "u1", projectIds: [routeData.projectId] },
+		);
+
+		expect(result).toEqual({ id: "r-new" } as any);
+		// both services get the *same* handle â€” that is what makes it atomic
+		// one handle shared by both — that is what makes it atomic
+		expect(calls.create.tx).toBeDefined();
+		expect(calls.canvas.tx).toBe(calls.create.tx);
+		expect(calls.canvas.parent).toEqual({ type: "route", id: "r-new" });
+		expect(calls.create.userId).toBe("u1");
+		expect(published).toEqual(["chan:on-route-change"]);
+	});
+
+	it("creates without a canvas when none is given", async () => {
+		await handleRouteOp(
+			{ action: "create", data: routeData },
+			{ userId: "u1", projectIds: [routeData.projectId] },
+		);
+
+		expect(calls.canvas).toBeUndefined();
+		expect(published).toEqual(["chan:on-route-change"]);
+	});
+
+	it("does not announce a change when the canvas fails", async () => {
+		canvasFails = true;
+
+		await handleRouteOp(
+			{ action: "create", data: routeData, canvas },
+			{ userId: "u1", projectIds: [routeData.projectId] },
+		).catch(() => {});
+
+		expect(published).toEqual([]);
+	});
+
+	it("refuses to create in a project the caller cannot reach", async () => {
+		const err = await handleRouteOp(
+			{ action: "create", data: routeData, canvas },
+			caller,
+		).catch((e) => e);
+
+		expect(err).toBeInstanceOf(RpcError);
+		expect(err.code).toBe("FORBIDDEN");
+		expect(calls.create).toBeUndefined();
+	});
+
+	it("rejects a nameless route before anything is written", async () => {
+		const err = await handleRouteOp(
+			{ action: "create", data: { ...routeData, name: "" } },
+			{ userId: "u1", projectIds: [routeData.projectId] },
+		).catch((e) => e);
+
+		expect(err.code).toBe("VALIDATION_FAILED");
+		expect(err.details[0].field).toBe("data.name");
+		expect(calls.create).toBeUndefined();
+	});
+
+	it("modifies partially, leaving absent fields alone", async () => {
+		await handleRouteOp(
+			{ action: "modify", id: "r-1", data: { active: false } },
+			caller,
+		);
+
+		expect(calls.modify.data).toEqual({ active: false });
+		expect(calls.modify.acl).toEqual([{ projectId: "p1", role: "creator" }]);
+	});
+
+	it("deletes through the existing service", async () => {
+		expect(await handleRouteOp({ action: "delete", id: "r-1" }, caller)).toEqual(
+			{ id: "r-1" } as any,
+		);
+		expect(calls.remove.id).toBe("r-1");
+	});
+
+	it("maps a domain error to a wire code", async () => {
+		stub(deleteService, "default", async () => {
+			throw new NotFoundError("Route not found");
+		});
+
+		const err = await handleRouteOp(
+			{ action: "delete", id: "gone" },
+			caller,
+		).catch((e) => e);
+
+		expect(err.code).toBe("PARENT_NOT_FOUND");
+		expect(err.message).toBe("Route not found");
+	});
+});

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -113,7 +113,13 @@ async function main() {
 		// Internal ops bus. Lives here for the same reason as the compile worker:
 		// this is the process that owns the database connection.
 		const { registerCanvasResponder } = await import("./modules/canvas/rpc");
+		const { registerRouteResponder } = await import("./modules/ops/route");
+		const { registerCustomBlockResponder } = await import(
+			"./modules/ops/customBlock"
+		);
 		registerCanvasResponder();
+		registerRouteResponder();
+		registerCustomBlockResponder();
 	}
 
 	if (builtinWorkerEnabled) {


### PR DESCRIPTION
Closes #174.

The remaining two subjects. `fluxify.ops.route` and `fluxify.ops.custom_block` take the same `action` / `id` / `data` / `canvas` shape and delegate to the services that already back the HTTP endpoints.

## Not a reimplementation

The issue asks that the handlers delegate to the existing services and warns they are "currently coupled to request/response objects". They turned out not to be — `routes/create/service.ts` and friends already take plain arguments and throw domain errors, with the Hono layer sitting above them. So no extraction was needed and none was done.

More usefully, **the request schemas are the HTTP DTOs**, imported directly. `create` reuses `routes/create/dto.ts`, `modify` reuses `update-partial/dto.ts`. That is what actually keeps the two transports from drifting — including the non-empty `name` guard the issue calls out, which the create DTO already enforces at `min(2)` and now applies to the bus for free.

`modify` maps to the partial-update service, so absent fields are left alone.

## create + canvas in one transaction

The one place a thin adapter was not enough. `saveCanvas` and both create services now take an optional `outer` transaction; a drizzle `tx.transaction()` nests as a savepoint, so the outer scope still decides the outcome. The handler opens one transaction, creates the parent, writes the canvas into the same handle, and only publishes the change signal after it commits — the services skip their own publish when they were told to join, since only the outer scope knows whether it committed. Without that, a rolled-back create would still have announced a route that does not exist.

Default behaviour for every existing caller is unchanged: no `outer`, own transaction, own publish.

## Authorization

`caller.projectIds` becomes creator-level ACL entries and the existing services enforce scope exactly as they do for HTTP. Two of the six operations needed care: `create` on both subjects is guarded by `requireProjectAccess` **middleware** on the HTTP side, not inside the service, so the bus checks `canAccessProject` itself before anything is written. The custom-block services also take a better-auth user; they only ever read `isSystemAdmin`, so the bus passes the caller with it false — a bus caller never gets an implicit admin bypass.

Error mapping (`NotFoundError` → `PARENT_NOT_FOUND`, `ForbiddenError` → `FORBIDDEN`, and so on) moved to `modules/ops/caller.ts` now that three responders share it. Anything unmapped stays an exception and `rpcRespond` reports it `INTERNAL`.

## Testing

13 tests across `modules/ops/tests/`. The one worth reading is that create hands the *same* transaction handle to both the parent service and the canvas service, plus its companion: when the canvas fails, no change is published. The rest cover create-without-canvas, a project the caller cannot reach, a nameless route rejected before any write, partial modify, delete, and domain-error mapping.

`bun test` in `apps/server`: 251 pass, 0 fail. Lint clean.

One test-infrastructure note for reviewers: these specs stub the delegated services with `spyOn` + an explicit `mockRestore`, installed inside `beforeEach` rather than at module scope. `mock.module` is global for the whole run, and every test file loads before any test executes — so a module mock, or even a load-time spy, follows the fake into the stubbed services' own specs. Getting that wrong is what the intermediate commits were fighting.

Not covered: anything against a real NATS server.

## Where this leaves the bus

All three `fluxify.ops.*` subjects now have responders. Nothing calls them yet — that is #177, the harness cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
