### PR TITLE
feat(portal): custom block canvas editor on the shared canvas model

### DIFF
--- a/apps/portal/src/components/canvas/CanvasWorkbench.tsx
+++ b/apps/portal/src/components/canvas/CanvasWorkbench.tsx
@@ -1,0 +1,126 @@
+import { useMemo, useRef, useState } from "react";
+import { Button, Spinner, toast } from "@fluxify/components";
+import { showErrorNotification } from "@/lib/errorNotifier";
+import type { CanvasItems, CanvasSavePayload } from "@/services/canvas";
+import { BlockCanvas } from "./BlockCanvas";
+import { createBlockNodeTypes } from "./blocks";
+import { emptyGraph } from "./adapters";
+import { saveWithDoctor, type ChangeSet } from "./changes";
+import type { BlockData, CanvasGraph } from "./types";
+
+/**
+ * The canvas host, independent of what the canvas hangs off. Routes and custom
+ * blocks store the same graph and serve it from the same endpoint shape, so the
+ * only thing a caller supplies is how to load and save.
+ */
+export type CanvasWorkbenchProps = {
+	title: string;
+	items: { data: CanvasItems | undefined; isLoading: boolean; isError: boolean };
+	/** re-read from the server, for diagnosing a rejected save */
+	reload: () => Promise<CanvasItems>;
+	save: (payload: CanvasSavePayload) => Promise<unknown>;
+};
+
+function toGraph(data: CanvasItems | undefined): CanvasGraph {
+	if (!data) return emptyGraph;
+	return {
+		blocks: data.blocks.map((block) => ({
+			id: block.id,
+			type: block.type,
+			position: block.position,
+			data: (block.data ?? {}) as BlockData,
+		})),
+		edges: data.edges,
+	};
+}
+
+const nodeTypes = createBlockNodeTypes();
+
+export function CanvasWorkbench({ title, items, reload, save }: CanvasWorkbenchProps) {
+	const [readOnly, setReadOnly] = useState(false);
+	const [pendingCount, setPendingCount] = useState(0);
+	const [isSaving, setIsSaving] = useState(false);
+	// Latest graph + delta reported by the canvas; only the delta gets saved.
+	const edited = useRef<{ graph: CanvasGraph; changes: ChangeSet } | null>(null);
+
+	async function onSave() {
+		const current = edited.current;
+		if (!current || isSaving) return;
+		setIsSaving(true);
+		try {
+			const outcome = await saveWithDoctor({
+				graph: current.graph,
+				changes: current.changes,
+				save,
+				// Diagnose against what the server actually holds.
+				loadServerGraph: async () => toGraph(await reload()),
+			});
+			edited.current = null;
+			setPendingCount(0);
+			toast.success(
+				outcome.repaired
+					? `Canvas saved after fixing ${outcome.notes.length} issue(s)`
+					: "Canvas saved",
+			);
+		} catch (error) {
+			// Both the save and the repaired retry failed — this is for the user.
+			showErrorNotification(error as Error);
+		} finally {
+			setIsSaving(false);
+		}
+	}
+
+	const graph = useMemo(() => toGraph(items.data), [items.data]);
+
+	return (
+		<div className="flex h-screen w-full flex-col">
+			<header className="flex items-center gap-4 border-b border-border px-4 py-2 text-sm">
+				<span className="font-medium">{title}</span>
+				<label className="flex items-center gap-2">
+					<input
+						type="checkbox"
+						checked={readOnly}
+						onChange={(e) => setReadOnly(e.target.checked)}
+					/>
+					Read only
+				</label>
+				<span className="text-muted">
+					{graph.blocks.length} blocks · {graph.edges.length} edges ·{" "}
+					{pendingCount} unsaved
+				</span>
+				{!readOnly && (
+					<Button
+						variant="primary"
+						isDisabled={pendingCount === 0 || isSaving}
+						isPending={isSaving}
+						onPress={() => void onSave()}
+					>
+						Save
+					</Button>
+				)}
+			</header>
+
+			<div className="min-h-0 flex-1">
+				{items.isLoading ? (
+					<div className="flex h-full items-center justify-center">
+						<Spinner />
+					</div>
+				) : items.isError ? (
+					<div className="flex h-full items-center justify-center text-muted">
+						Couldn't load the graph.
+					</div>
+				) : (
+					<BlockCanvas
+						graph={graph}
+						mode={readOnly ? "readonly" : "edit"}
+						nodeTypes={nodeTypes}
+						onChange={(next, changes) => {
+							edited.current = { graph: next, changes };
+							setPendingCount(changes.blocks.size + changes.edges.size);
+						}}
+					/>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/apps/portal/src/components/canvas/index.ts
+++ b/apps/portal/src/components/canvas/index.ts
@@ -1,4 +1,5 @@
 export { BlockCanvas } from "./BlockCanvas";
+export { CanvasWorkbench } from "./CanvasWorkbench";
 export * from "./aiButton";
 export * from "./blocks";
 export { DEFAULT_EDGE_TYPES, FLOW_EDGE_TYPE, FlowEdge } from "./edges";

--- a/apps/portal/src/query/customBlocksQuery.ts
+++ b/apps/portal/src/query/customBlocksQuery.ts
@@ -1,8 +1,10 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { z } from "zod";
+import type { CanvasSavePayload } from "@/services/canvas";
 import { customBlocksService } from "@/services/customBlocks";
 
 const key = (projectId: string) => ["custom-blocks", projectId];
+const canvasKey = (id: string) => ["custom-blocks", id, "canvas-items"];
 
 export const customBlocksQuery = {
 	getAll: {
@@ -11,6 +13,25 @@ export const customBlocksQuery = {
 				queryKey: key(projectId),
 				queryFn: () => customBlocksService.getAll(projectId),
 				refetchOnWindowFocus: false,
+			});
+		},
+	},
+	canvasItems: {
+		useQuery(id: string) {
+			return useQuery({
+				queryKey: canvasKey(id),
+				queryFn: () => customBlocksService.getCanvasItems(id),
+				refetchOnWindowFocus: false,
+			});
+		},
+	},
+	saveCanvas: {
+		mutation(id: string) {
+			const qc = useQueryClient();
+			return useMutation({
+				mutationFn: (payload: CanvasSavePayload) =>
+					customBlocksService.saveCanvasItems(id, payload),
+				onSuccess: () => qc.invalidateQueries({ queryKey: canvasKey(id) }),
 			});
 		},
 	},

--- a/apps/portal/src/routes/_authed/$projectId/custom-blocks.tsx
+++ b/apps/portal/src/routes/_authed/$projectId/custom-blocks.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import {
 	Button,
 	Card,
@@ -25,6 +25,7 @@ function CustomBlocksPage() {
 	const { projectId } = Route.useParams();
 	const { data, isLoading, isError } = customBlocksQuery.getAll.useQuery(projectId);
 	const remove = customBlocksQuery.remove.mutation(projectId);
+	const navigate = useNavigate();
 	const [pendingDelete, setPendingDelete] = useState<Block | null>(null);
 
 	return (
@@ -58,7 +59,18 @@ function CustomBlocksPage() {
 									{block.description || "No description"}
 								</p>
 							</Card.Content>
-							<Card.Footer>
+							<Card.Footer className="flex items-center gap-2">
+								<Button
+									variant="ghost"
+									onPress={() =>
+										navigate({
+											to: "/$projectId/custom-block-canvas/$blockId",
+											params: { projectId, blockId: block.id },
+										})
+									}
+								>
+									Open canvas
+								</Button>
 								<Button
 									isIconOnly
 									variant="ghost"

--- a/apps/portal/src/routes/_authed/$projectId_.canvas.$routeId.tsx
+++ b/apps/portal/src/routes/_authed/$projectId_.canvas.$routeId.tsx
@@ -1,128 +1,22 @@
-import { useMemo, useRef, useState } from "react";
 import { createFileRoute } from "@tanstack/react-router";
-import { Button, Spinner, toast } from "@fluxify/components";
 import { routesQuery } from "@/query/routesQuery";
 import { routesService } from "@/services/routes";
-import { showErrorNotification } from "@/lib/errorNotifier";
-import {
-	BlockCanvas,
-	createBlockNodeTypes,
-	emptyGraph,
-	saveWithDoctor,
-} from "@/components/canvas";
-import type { BlockData, CanvasGraph, ChangeSet } from "@/components/canvas";
-
-type ServerCanvas = Awaited<ReturnType<typeof routesService.getCanvasItems>>;
-
-function toGraph(data: ServerCanvas | undefined): CanvasGraph {
-	if (!data) return emptyGraph;
-	return {
-		blocks: data.blocks.map((block) => ({
-			id: block.id,
-			type: block.type,
-			position: block.position,
-			data: (block.data ?? {}) as BlockData,
-		})),
-		edges: data.edges,
-	};
-}
+import { CanvasWorkbench } from "@/components/canvas";
 
 export const Route = createFileRoute("/_authed/$projectId_/canvas/$routeId")({
-	component: CanvasDemoPage,
+	component: RouteCanvasPage,
 });
 
-const nodeTypes = createBlockNodeTypes();
-
-/** Dummy host page for the canvas package — loads a route's graph client-side. */
-function CanvasDemoPage() {
+function RouteCanvasPage() {
 	const { routeId } = Route.useParams();
-	const canvas = routesQuery.canvasItems.useQuery(routeId);
 	const save = routesQuery.saveCanvas.mutation(routeId);
-	const [readOnly, setReadOnly] = useState(false);
-	const [pendingCount, setPendingCount] = useState(0);
-	const [isSaving, setIsSaving] = useState(false);
-	// Latest graph + delta reported by the canvas; only the delta gets saved.
-	const edited = useRef<{ graph: CanvasGraph; changes: ChangeSet } | null>(null);
-
-	async function onSave() {
-		const current = edited.current;
-		if (!current || isSaving) return;
-		setIsSaving(true);
-		try {
-			const outcome = await saveWithDoctor({
-				graph: current.graph,
-				changes: current.changes,
-				save: (payload) => save.mutateAsync(payload),
-				// Diagnose against what the server actually holds.
-				loadServerGraph: async () =>
-					toGraph(await routesService.getCanvasItems(routeId)),
-			});
-			edited.current = null;
-			setPendingCount(0);
-			toast.success(
-				outcome.repaired
-					? `Canvas saved after fixing ${outcome.notes.length} issue(s)`
-					: "Canvas saved",
-			);
-		} catch (error) {
-			// Both the save and the repaired retry failed — this is for the user.
-			showErrorNotification(error as Error);
-		} finally {
-			setIsSaving(false);
-		}
-	}
-
-	const graph = useMemo(() => toGraph(canvas.data), [canvas.data]);
 
 	return (
-		<div className="flex h-screen w-full flex-col">
-			<header className="flex items-center gap-4 border-b border-border px-4 py-2 text-sm">
-				<span className="font-medium">Canvas sandbox</span>
-				<label className="flex items-center gap-2">
-					<input
-						type="checkbox"
-						checked={readOnly}
-						onChange={(e) => setReadOnly(e.target.checked)}
-					/>
-					Read only
-				</label>
-				<span className="text-muted">
-					{graph.blocks.length} blocks · {graph.edges.length} edges ·{" "}
-					{pendingCount} unsaved
-				</span>
-				{!readOnly && (
-					<Button
-						variant="primary"
-						isDisabled={pendingCount === 0 || isSaving}
-						isPending={isSaving}
-						onPress={() => void onSave()}
-					>
-						Save
-					</Button>
-				)}
-			</header>
-
-			<div className="min-h-0 flex-1">
-				{canvas.isLoading ? (
-					<div className="flex h-full items-center justify-center">
-						<Spinner />
-					</div>
-				) : canvas.isError ? (
-					<div className="flex h-full items-center justify-center text-muted">
-						Couldn't load the graph.
-					</div>
-				) : (
-					<BlockCanvas
-						graph={graph}
-						mode={readOnly ? "readonly" : "edit"}
-						nodeTypes={nodeTypes}
-						onChange={(next, changes) => {
-							edited.current = { graph: next, changes };
-							setPendingCount(changes.blocks.size + changes.edges.size);
-						}}
-					/>
-				)}
-			</div>
-		</div>
+		<CanvasWorkbench
+			title="Route canvas"
+			items={routesQuery.canvasItems.useQuery(routeId)}
+			reload={() => routesService.getCanvasItems(routeId)}
+			save={(payload) => save.mutateAsync(payload)}
+		/>
 	);
 }

--- a/apps/portal/src/routes/_authed/$projectId_.custom-block-canvas.$blockId.tsx
+++ b/apps/portal/src/routes/_authed/$projectId_.custom-block-canvas.$blockId.tsx
@@ -1,0 +1,24 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { customBlocksQuery } from "@/query/customBlocksQuery";
+import { customBlocksService } from "@/services/customBlocks";
+import { CanvasWorkbench } from "@/components/canvas";
+
+export const Route = createFileRoute(
+	"/_authed/$projectId_/custom-block-canvas/$blockId",
+)({
+	component: CustomBlockCanvasPage,
+});
+
+function CustomBlockCanvasPage() {
+	const { blockId } = Route.useParams();
+	const save = customBlocksQuery.saveCanvas.mutation(blockId);
+
+	return (
+		<CanvasWorkbench
+			title="Custom block canvas"
+			items={customBlocksQuery.canvasItems.useQuery(blockId)}
+			reload={() => customBlocksService.getCanvasItems(blockId)}
+			save={(payload) => save.mutateAsync(payload)}
+		/>
+	);
+}

--- a/apps/portal/src/services/canvas.test.ts
+++ b/apps/portal/src/services/canvas.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, mock } from "bun:test";
+
+const calls: { method: string; url: string; body?: unknown }[] = [];
+mock.module("@/lib/http", () => ({
+	httpClient: {
+		get: async (url: string) => {
+			calls.push({ method: "get", url });
+			return { data: { blocks: [], edges: [] } };
+		},
+		put: async (url: string, body: unknown) => {
+			calls.push({ method: "put", url, body });
+			return { data: null };
+		},
+		post: async () => ({ data: null }),
+		delete: async () => ({ data: null }),
+	},
+}));
+
+const { routesService } = await import("./routes");
+const { customBlocksService } = await import("./customBlocks");
+
+const payload = {
+	actionsToPerform: { blocks: [], edges: [] },
+	changes: { blocks: [], edges: [] },
+};
+
+// The point of the shared factory: a custom block's canvas is the same two
+// endpoints as a route's, under a different base.
+describe("canvas endpoints", () => {
+	it("hits the same paths for both parents", async () => {
+		calls.length = 0;
+		await routesService.getCanvasItems("r-1");
+		await routesService.saveCanvasItems("r-1", payload);
+		await customBlocksService.getCanvasItems("cb-1");
+		await customBlocksService.saveCanvasItems("cb-1", payload);
+
+		expect(calls.map((c) => `${c.method} ${c.url}`)).toEqual([
+			"get /v1/routes/r-1/canvas-items",
+			"put /v1/routes/r-1/save-canvas",
+			"get /v1/custom-blocks/cb-1/canvas-items",
+			"put /v1/custom-blocks/cb-1/save-canvas",
+		]);
+		expect(calls[3].body).toEqual(payload);
+	});
+});

--- a/apps/portal/src/services/canvas.ts
+++ b/apps/portal/src/services/canvas.ts
@@ -1,0 +1,43 @@
+import { httpClient } from "@/lib/http";
+
+/**
+ * One canvas contract on the client, mirroring the server's: routes and custom
+ * blocks store the same blocks and edges and expose the same two endpoints, so
+ * they differ by base URL and nothing else.
+ */
+export type CanvasAction = { id: string; action: "upsert" | "delete" };
+export type CanvasSavePayload = {
+	actionsToPerform: { blocks: CanvasAction[]; edges: CanvasAction[] };
+	changes: {
+		blocks: {
+			id: string;
+			type: string;
+			data: unknown;
+			position: { x: number; y: number };
+		}[];
+		edges: {
+			id: string;
+			from: string;
+			to: string;
+			fromHandle: string;
+			toHandle: string;
+		}[];
+	};
+};
+
+export type CanvasItems = {
+	blocks: { id: string; type: string; data: unknown; position: { x: number; y: number } }[];
+	edges: { id: string; from: string; to: string; fromHandle: string; toHandle: string }[];
+};
+
+export function canvasEndpoints(baseUrl: string) {
+	return {
+		async getCanvasItems(id: string): Promise<CanvasItems> {
+			const result = await httpClient.get(`${baseUrl}/${id}/canvas-items`);
+			return result.data;
+		},
+		async saveCanvasItems(id: string, payload: CanvasSavePayload) {
+			await httpClient.put(`${baseUrl}/${id}/save-canvas`, payload);
+		},
+	};
+}

--- a/apps/portal/src/services/customBlocks.ts
+++ b/apps/portal/src/services/customBlocks.ts
@@ -5,6 +5,7 @@ import {
 	responseSchema as createResponseSchema,
 } from "@fluxify/server/src/api/v1/custom-blocks/create/dto";
 import { httpClient } from "@/lib/http";
+import { canvasEndpoints } from "./canvas";
 
 const baseUrl = "/v1/custom-blocks";
 
@@ -22,5 +23,7 @@ export const customBlocksService = {
 	async delete(id: string) {
 		await httpClient.delete(`${baseUrl}/${id}`);
 	},
+	// a custom block's canvas is stored and served exactly like a route's
+	...canvasEndpoints(baseUrl),
 	createRequestSchema,
 };

--- a/apps/portal/src/services/routes.ts
+++ b/apps/portal/src/services/routes.ts
@@ -5,22 +5,15 @@ import {
 	responseSchema as createResponseSchema,
 } from "@fluxify/server/src/api/v1/routes/create/dto";
 import { requestBodySchema as updatePartialRequestSchema } from "@fluxify/server/src/api/v1/routes/update-partial/dto";
-import { responseSchema as canvasItemsResponseSchema } from "@fluxify/server/src/api/v1/routes/get-canvas-items/dto";
 import { responseSchema as getByIdResponseSchema } from "@fluxify/server/src/api/v1/routes/get-by-id/dto";
 import { httpClient } from "@/lib/http";
+import { canvasEndpoints } from "./canvas";
 
 const baseUrl = "/v1/routes";
 
 export type ListRoutesQuery = { page?: number; perPage?: number; projectId: string };
 
-type CanvasAction = { id: string; action: "upsert" | "delete" };
-export type CanvasSavePayload = {
-	actionsToPerform: { blocks: CanvasAction[]; edges: CanvasAction[] };
-	changes: {
-		blocks: { id: string; type: string; data: unknown; position: { x: number; y: number } }[];
-		edges: { id: string; from: string; to: string; fromHandle: string; toHandle: string }[];
-	};
-};
+export type { CanvasSavePayload } from "./canvas";
 
 export const routesService = {
 	async getAll(
@@ -49,20 +42,12 @@ export const routesService = {
 	async delete(id: string) {
 		await httpClient.delete(`${baseUrl}/${id}`);
 	},
-	async getCanvasItems(
-		routeId: string,
-	): Promise<z.infer<typeof canvasItemsResponseSchema>> {
-		const result = await httpClient.get(`${baseUrl}/${routeId}/canvas-items`);
-		return result.data;
-	},
+	...canvasEndpoints(baseUrl),
 	async getById(
 		routeId: string,
 	): Promise<z.infer<typeof getByIdResponseSchema>> {
 		const result = await httpClient.get(`${baseUrl}/${routeId}`);
 		return result.data;
-	},
-	async saveCanvasItems(routeId: string, payload: CanvasSavePayload) {
-		await httpClient.put(`${baseUrl}/${routeId}/save-canvas`, payload);
 	},
 	createRequestSchema,
 };


### PR DESCRIPTION
Closes #176.

## The premise was off

The issue asks to *migrate* the portal's canvas editors to the unified model. There was only ever one: the portal has no custom block canvas editor and never had. Nothing in the portal referenced `custom_block_graphs` or the removed columns either — the only file that touched a canvas endpoint was `services/routes.ts`.

So this builds the missing half instead, on the shared model the server already exposes.

## One client model

Routes and custom blocks serve the same blocks and edges from the same endpoint shape (`/:id/canvas-items`, `/:id/save-canvas`), so the client difference is the base URL and nothing else:

- `services/canvas.ts` — the payload types and a `canvasEndpoints(baseUrl)` factory both services spread.
- `components/canvas/CanvasWorkbench.tsx` — the canvas host, extracted from the route canvas page unchanged. It takes `items` / `reload` / `save` rather than a parent type, so it knows nothing about what the canvas hangs off.
- Both file routes are now ~20 lines. The custom block one is `/$projectId/custom-block-canvas/$blockId`, linked from the custom blocks list.

The custom block canvas round-trips positions and edges because the server writes it through the same `saveCanvas` as a route's — that came with the storage migration, this is the UI that exercises it.

## Not collapsed

`components/editor/` (used by `/$projectId/editor/$routeId`) is a second, older canvas UI predating `components/canvas`. Its divergence was never about storage, so it is out of scope here and untouched.

## Testing

`services/canvas.test.ts` asserts both services hit the four expected URLs through the shared factory — the thing that breaks silently if the bases drift.

`bun test` in `apps/portal`: 49 pass, 0 fail. Lint clean across all packages.

Manual DoD (create / move / connect / delete, reload, on both parent types) still wants a run against a live server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
