### PR TITLE
fix(worker): scope integrations to their owning project

### DIFF
--- a/apps/server/deployments/compiledWorker.ts
+++ b/apps/server/deployments/compiledWorker.ts
@@ -61,10 +61,22 @@ initializeLogger({
 
 if (!WORKER_PROJECT_ID) {
 	logger.error(
-		"WORKER_PROJECT_ID is required — a compiled worker serves exactly one project",
+		"WORKER_PROJECT_ID is required — set a project id, or * to serve every project",
 	);
 	process.exit(1);
 }
+
+/**
+ * `*` serves every project in the bucket. The artifact key filters are already
+ * `<kind>.<projectId>.*`, so a literal `*` is a valid KV wildcard and needs no
+ * special casing below — it just widens what this worker watches.
+ *
+ * ponytail: routes from all projects share one route table, so two projects
+ * with the same method+path collide. Fine for single-tenant and dev
+ * deployments, which is what this is for; per-project routing (host or prefix
+ * based) is the upgrade path if it ever has to serve untrusted tenants.
+ */
+const ALL_PROJECTS = WORKER_PROJECT_ID === "*";
 
 // Project config arrives sealed. Without the key the worker boots fine and then
 // fails on every request with no integrations — fail loudly here instead.
@@ -128,7 +140,9 @@ await watchProjectArtifacts(WORKER_PROJECT_ID, (entry) => {
 
 markReady();
 logger.info(
-	`compiled worker ready — ${threadCount} threads on port ${port}, project ${WORKER_PROJECT_ID}`,
+	`compiled worker ready — ${threadCount} threads on port ${port}, ${
+		ALL_PROJECTS ? "all projects" : `project ${WORKER_PROJECT_ID}`
+	}`,
 );
 
 let shuttingDown = false;

--- a/apps/server/src/lib/env.ts
+++ b/apps/server/src/lib/env.ts
@@ -42,7 +42,7 @@ export const serverEnvSchema = baseEnvSchema.extend({
 		.string()
 		.optional()
 		.describe(
-			"Project this worker serves. The compiled worker watches only this project's artifacts and never connects to the database",
+			"Project this worker serves. The compiled worker watches only this project's artifacts and never connects to the database. Set to * to serve every project in the artifact bucket (single-tenant and dev deployments — route paths are shared across projects)",
 		),
 
 	AI_API_KEY: z

--- a/apps/server/src/loaders/integrationsLoader.ts
+++ b/apps/server/src/loaders/integrationsLoader.ts
@@ -36,20 +36,71 @@ export let observabilityIntegrationsCache: Record<string, any> = {};
 export let aiIntegrationsCache: Record<string, any> = {};
 
 /**
+ * Every cached config carries the id of the project that owns it. Nothing else
+ * in the cache records ownership — the key is the integration id — so without
+ * this any code holding the cache can hand one project's credentials to
+ * another. Prefixed to keep it clear of the connection fields adapters read.
+ */
+export const OWNER_KEY = "__projectId";
+
+/** null owner = not project-scoped, usable by everyone */
+export function ownsIntegration(config: any, projectId: string) {
+	const owner = config?.[OWNER_KEY];
+	return !!config && (owner == null || owner === projectId);
+}
+
+/** only the entries `projectId` is allowed to see */
+export function scopeToProject<T>(
+	cache: Record<string, T>,
+	projectId: string,
+): Record<string, T> {
+	const scoped: Record<string, T> = {};
+	for (const id in cache) {
+		if (ownsIntegration(cache[id], projectId)) scoped[id] = cache[id]!;
+	}
+	return scoped;
+}
+
+/**
  * Fill the caches from an artifact instead of the database. Configs are already
  * resolved when the compiler publishes them (cfg: references expanded, urls
  * parsed), so there is nothing left to look up.
+ *
+ * Merged per project rather than replaced: a worker running with
+ * WORKER_PROJECT_ID=* holds several projects at once, and each project's config
+ * artifact arrives as its own update.
  */
-export function hydrateIntegrations(caches: {
-	db?: Record<string, any>;
-	kv?: Record<string, any>;
-	observability?: Record<string, any>;
-	ai?: Record<string, any>;
-}) {
-	if (caches.db) dbIntegrationsCache = caches.db;
-	if (caches.kv) kvIntegrationsCache = caches.kv;
-	if (caches.observability) observabilityIntegrationsCache = caches.observability;
-	if (caches.ai) aiIntegrationsCache = caches.ai;
+export function hydrateIntegrations(
+	projectId: string,
+	caches: {
+		db?: Record<string, any>;
+		kv?: Record<string, any>;
+		observability?: Record<string, any>;
+		ai?: Record<string, any>;
+	},
+) {
+	if (caches.db) dbIntegrationsCache = merge(dbIntegrationsCache, caches.db, projectId);
+	if (caches.kv) kvIntegrationsCache = merge(kvIntegrationsCache, caches.kv, projectId);
+	if (caches.observability)
+		observabilityIntegrationsCache = merge(
+			observabilityIntegrationsCache,
+			caches.observability,
+			projectId,
+		);
+	if (caches.ai) aiIntegrationsCache = merge(aiIntegrationsCache, caches.ai, projectId);
+}
+
+/** drop what this project used to own, then take what it owns now */
+function merge(
+	current: Record<string, any>,
+	incoming: Record<string, any>,
+	projectId: string,
+) {
+	const next: Record<string, any> = {};
+	for (const id in current) {
+		if (current[id]?.[OWNER_KEY] !== projectId) next[id] = current[id];
+	}
+	return Object.assign(next, incoming);
 }
 
 export async function loadIntegrations() {
@@ -162,6 +213,7 @@ async function loadFromDB() {
 		if (config) {
 			config["variant"] = variant;
 			config["group"] = group;
+			config[OWNER_KEY] = integration.projectId ?? null;
 			if (group === integrationsGroupSchema.enum.database) {
 				if (variant === databaseVariantSchema.enum.PostgreSQL) {
 					config["dbType"] = "pg";

--- a/apps/server/src/loaders/tests/integrationsScope.test.ts
+++ b/apps/server/src/loaders/tests/integrationsScope.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "bun:test";
+import {
+	OWNER_KEY,
+	dbIntegrationsCache,
+	hydrateIntegrations,
+	ownsIntegration,
+	scopeToProject,
+} from "../integrationsLoader";
+
+const owned = (projectId: string | null) => ({ [OWNER_KEY]: projectId });
+
+describe("integration ownership", () => {
+	it("keeps only the project's own integrations", () => {
+		const cache = { a: owned("p1"), b: owned("p2"), c: owned(null) };
+		// null owner is not project-scoped, so it stays
+		expect(Object.keys(scopeToProject(cache, "p1")).sort()).toEqual(["a", "c"]);
+	});
+
+	it("rejects a foreign integration", () => {
+		expect(ownsIntegration(owned("p2"), "p1")).toBe(false);
+		expect(ownsIntegration(undefined, "p1")).toBe(false);
+		expect(ownsIntegration(owned("p1"), "p1")).toBe(true);
+	});
+
+	it("merges per project instead of replacing the cache", () => {
+		hydrateIntegrations("p1", { db: { a: owned("p1") } });
+		hydrateIntegrations("p2", { db: { b: owned("p2") } });
+		expect(Object.keys(dbIntegrationsCache).sort()).toEqual(["a", "b"]);
+
+		// re-publishing p1 without `a` drops it, and leaves p2 alone
+		hydrateIntegrations("p1", { db: {} });
+		expect(Object.keys(dbIntegrationsCache)).toEqual(["b"]);
+	});
+});

--- a/apps/server/src/modules/compiler/service.ts
+++ b/apps/server/src/modules/compiler/service.ts
@@ -22,6 +22,7 @@ import {
 	dbIntegrationsCache,
 	kvIntegrationsCache,
 	observabilityIntegrationsCache,
+	scopeToProject,
 } from "../../loaders/integrationsLoader";
 import { projectSettingsCache } from "../../loaders/projectSettingsLoader";
 import type {
@@ -184,10 +185,16 @@ export async function publishProjectConfig(projectId: string) {
 			string,
 			string | number | boolean
 		>,
-		dbIntegrations: dbIntegrationsCache,
-		kvIntegrations: kvIntegrationsCache,
-		observabilityIntegrations: observabilityIntegrationsCache,
-		aiIntegrations: aiIntegrationsCache,
+		// scoped, not the whole cache: an artifact is per project, so shipping the
+		// global cache would put every tenant's database password in every other
+		// tenant's worker
+		dbIntegrations: scopeToProject(dbIntegrationsCache, projectId),
+		kvIntegrations: scopeToProject(kvIntegrationsCache, projectId),
+		observabilityIntegrations: scopeToProject(
+			observabilityIntegrationsCache,
+			projectId,
+		),
+		aiIntegrations: scopeToProject(aiIntegrationsCache, projectId),
 		projectSettings: (projectSettingsCache[projectId] ?? {}) as Record<
 			string,
 			string

--- a/apps/server/src/modules/requestRouter/compiledRuntime.ts
+++ b/apps/server/src/modules/requestRouter/compiledRuntime.ts
@@ -150,7 +150,7 @@ function removeCustomBlock(id: string) {
 function applyProjectConfig(artifact: UnsealedProjectConfig) {
 	const { payload } = artifact;
 	hydrateAppConfig(artifact.projectId, payload.appConfig);
-	hydrateIntegrations({
+	hydrateIntegrations(artifact.projectId, {
 		db: payload.dbIntegrations,
 		kv: payload.kvIntegrations,
 		observability: payload.observabilityIntegrations,

--- a/apps/server/src/modules/requestRouter/service.ts
+++ b/apps/server/src/modules/requestRouter/service.ts
@@ -26,6 +26,7 @@ import { createObservabilityLogger, DbFactory } from "@fluxify/adapters";
 import {
 	dbIntegrationsCache,
 	observabilityIntegrationsCache,
+	ownsIntegration,
 } from "../../loaders/integrationsLoader";
 import * as zodLib from "zod";
 import { projectSettingsCache } from "../../loaders/projectSettingsLoader";
@@ -144,6 +145,9 @@ export async function executeRouteInternal(
 	overrides?: RequestOverrides,
 	trigger: TriggerContext = DEFAULT_TRIGGER,
 ): Promise<HandleRequestType> {
+	const denied = assertOverridesOwned(routeInfo.projectId, overrides);
+	if (denied) return denied;
+
 	const httpClient = createHttpClient();
 	const vars = setupContextVars(
 		ctx,
@@ -209,7 +213,11 @@ export async function executeRouteInternal(
 		}
 	}
 
-	const dbFactory = createDbFactory(vm, overrides?.integrations);
+	const dbFactory = createDbFactory(
+		vm,
+		routeInfo.projectId,
+		overrides?.integrations,
+	);
 	const context = createContext(
 		routeInfo,
 		requestData,
@@ -283,8 +291,42 @@ function createHttpClient() {
 	return new HttpClient();
 }
 
+/**
+ * Every integration id an override names must belong to the project the route
+ * belongs to. Rejected outright rather than ignored: a request aimed at another
+ * tenant's integration should fail loudly, not silently run against the real one.
+ */
+function assertOverridesOwned(
+	projectId: string,
+	overrides?: RequestOverrides,
+): HandleRequestType | null {
+	const foreign = (overrides?.integrations ?? [])
+		.map((o) => o.newId)
+		.filter((id) => {
+			const config =
+				dbIntegrationsCache[id] ?? observabilityIntegrationsCache[id];
+			return config && !ownsIntegration(config, projectId);
+		});
+
+	if (foreign.length === 0) return null;
+	return {
+		status: 403,
+		data: {
+			message: "Integration override not permitted",
+			integrations: foreign,
+		},
+	};
+}
+
+/**
+ * Overrides are the integration-mocking seam: a request may point a block at a
+ * different integration id. They are request input, so the target must be
+ * checked against the project — otherwise any request can name another tenant's
+ * integration id and read their database.
+ */
 function createDbFactory(
 	vm: JsVM,
+	projectId: string,
 	integrationOverrides?: Array<{ existingId: string; newId: string }>,
 ) {
 	if (!integrationOverrides || integrationOverrides.length === 0) {
@@ -293,9 +335,11 @@ function createDbFactory(
 
 	const customDbCache = { ...dbIntegrationsCache };
 	for (const override of integrationOverrides) {
-		if (dbIntegrationsCache[override.newId]) {
-			customDbCache[override.existingId] = dbIntegrationsCache[override.newId];
-		}
+		const target = dbIntegrationsCache[override.newId];
+		// ownership is already gated by assertOverridesOwned(); this is the
+		// second half of the same check, so a missed gate cannot leak
+		if (!target || !ownsIntegration(target, projectId)) continue;
+		customDbCache[override.existingId] = target;
 	}
 	return new DbFactory(vm, customDbCache);
 }
@@ -327,13 +371,16 @@ function setupContextVars(
 			const override = overrides.integrations.find(
 				(o) => o.existingId === connectionId,
 			);
-			if (override) {
+			if (
+				override &&
+				ownsIntegration(observabilityIntegrationsCache[override.newId], projectId)
+			) {
 				connectionId = override.newId;
 			}
 		}
 
 		const config = observabilityIntegrationsCache[connectionId];
-		if (!!config) {
+		if (ownsIntegration(config, projectId)) {
 			config.projectId = projectId;
 			config.routeId = routeId;
 			logger = createObservabilityLogger(config["variant"], config)!;

--- a/docs/deployments/index.md
+++ b/docs/deployments/index.md
@@ -167,6 +167,15 @@ start.
 To serve several projects, run a separate group of workers for each. Copies of
 the same worker share their settings, so they always share a project.
 
+::: tip Serving every project from one worker
+Set `WORKER_PROJECT_ID` to `*` and the worker serves every project you have,
+picking up new ones as you create them — no restart, no id to copy.
+
+Good for a personal install or a staging box. Not recommended when projects
+belong to different people: they share one worker, so a route path used by two
+projects can only resolve to one of them, and a slow project slows the rest.
+:::
+
 ---
 
 ## Next steps


### PR DESCRIPTION
Closes #187.

## Why

`publishProjectConfig(projectId)` embedded the **global** integration caches — db, kv, observability, ai — into a per-project artifact. Every project's artifact therefore carried every other project's integration credentials, sealed but present in each worker's memory.

That was not only exposure at rest. `createDbFactory` resolved `overrides.integrations` against the same global cache with no ownership check, so a request could name another project's integration id and read their database.

## What

**Ownership is now recorded.** Each cached config carries the id of the project that owns it (`__projectId`, null = not project-scoped). Nothing else in the cache recorded ownership — the key is the integration id — which is what made both bugs possible.

**Artifacts are scoped.** `publishProjectConfig` publishes only the integrations that project owns.

**Overrides are authorized, not removed.** An override naming a foreign integration is rejected with `403` before the route runs, instead of silently resolving. The seam itself is kept deliberately — it is also the integration-mocking hook the roadmap needs. Ownership is checked twice: once at the gate, once where the cache entry is actually read, so a missed gate cannot leak. The observability-logger override goes through the same check.

## Also: `WORKER_PROJECT_ID=*`

A worker can now serve every project in the artifact bucket. The KV key filters were already `<kind>.<projectId>.*`, so a literal `*` is a valid wildcard and needed no special casing — it just widens what the worker watches, and new projects are picked up without a restart.

To make that safe, integration hydration **merges per project** rather than replacing the cache: a wildcard worker holds several projects at once and each project's config artifact arrives as its own update. Re-publishing a project replaces only its own entries.

Known limit, marked in the source: all projects share one route table, so two projects with the same method+path collide. Fine for single-tenant and dev deployments, which is what the flag is for. Per-project routing is the upgrade path.

## Testing

- `apps/server/src/loaders/tests/integrationsScope.test.ts` — scoping, foreign-integration rejection, and the per-project merge (including that re-publishing a project drops its removed entries and leaves other projects alone). 3 pass.
- Pre-commit chain green: `turbo run lint` (8/8), secret scan, FTA analysis, selective tests.

## Operator note

If this instance has served mutually untrusted projects, integration credentials should be treated as exposed and rotated — the artifacts already distributed contain them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
