### PR TITLE
feat(harness): apply artifacts through the internal ops bus

### DIFF
--- a/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/normalize.spec.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/normalize.spec.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from "bun:test";
+import {
+	canvasChangesFromPayload,
+	routeOpFromPayload,
+	type CanvasItems,
+} from "./normalize";
+
+const EMPTY: CanvasItems = { blocks: [], edges: [] };
+
+describe("routeOpFromPayload", () => {
+	it("turns a create output into the ops create request", () => {
+		const op = routeOpFromPayload(
+			{
+				action: "create",
+				routeId: "agent-generated",
+				data: {
+					name: " Create Order ",
+					method: "post",
+					path: "orders//new",
+					bodySchema: { dataType: "object" },
+					querySchema: null,
+				},
+			},
+			"proj-1",
+		);
+
+		expect(op as Record<string, unknown>).toEqual({
+			action: "create",
+			data: {
+				name: "Create Order",
+				path: "/orders/new",
+				method: "POST",
+				projectId: "proj-1",
+				bodySchema: { dataType: "object" },
+			},
+		});
+	});
+
+	it("renames update-partial to the subject's action and drops schemas", () => {
+		const op = routeOpFromPayload(
+			{
+				action: "update-partial",
+				routeId: "r-1",
+				data: { name: "Renamed", bodySchema: { dataType: "object" } },
+			},
+			"proj-1",
+		);
+
+		expect(op as Record<string, unknown>).toEqual({
+			action: "modify",
+			id: "r-1",
+			data: { name: "Renamed" },
+		});
+	});
+});
+
+describe("canvasChangesFromPayload", () => {
+	const newCanvas = {
+		targetType: "route" as const,
+		targetId: "r-1",
+		blocks: [
+			{
+				id: "block_1",
+				blockType: "errorHandler",
+				blockName: "Errors",
+				position: { x: 0, y: 0 },
+				connections: [{ blockId: "block_2", handle: "source" }],
+			},
+			{
+				id: "block_2",
+				blockType: "response",
+				data: { status: 200 },
+				position: { x: 0, y: 100 },
+				connections: [],
+			},
+		],
+	};
+
+	it("mints real ids, canonicalizes types and expands handles", () => {
+		const result = canvasChangesFromPayload(newCanvas, EMPTY);
+
+		const [first, second] = result.changes.blocks;
+		expect(first.id).not.toBe("block_1");
+		expect(second.id).not.toBe("block_2");
+		// `errorHandler` is what the model says; `error_handler` is what storage
+		// counts when it enforces exactly one per canvas
+		expect(first.type).toBe("error_handler");
+		expect(first.data).toEqual({ blockName: "Errors" });
+
+		const [edge] = result.changes.edges;
+		expect(edge.from).toBe(first.id);
+		expect(edge.to).toBe(second.id);
+		expect(edge.fromHandle).toBe(`${first.id}-source`);
+		expect(edge.toHandle).toBe(`${second.id}-target`);
+
+		expect(result.actionsToPerform.blocks).toEqual([
+			{ id: first.id, action: "upsert" },
+			{ id: second.id, action: "upsert" },
+		]);
+		expect(result.actionsToPerform.edges).toEqual([
+			{ id: edge.id, action: "upsert" },
+		]);
+	});
+
+	it("keeps stored ids and reuses the stored edge id", () => {
+		const existing: CanvasItems = {
+			blocks: [
+				{ id: "stored-a", type: "entrypoint", data: {}, position: { x: 0, y: 0 } },
+				{ id: "stored-b", type: "response", data: {}, position: { x: 0, y: 100 } },
+			],
+			edges: [
+				{
+					id: "edge-1",
+					from: "stored-a",
+					to: "stored-b",
+					fromHandle: "stored-a-source",
+					toHandle: "stored-b-target",
+				},
+			],
+		};
+
+		const result = canvasChangesFromPayload(
+			{
+				targetType: "route",
+				targetId: "r-1",
+				canvasChanges: [
+					{
+						type: "block_change",
+						data: {
+							blocksInfo: [
+								{
+									id: "stored-a",
+									blockType: "entrypoint",
+									position: { x: 5, y: 5 },
+									connections: [{ blockId: "stored-b", handle: "source" }],
+								},
+							],
+						},
+					},
+				],
+			},
+			existing,
+		);
+
+		expect(result.changes.blocks.map((b) => b.id)).toEqual(["stored-a"]);
+		// same endpoints as the stored edge, so it updates rather than duplicates
+		expect(result.changes.edges).toEqual([
+			{
+				id: "edge-1",
+				from: "stored-a",
+				to: "stored-b",
+				fromHandle: "stored-a-source",
+				toHandle: "stored-b-target",
+			},
+		]);
+	});
+
+	it("removes blocks and drops edges that would dangle", () => {
+		const existing: CanvasItems = {
+			blocks: [
+				{ id: "stored-a", type: "entrypoint", data: {}, position: { x: 0, y: 0 } },
+				{ id: "stored-b", type: "response", data: {}, position: { x: 0, y: 100 } },
+			],
+			edges: [],
+		};
+
+		const result = canvasChangesFromPayload(
+			{
+				targetType: "route",
+				targetId: "r-1",
+				blocks: [
+					{
+						id: "block_1",
+						blockType: "consolelog",
+						position: { x: 0, y: 0 },
+						// one target is being removed, the other was never declared
+						connections: [
+							{ blockId: "stored-b", handle: "source" },
+							{ blockId: "ghost", handle: "source" },
+						],
+					},
+				],
+				canvasChanges: [
+					{ type: "block_remove", data: { blocks: ["stored-b"], reason: "unused" } },
+				],
+			},
+			existing,
+		);
+
+		expect(result.changes.edges).toEqual([]);
+		expect(result.actionsToPerform.blocks).toContainEqual({
+			id: "stored-b",
+			action: "delete",
+		});
+	});
+
+	it("re-routes an existing edge in place", () => {
+		const existing: CanvasItems = {
+			blocks: [
+				{ id: "a", type: "entrypoint", data: {}, position: { x: 0, y: 0 } },
+				{ id: "b", type: "response", data: {}, position: { x: 0, y: 100 } },
+				{ id: "c", type: "consolelog", data: {}, position: { x: 0, y: 200 } },
+			],
+			edges: [
+				{ id: "edge-1", from: "a", to: "b", fromHandle: "a-source", toHandle: "b-target" },
+			],
+		};
+
+		const result = canvasChangesFromPayload(
+			{
+				targetType: "route",
+				targetId: "r-1",
+				canvasChanges: [
+					{
+						type: "edge_swap",
+						data: { fromEdge: "a", fromHandle: "source", toEdge: "c", toHandle: "target" },
+					},
+				],
+			},
+			existing,
+		);
+
+		expect(result.changes.edges).toEqual([
+			{ id: "edge-1", from: "a", to: "c", fromHandle: "a-source", toHandle: "c-target" },
+		]);
+	});
+});

--- a/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/normalize.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/normalize.ts
@@ -1,0 +1,265 @@
+import { BlockTypes } from "@fluxify/blocks";
+import { generateID } from "@fluxify/lib";
+import type { canvasChangesSchema } from "@fluxify/server/src/modules/canvas/types";
+import type { z } from "zod";
+
+/**
+ * Sub-agent output is written to `agent_harness_sub_artifacts` verbatim — it is
+ * a record of what the model proposed, in the shape the model was asked for.
+ * The project's own contract is different, so everything here turns one into
+ * the other at apply time.
+ *
+ * Three gaps this closes, all of which produce a broken canvas if skipped:
+ *  - block ids: the prompt tells the agent to emit `block_1`, not a UUID
+ *  - handle ids: edges persist `<blockId>-<kind>`, the agent emits bare `source`
+ *  - block types: the agent may emit `errorHandler` where storage wants
+ *    `error_handler`
+ */
+
+export type CanvasChanges = z.infer<typeof canvasChangesSchema>;
+
+/** What the canvas currently holds, as `fluxify.ops.canvas` returns it. */
+export type CanvasItems = {
+	blocks: { id: string; type: string; data: unknown; position: { x: number; y: number } }[];
+	edges: {
+		id: string;
+		from: string;
+		to: string;
+		fromHandle?: string | null;
+		toHandle?: string | null;
+	}[];
+};
+
+type AgentBlock = {
+	id: string;
+	blockType: string;
+	blockName?: string | null;
+	blockDescription?: string | null;
+	data?: Record<string, unknown> | null;
+	position?: { x?: number; y?: number } | null;
+	connections?: { blockId: string; handle?: string | null }[] | null;
+};
+
+export type BlockBuilderPayload = {
+	targetType?: "route" | "custom_block";
+	targetId?: string;
+	blocks?: AgentBlock[] | null;
+	canvasChanges?: { type: string; data: any }[] | null;
+};
+
+export type RouteConfigPayload = {
+	action?: "create" | "delete" | "update-partial";
+	routeId?: string | null;
+	data?: {
+		name?: string | null;
+		method?: string | null;
+		path?: string | null;
+		bodySchema?: unknown;
+		paramsSchema?: unknown;
+		querySchema?: unknown;
+	} | null;
+};
+
+/* ------------------------------------------------------------------ routes */
+
+function normalizePath(path: string) {
+	const trimmed = path.trim();
+	const rooted = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+	// the route regex rejects `//`, and a model joining segments produces it
+	return rooted.replace(/\/{2,}/g, "/");
+}
+
+/** Drops keys the model left null — the create DTO treats null and absent
+ *  differently, and `.optional()` rejects null. */
+function compact<T extends Record<string, unknown>>(value: T) {
+	return Object.fromEntries(
+		Object.entries(value).filter(([, v]) => v !== null && v !== undefined),
+	);
+}
+
+/**
+ * A route sub-artifact as the `fluxify.ops.route` subject wants it. `projectId`
+ * comes from the request path, never from the payload — the agent does not get
+ * to pick which project it writes to.
+ */
+export function routeOpFromPayload(payload: RouteConfigPayload, projectId: string) {
+	const action = payload.action ?? "create";
+	const data = payload.data ?? {};
+
+	if (action === "delete") {
+		if (!payload.routeId) throw new Error("Route delete output has no routeId");
+		return { action: "delete" as const, id: payload.routeId };
+	}
+
+	const common = compact({
+		name: data.name?.trim(),
+		path: data.path ? normalizePath(data.path) : undefined,
+		// the method enum is upper case; a model writing `get` is routine
+		method: data.method?.trim().toUpperCase(),
+	});
+
+	if (action === "update-partial") {
+		if (!payload.routeId) throw new Error("Route update output has no routeId");
+		// update-partial takes name/path/method only; schemas are not editable
+		// through it, and sending them would fail validation rather than apply.
+		return { action: "modify" as const, id: payload.routeId, data: common };
+	}
+
+	return {
+		action: "create" as const,
+		data: {
+			...common,
+			projectId,
+			...compact({
+				bodySchema: data.bodySchema,
+				querySchema: data.querySchema,
+				paramsSchema: data.paramsSchema,
+			}),
+		},
+	};
+}
+
+/* ------------------------------------------------------------------ canvas */
+
+/** `errorHandler` / `HTTP_Request` → the exact string storage stores. */
+const CANONICAL_TYPE = new Map(
+	Object.values(BlockTypes).map((type) => [key(type), type as string]),
+);
+
+function key(value: string) {
+	return value.replace(/_/g, "").toLowerCase();
+}
+
+function canonicalType(raw: string) {
+	// custom blocks are named by the user, so only built-ins are mapped
+	if (raw.startsWith("custom:")) return raw;
+	return CANONICAL_TYPE.get(key(raw)) ?? raw;
+}
+
+/** Edges persist `<blockId>-<kind>`; the agent emits the bare kind. */
+function fullHandle(blockId: string, handle: string | null | undefined, fallback: string) {
+	const kind = (handle ?? fallback).trim() || fallback;
+	return kind.startsWith(`${blockId}-`) ? kind : `${blockId}-${kind}`;
+}
+
+/**
+ * One block-builder output plus the canvas it lands on, as a save-canvas
+ * payload. `existing` decides which ids are real: anything the agent names that
+ * is not already stored is a new block and gets a generated id, and every
+ * reference to it is remapped to match.
+ */
+export function canvasChangesFromPayload(
+	payload: BlockBuilderPayload,
+	existing: CanvasItems,
+): CanvasChanges {
+	const storedIds = new Set(existing.blocks.map((b) => b.id));
+	const minted = new Map<string, string>();
+	const idFor = (raw: string) => {
+		if (storedIds.has(raw)) return raw;
+		let id = minted.get(raw);
+		if (!id) {
+			id = generateID();
+			minted.set(raw, id);
+		}
+		return id;
+	};
+
+	const changes = payload.canvasChanges ?? [];
+	const edited: AgentBlock[] = changes
+		.filter((c) => c?.type === "block_change")
+		.flatMap((c) => (c.data?.blocksInfo ?? []) as AgentBlock[]);
+	const declared = [...(payload.blocks ?? []), ...edited].filter((b) => b?.id);
+
+	const removed = new Set<string>();
+	for (const change of changes) {
+		if (change?.type !== "block_remove") continue;
+		for (const id of (change.data?.blocks ?? []) as string[]) {
+			if (storedIds.has(id)) removed.add(id);
+		}
+	}
+
+	// An edge to a block that is neither stored nor declared has no endpoint to
+	// point at; save-canvas would reject the whole payload for it.
+	const known = new Set([...storedIds, ...declared.map((b) => b.id)]);
+
+	const blocks = declared
+		.filter((b) => !removed.has(b.id))
+		.map((block) => ({
+			id: idFor(block.id),
+			type: canonicalType(block.blockType ?? ""),
+			// name and description live inside `data` (see `baseBlockDataSchema`),
+			// but the agent reports them as siblings of it
+			data: {
+				...(block.data ?? {}),
+				...(block.blockName ? { blockName: block.blockName } : {}),
+				...(block.blockDescription
+					? { blockDescription: block.blockDescription }
+					: {}),
+			},
+			position: {
+				x: Number(block.position?.x ?? 0),
+				y: Number(block.position?.y ?? 0),
+			},
+		}));
+
+	const edges: CanvasChanges["changes"]["edges"] = [];
+	const seen = new Set<string>();
+	const storedEdgeId = new Map(
+		existing.edges.map((e) => [`${e.from}|${e.fromHandle ?? ""}|${e.to}`, e.id]),
+	);
+
+	function addEdge(from: string, to: string, handle: string, id?: string) {
+		const fromHandle = fullHandle(from, handle, "source");
+		const toHandle = fullHandle(to, null, "target");
+		const dedupe = `${from}|${fromHandle}|${to}`;
+		if (seen.has(dedupe)) return;
+		seen.add(dedupe);
+		edges.push({
+			// reuse the stored id so re-applying updates rather than duplicates
+			id: id ?? storedEdgeId.get(dedupe) ?? generateID(),
+			from,
+			to,
+			fromHandle,
+			toHandle,
+		});
+	}
+
+	for (const block of declared) {
+		if (removed.has(block.id)) continue;
+		for (const connection of block.connections ?? []) {
+			if (!connection?.blockId || !known.has(connection.blockId)) continue;
+			if (removed.has(connection.blockId)) continue;
+			addEdge(idFor(block.id), idFor(connection.blockId), connection.handle ?? "source");
+		}
+	}
+
+	for (const change of changes) {
+		if (change?.type !== "edge_swap") continue;
+		const { fromEdge, fromHandle, toEdge, toHandle } = change.data ?? {};
+		if (!fromEdge || !toEdge || !known.has(fromEdge) || !known.has(toEdge)) continue;
+		const from = idFor(fromEdge);
+		const handle = fullHandle(from, fromHandle, "source");
+		// Re-routing means the edge already off that handle now points elsewhere,
+		// so keep its id: it is an update, not a second edge off one socket.
+		const previous = existing.edges.find(
+			(e) => e.from === from && (e.fromHandle ?? "") === handle,
+		);
+		// `toHandle` is ignored on purpose: every block has exactly one inbound
+		// socket, so the target side is always `<to>-target`.
+		void toHandle;
+		addEdge(from, idFor(toEdge), fromHandle ?? "source", previous?.id);
+	}
+
+	return {
+		actionsToPerform: {
+			blocks: [
+				...blocks.map((b) => ({ id: b.id, action: "upsert" as const })),
+				...[...removed].map((id) => ({ id, action: "delete" as const })),
+			],
+			// edges of a removed block go with it (the FK cascades), so only
+			// upserts are ever listed here
+			edges: edges.map((e) => ({ id: e.id, action: "upsert" as const })),
+		},
+		changes: { blocks, edges },
+	};
+}

--- a/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/opsClient.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/opsClient.ts
@@ -1,0 +1,104 @@
+import {
+	RPC_SUBJECTS,
+	RpcError,
+	rpcRequest,
+	type RpcCaller,
+} from "@fluxify/server/src/db/natsRpc";
+import {
+	BadRequestError,
+	ConflictError,
+	ForbiddenError,
+	NotFoundError,
+} from "@fluxify/server";
+import type { CanvasChanges, CanvasItems } from "./normalize";
+
+/**
+ * The harness writes artifacts through the internal req/res bus, not by
+ * touching the tables. `@fluxify/server` owns route, custom block and canvas
+ * persistence; this app only asks for it.
+ *
+ * The HTTP endpoint above stays the authorization edge — it authenticates the
+ * request and hands the result down as `caller`. Nothing here invents identity.
+ */
+export function callerFor(userId: string, projectId: string): RpcCaller {
+	return { userId, projectIds: [projectId] };
+}
+
+/**
+ * Wire codes back into the HTTP errors this app already reports. `PARENT_NOT_FOUND`
+ * and `VALIDATION_FAILED` are things the user (or a follow-up run) can act on;
+ * `INTERNAL` and `TIMEOUT` are failures, so they stay 500s.
+ */
+export function fromRpcError(error: unknown) {
+	if (!(error instanceof RpcError)) return error;
+	switch (error.code) {
+		case "PARENT_NOT_FOUND":
+		case "NOT_FOUND":
+			return new NotFoundError(error.message);
+		case "VALIDATION_FAILED":
+		case "PAYLOAD_TOO_LARGE":
+			return new BadRequestError(error.message);
+		case "CONFLICT":
+			return new ConflictError(error.message);
+		case "FORBIDDEN":
+			return new ForbiddenError(error.message);
+		default:
+			return error;
+	}
+}
+
+async function call<T>(subject: string, caller: RpcCaller, payload: unknown) {
+	try {
+		return await rpcRequest<unknown, T>(subject, caller, payload);
+	} catch (error) {
+		throw fromRpcError(error);
+	}
+}
+
+/** Create a route, optionally with its whole canvas in the same transaction so
+ *  an approved plan cannot half-apply. Returns the id storage actually chose. */
+export function createRoute(
+	caller: RpcCaller,
+	data: Record<string, unknown>,
+	canvas?: CanvasChanges,
+) {
+	return call<{ id: string }>(RPC_SUBJECTS.route, caller, {
+		action: "create",
+		data,
+		canvas,
+	});
+}
+
+export function modifyRoute(
+	caller: RpcCaller,
+	id: string,
+	data: Record<string, unknown>,
+) {
+	return call<{ id: string }>(RPC_SUBJECTS.route, caller, {
+		action: "modify",
+		id,
+		data,
+	});
+}
+
+export function deleteRoute(caller: RpcCaller, id: string) {
+	return call<{ id: string }>(RPC_SUBJECTS.route, caller, { action: "delete", id });
+}
+
+/** Omitting both change fields is a read — that is how the subject is defined. */
+export function readCanvas(
+	caller: RpcCaller,
+	source: "route" | "custom_block",
+	sourceId: string,
+) {
+	return call<CanvasItems>(RPC_SUBJECTS.canvas, caller, { source, sourceId });
+}
+
+export function saveCanvas(
+	caller: RpcCaller,
+	source: "route" | "custom_block",
+	sourceId: string,
+	changes: CanvasChanges,
+) {
+	return call<null>(RPC_SUBJECTS.canvas, caller, { source, sourceId, ...changes });
+}

--- a/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/repository.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/repository.ts
@@ -93,6 +93,24 @@ export async function markSubArtifactsApplied(
 		});
 }
 
+/** The id an agent invented for a route is not the id storage chose, so the
+ *  payload is rewritten once the real one is known. */
+export async function updateSubArtifactPayload(
+	conversationId: string,
+	subArtifactId: string,
+	payload: Record<string, any>,
+) {
+	await db
+		.update(subArtifacts)
+		.set({ payload })
+		.where(
+			and(
+				eq(subArtifacts.id, subArtifactId),
+				eq(subArtifacts.conversationId, conversationId),
+			),
+		);
+}
+
 /** Which of these route ids are actually live in the project. */
 export async function findExistingRouteIds(projectId: string, routeIds: string[]) {
 	if (routeIds.length === 0) return new Set<string>();

--- a/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/route.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/route.ts
@@ -46,6 +46,9 @@ export default function (app: Hono) {
 			const param = c.req.valid("param");
 			return c.json(
 				await applySubArtifact(
+					// the authenticated identity travels into the bus envelope;
+					// the harness never invents a caller
+					c.get("user").id,
 					param.conversationId,
 					param.projectId,
 					param.subArtifactId,
@@ -62,7 +65,12 @@ export default function (app: Hono) {
 		async (c: any) => {
 			const param = c.req.valid("param");
 			return c.json(
-				await applyArtifact(param.conversationId, param.projectId, param.artifactId),
+				await applyArtifact(
+					c.get("user").id,
+					param.conversationId,
+					param.projectId,
+					param.artifactId,
+				),
 			);
 		},
 	);

--- a/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/service.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/service.ts
@@ -1,10 +1,28 @@
 import { ConflictError, NotFoundError } from "@fluxify/server";
+import type { RpcCaller } from "@fluxify/server/src/db/natsRpc";
+import {
+	canvasChangesFromPayload,
+	routeOpFromPayload,
+	type BlockBuilderPayload,
+	type CanvasChanges,
+	type CanvasItems,
+	type RouteConfigPayload,
+} from "./normalize";
+import {
+	callerFor,
+	createRoute,
+	deleteRoute,
+	modifyRoute,
+	readCanvas,
+	saveCanvas,
+} from "./opsClient";
 import {
 	findExistingRouteIds,
 	getArtifactSubArtifacts,
 	getSubArtifactById,
 	listSubArtifactsByRun,
 	markSubArtifactsApplied,
+	updateSubArtifactPayload,
 } from "./repository";
 
 /** The subset of a sub-artifact row the dependency check reads. */
@@ -25,6 +43,8 @@ const parentRouteIdOf = (row: DependencyRow) =>
 	row.payload?.targetType === "route"
 		? (row.payload?.targetId as string | undefined)
 		: undefined;
+
+const EMPTY_CANVAS: CanvasItems = { blocks: [], edges: [] };
 
 /**
  * A canvas is meaningless without its route — its blocks hang off a route id, so
@@ -83,10 +103,85 @@ export async function listRunSubArtifacts(conversationId: string, runId: string)
 }
 
 /**
- * Validates only, then stamps `applied_at`. The actual project mutation is owned
- * by `@fluxify/server` — the single source of truth for route/canvas writes.
+ * The id the agent invented for a route it was creating is not the id storage
+ * chose. Rewriting the payload keeps every later read — the artifact chips, the
+ * `get_artifact` tool, the canvas dependency check — pointing at the live route.
  */
+async function rememberRealRouteId(
+	conversationId: string,
+	row: { id: string; payload: Record<string, any> | null },
+	field: "routeId" | "targetId",
+	realId: string,
+) {
+	if (row.payload?.[field] === realId) return;
+	await updateSubArtifactPayload(conversationId, row.id, {
+		...(row.payload ?? {}),
+		[field]: realId,
+	});
+}
+
+type ApplyContext = {
+	conversationId: string;
+	projectId: string;
+	caller: RpcCaller;
+	/** the id the agent used for a route it created → the id storage gave it */
+	routeIds: Map<string, string>;
+};
+
+/**
+ * Writes one route output through the bus. `canvas` is sent inline on a create
+ * so the route and its blocks land in one transaction — an approved plan that
+ * half-applies leaves the user a route with no logic in it.
+ */
+async function applyRouteRow(
+	ctx: ApplyContext,
+	row: { id: string; payload: Record<string, any> | null },
+	canvas?: CanvasChanges,
+) {
+	const payload = (row.payload ?? {}) as RouteConfigPayload;
+	const op = routeOpFromPayload(payload, ctx.projectId);
+
+	if (op.action === "delete") {
+		await deleteRoute(ctx.caller, op.id);
+		return;
+	}
+	if (op.action === "modify") {
+		await modifyRoute(ctx.caller, op.id, op.data);
+		return;
+	}
+
+	const { id } = await createRoute(ctx.caller, op.data, canvas);
+	if (payload.routeId) ctx.routeIds.set(payload.routeId, id);
+	await rememberRealRouteId(ctx.conversationId, row, "routeId", id);
+}
+
+async function applyCanvasRow(
+	ctx: ApplyContext,
+	row: { id: string; payload: Record<string, any> | null },
+) {
+	const payload = (row.payload ?? {}) as BlockBuilderPayload;
+	const source = payload.targetType ?? "route";
+	const target = payload.targetId;
+	if (!target) throw new NotFoundError("Canvas output has no target to apply to");
+
+	const sourceId = ctx.routeIds.get(target) ?? target;
+	// Normalizing needs the canvas as it stands: it decides which block ids are
+	// already real and which edge is being re-routed.
+	const existing = await readCanvas(ctx.caller, source, sourceId);
+	await saveCanvas(
+		ctx.caller,
+		source,
+		sourceId,
+		canvasChangesFromPayload(payload, existing),
+	);
+	if (sourceId !== target) {
+		await rememberRealRouteId(ctx.conversationId, row, "targetId", sourceId);
+	}
+}
+
+/** Applies one output, then stamps `applied_at`. */
 export async function applySubArtifact(
+	userId: string,
 	conversationId: string,
 	projectId: string,
 	subArtifactId: string,
@@ -94,9 +189,19 @@ export async function applySubArtifact(
 	const row = await getSubArtifactById(conversationId, subArtifactId);
 	if (!row) throw new NotFoundError("Sub-artifact not found");
 
+	const ctx: ApplyContext = {
+		conversationId,
+		projectId,
+		caller: callerFor(userId, projectId),
+		routeIds: new Map(),
+	};
+
 	if (row.kind === "canvas") {
 		const siblings = await getArtifactSubArtifacts(conversationId, row.artifactId);
 		await assertParentRoutesReady(projectId, [row], siblings, new Set());
+		await applyCanvasRow(ctx, row);
+	} else if (row.kind === "route") {
+		await applyRouteRow(ctx, row);
 	}
 
 	const [applied] = await markSubArtifactsApplied(
@@ -109,6 +214,7 @@ export async function applySubArtifact(
 
 /** Applies every output of one run's artifact in one shot. */
 export async function applyArtifact(
+	userId: string,
 	conversationId: string,
 	projectId: string,
 	artifactId: string,
@@ -127,17 +233,73 @@ export async function applyArtifact(
 	);
 	await assertParentRoutesReady(projectId, canvases, routes, applyingRouteIds);
 
-	const ordered = [...routes, ...canvases, ...rest];
-	const appliedAt = new Date();
-	await markSubArtifactsApplied(
+	const ctx: ApplyContext = {
 		conversationId,
-		ordered.map((r) => r.id),
-		appliedAt,
-	);
+		projectId,
+		caller: callerFor(userId, projectId),
+		routeIds: new Map(),
+	};
+
+	// A canvas for a route this run is creating rides along with the create, so
+	// the route never exists without its blocks.
+	const inlineCanvas = new Map<string, (typeof canvases)[number]>();
+	const inlined = new Set<string>();
+	for (const route of routes) {
+		if (route.payload?.action !== "create") continue;
+		const paired = canvases.find(
+			(c) =>
+				!inlined.has(c.id) &&
+				c.payload?.targetType === "route" &&
+				c.payload?.targetId === routeIdOf(route),
+		);
+		if (!paired) continue;
+		inlineCanvas.set(route.id, paired);
+		inlined.add(paired.id);
+	}
+
+	const ordered = [...routes, ...canvases, ...rest];
+	const done: string[] = [];
+	try {
+		for (const route of routes) {
+			const canvasRow = inlineCanvas.get(route.id);
+			await applyRouteRow(
+				ctx,
+				route,
+				canvasRow
+					? canvasChangesFromPayload(
+							(canvasRow.payload ?? {}) as BlockBuilderPayload,
+							EMPTY_CANVAS,
+						)
+					: undefined,
+			);
+			done.push(route.id);
+			if (canvasRow) {
+				const real = ctx.routeIds.get(routeIdOf(route) ?? "");
+				if (real)
+					await rememberRealRouteId(conversationId, canvasRow, "targetId", real);
+				done.push(canvasRow.id);
+			}
+		}
+		for (const canvas of canvases) {
+			if (inlined.has(canvas.id)) continue;
+			await applyCanvasRow(ctx, canvas);
+			done.push(canvas.id);
+		}
+		done.push(...rest.map((r) => r.id));
+	} catch (error) {
+		// Whatever landed is live; stamping it keeps a retry from redoing it.
+		if (done.length > 0) await markSubArtifactsApplied(conversationId, done, new Date());
+		throw error;
+	}
+
+	const appliedAt = new Date();
+	await markSubArtifactsApplied(conversationId, done, appliedAt);
 
 	return {
 		artifactId,
 		appliedAt,
-		applied: ordered.map((r) => ({ id: r.id, kind: r.kind, action: r.action })),
+		applied: ordered
+			.filter((r) => done.includes(r.id))
+			.map((r) => ({ id: r.id, kind: r.kind, action: r.action })),
 	};
 }

--- a/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/tests/artifacts.spec.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/tests/artifacts.spec.ts
@@ -13,7 +13,30 @@ mock.module("../repository", () => ({
 	listSubArtifactsByRun: mock(),
 	getArtifactSubArtifacts: mock(),
 	markSubArtifactsApplied: mock(),
+	updateSubArtifactPayload: mock(),
 	findExistingRouteIds: mock(),
+}));
+
+/** Every project write goes over the bus, so the bus is the seam these tests
+ *  assert against — nothing here should reach NATS or the database. */
+const bus: { call: string; args: any[] }[] = [];
+const record =
+	(call: string, result?: unknown) =>
+	async (...args: any[]) => {
+		bus.push({ call, args });
+		return result;
+	};
+
+mock.module("../opsClient", () => ({
+	callerFor: (userId: string, projectId: string) => ({
+		userId,
+		projectIds: [projectId],
+	}),
+	createRoute: record("createRoute", { id: "live-route" }),
+	modifyRoute: record("modifyRoute", { id: "live-route" }),
+	deleteRoute: record("deleteRoute", { id: "live-route" }),
+	readCanvas: record("readCanvas", { blocks: [], edges: [] }),
+	saveCanvas: record("saveCanvas", null),
 }));
 
 const routeRow = (over: Record<string, any> = {}) => ({
@@ -39,6 +62,7 @@ const canvasRow = (over: Record<string, any> = {}) => ({
 /** Nothing lives in the project unless a test says so. `spyOn` keeps the same
  *  mock across tests, so call counts must be cleared or they accumulate. */
 beforeEach(() => {
+	bus.length = 0;
 	for (const fn of Object.keys(repository) as (keyof typeof repository)[]) {
 		(repository[fn] as any).mockClear?.();
 	}
@@ -73,7 +97,7 @@ describe("Harness Artifacts Service", () => {
 		spyOn(repository, "getSubArtifactById").mockResolvedValue(routeRow() as never);
 		const artifactSpy = spyOn(repository, "getArtifactSubArtifacts");
 
-		const result = await applySubArtifact("conv1", "proj1", "route-sub");
+		const result = await applySubArtifact("user1", "conv1", "proj1", "route-sub");
 
 		expect(artifactSpy).not.toHaveBeenCalled();
 		expect(result?.appliedAt).toBeInstanceOf(Date);
@@ -86,7 +110,7 @@ describe("Harness Artifacts Service", () => {
 			canvasRow(),
 		] as never);
 
-		expect(applySubArtifact("conv1", "proj1", "canvas-sub")).rejects.toThrow(
+		expect(applySubArtifact("user1", "conv1", "proj1", "canvas-sub")).rejects.toThrow(
 			serverModule.ConflictError,
 		);
 	});
@@ -98,7 +122,7 @@ describe("Harness Artifacts Service", () => {
 			canvasRow(),
 		] as never);
 
-		const result = await applySubArtifact("conv1", "proj1", "canvas-sub");
+		const result = await applySubArtifact("user1", "conv1", "proj1", "canvas-sub");
 
 		expect(result?.appliedAt).toBeInstanceOf(Date);
 	});
@@ -110,7 +134,7 @@ describe("Harness Artifacts Service", () => {
 			canvasRow(),
 		] as never);
 
-		expect(applySubArtifact("conv1", "proj1", "canvas-sub")).rejects.toThrow(
+		expect(applySubArtifact("user1", "conv1", "proj1", "canvas-sub")).rejects.toThrow(
 			serverModule.NotFoundError,
 		);
 	});
@@ -124,7 +148,7 @@ describe("Harness Artifacts Service", () => {
 			new Set(["route-1"]) as never,
 		);
 
-		const result = await applySubArtifact("conv1", "proj1", "canvas-sub");
+		const result = await applySubArtifact("user1", "conv1", "proj1", "canvas-sub");
 
 		expect(result?.appliedAt).toBeInstanceOf(Date);
 	});
@@ -138,7 +162,7 @@ describe("Harness Artifacts Service", () => {
 		spyOn(repository, "getArtifactSubArtifacts").mockResolvedValue([] as never);
 		const routesSpy = spyOn(repository, "findExistingRouteIds");
 
-		await applySubArtifact("conv1", "proj1", "canvas-sub");
+		await applySubArtifact("user1", "conv1", "proj1", "canvas-sub");
 
 		expect(routesSpy).not.toHaveBeenCalled();
 	});
@@ -146,7 +170,7 @@ describe("Harness Artifacts Service", () => {
 	it("404s an empty/unknown artifact", async () => {
 		spyOn(repository, "getArtifactSubArtifacts").mockResolvedValue([] as never);
 
-		expect(applyArtifact("conv1", "proj1", "nope")).rejects.toThrow(
+		expect(applyArtifact("user1", "conv1", "proj1", "nope")).rejects.toThrow(
 			serverModule.NotFoundError,
 		);
 	});
@@ -158,7 +182,7 @@ describe("Harness Artifacts Service", () => {
 			routeRow(),
 		] as never);
 
-		const result = await applyArtifact("conv1", "proj1", "art1");
+		const result = await applyArtifact("user1", "conv1", "proj1", "art1");
 
 		expect(result.applied.map((a) => a.id)).toEqual(["route-sub", "canvas-sub"]);
 		expect(repository.markSubArtifactsApplied).toHaveBeenCalledWith(
@@ -168,13 +192,70 @@ describe("Harness Artifacts Service", () => {
 		);
 	});
 
+	it("creates a route and its canvas in one bus call", async () => {
+		spyOn(repository, "getArtifactSubArtifacts").mockResolvedValue([
+			canvasRow(),
+			routeRow(),
+		] as never);
+
+		await applyArtifact("user1", "conv1", "proj1", "art1");
+
+		// One call, canvas included: the route must never exist without its blocks
+		expect(bus.map((b) => b.call)).toEqual(["createRoute"]);
+		const [caller, data, canvas] = bus[0].args;
+		expect(caller).toEqual({ userId: "user1", projectIds: ["proj1"] });
+		expect(data.projectId).toBe("proj1");
+		expect(canvas).toEqual({
+			actionsToPerform: { blocks: [], edges: [] },
+			changes: { blocks: [], edges: [] },
+		});
+	});
+
+	it("rewrites the agent's invented route id to the one storage chose", async () => {
+		spyOn(repository, "getArtifactSubArtifacts").mockResolvedValue([
+			canvasRow(),
+			routeRow(),
+		] as never);
+
+		await applyArtifact("user1", "conv1", "proj1", "art1");
+
+		// Both rows carried "route-1", which never existed anywhere but the model's
+		// output — every later read has to find the live route instead.
+		expect(repository.updateSubArtifactPayload).toHaveBeenCalledWith(
+			"conv1",
+			"route-sub",
+			expect.objectContaining({ routeId: "live-route" }) as never,
+		);
+		expect(repository.updateSubArtifactPayload).toHaveBeenCalledWith(
+			"conv1",
+			"canvas-sub",
+			expect.objectContaining({ targetId: "live-route" }) as never,
+		);
+	});
+
+	it("reads the canvas before saving one onto an existing route", async () => {
+		spyOn(repository, "getSubArtifactById").mockResolvedValue(canvasRow() as never);
+		spyOn(repository, "getArtifactSubArtifacts").mockResolvedValue([
+			canvasRow(),
+		] as never);
+		spyOn(repository, "findExistingRouteIds").mockResolvedValue(
+			new Set(["route-1"]) as never,
+		);
+
+		await applySubArtifact("user1", "conv1", "proj1", "canvas-sub");
+
+		// The read is what tells the normalizer which ids are already real.
+		expect(bus.map((b) => b.call)).toEqual(["readCanvas", "saveCanvas"]);
+		expect(bus[1].args.slice(1, 3)).toEqual(["route", "route-1"]);
+	});
+
 	it("404s a whole artifact whose canvas points at a deleted route", async () => {
 		spyOn(repository, "getArtifactSubArtifacts").mockResolvedValue([
 			canvasRow({ payload: { targetType: "route", targetId: "route-gone" } }),
 			routeRow(),
 		] as never);
 
-		expect(applyArtifact("conv1", "proj1", "art1")).rejects.toThrow(
+		expect(applyArtifact("user1", "conv1", "proj1", "art1")).rejects.toThrow(
 			serverModule.NotFoundError,
 		);
 	});


### PR DESCRIPTION
Closes #177.

## The write was missing entirely

`applySubArtifact` / `applyArtifact` validated the route dependency and then stamped `applied_at`. The comment said the mutation was "owned by `@fluxify/server`" — nothing ever called it. Approving a plan changed nothing in the project.

So this is not a transport swap; it is the write, done over the bus.

## What goes over the bus

- `fluxify.ops.route` for create / modify / delete, `fluxify.ops.canvas` for the graph (and to read the canvas back).
- The HTTP endpoint stays the **authorization edge**: it authenticates, then passes `{ userId, projectIds: [projectId] }` down as the envelope's `caller`. The harness never invents an identity, and `projectId` comes from the request path — never from the agent's payload.
- Wire codes map back to this app's errors in `opsClient.ts`: `PARENT_NOT_FOUND` / `NOT_FOUND` → 404, `VALIDATION_FAILED` / `PAYLOAD_TOO_LARGE` → 400, `CONFLICT` → 409, `FORBIDDEN` → 403. `INTERNAL` and `TIMEOUT` stay failures.

## Standardizing the payload

Sub-artifacts are stored verbatim — a record of what the model proposed, in the shape the model was asked for. That shape is not the canvas contract, so `normalize.ts` converts it at apply time. Four gaps, each of which silently produces a broken canvas:

| | agent emits | storage wants |
|---|---|---|
| block ids | `block_1` (the prompt forbids UUIDs) | a real id, with every `connections` reference remapped |
| handle ids | `"source"` | `<blockId>-source` / `<blockId>-target` |
| block types | `errorHandler` | `error_handler` — what save-canvas counts when it enforces one per canvas |
| route ops | `update-partial`, `get`, `orders//new` | `modify`, `GET`, `/orders/new` |

Also: `blockName` / `blockDescription` arrive as siblings of `data` and belong inside it; `connections` to a block that is neither stored nor declared are dropped rather than sent to be rejected; a re-routed edge reuses the stored edge id so it updates instead of adding a second edge to a one-connection socket; and `null` optionals are stripped, since the create DTO's `.optional()` rejects null.

The agent contract itself is left alone. `connections` on the block is the right shape to ask a model for — it cannot invent edge ids it has never seen — so the translation belongs here, against the canvas as it actually stands.

## A route and its blocks land together

A canvas whose parent route is a `create` sibling in the same artifact is sent **inline on the create**, so both land in one transaction. An approved plan can no longer half-apply into a route with no logic in it.

The route id storage chose is then written back over the one the agent invented, on both rows — otherwise the artifact chips, `get_artifact` and the canvas dependency check all keep pointing at an id that never existed. If a write does fail mid-artifact, whatever already landed is stamped applied before the error propagates, so a retry does not redo it.

## Testing

`normalize.spec.ts` covers the translation directly. `artifacts.spec.ts` now mocks the ops client and asserts against the bus: one `createRoute` carrying the canvas, the caller envelope, the id rewrite, and read-before-save on an existing route.

`bun test` in `apps/ai-gateway`: 192 pass, 0 fail. Full pre-commit suite: 518 pass. Lint clean across all 9 packages.

Wants a live run before merge: approve a plan that creates a route with a canvas, and one that edits an existing canvas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
