### PR TITLE
fix(worker): share database connections per runtime

### DIFF
--- a/apps/server/deployments/compiledWorker.ts
+++ b/apps/server/deployments/compiledWorker.ts
@@ -50,6 +50,8 @@ const healthPort = Number(getEnv("WORKER_HEALTH_PORT")) || port + 1;
  * larger containers with several CPUs each.
  */
 const threadCount = Number(getEnv("WORKER_THREADS")) || 1;
+const databaseIdleTimeoutMs =
+	Number(getEnv("INTEGRATION_TIMEOUT_POLICY_IN_SEC") || 450) * 1_000;
 
 initializeLogger({
 	serviceName: "fluxify.worker.compiled",
@@ -116,6 +118,7 @@ for (let threadId = 0; threadId < threadCount; threadId++) {
 		threadId,
 		projectId: WORKER_PROJECT_ID,
 		port,
+		databaseIdleTimeoutMs,
 		artifacts,
 		logging: {
 			level: OTLP_LOGGER_LEVEL,

--- a/apps/server/deployments/compiledWorker.ts
+++ b/apps/server/deployments/compiledWorker.ts
@@ -151,7 +151,7 @@ async function shutdown(sig: string) {
 	shuttingDown = true;
 	logger.info(`received ${sig} — shutting down`);
 	try {
-		for (const thread of threads) thread.terminate();
+		await Promise.all(threads.map(stopThread));
 		healthServer.stop(true);
 		await closePubSub();
 	} catch (e) {
@@ -159,6 +159,24 @@ async function shutdown(sig: string) {
 	} finally {
 		process.exit(0);
 	}
+}
+
+function stopThread(thread: Worker) {
+	return new Promise<void>((resolve) => {
+		const timeout = setTimeout(() => {
+			thread.terminate();
+			resolve();
+		}, 5_000);
+		const onMessage = (event: MessageEvent) => {
+			if (event.data?.type !== "stopped") return;
+			clearTimeout(timeout);
+			thread.removeEventListener("message", onMessage);
+			thread.terminate();
+			resolve();
+		};
+		thread.addEventListener("message", onMessage);
+		thread.postMessage({ type: "shutdown" } satisfies ThreadMessage);
+	});
 }
 process.on("SIGTERM", () => shutdown("SIGTERM"));
 process.on("SIGINT", () => shutdown("SIGINT"));

--- a/apps/server/src/lib/env.ts
+++ b/apps/server/src/lib/env.ts
@@ -38,6 +38,17 @@ export const serverEnvSchema = baseEnvSchema.extend({
 			"Execution threads per compiled worker container (default 1). Threads provide isolation and a kill boundary, not parallelism — scale out with replicas, not this",
 		),
 
+	INTEGRATION_TIMEOUT_POLICY_IN_SEC: z
+		.string()
+		.optional()
+		.refine(
+			(val) => !val || (Number.isInteger(Number(val)) && Number(val) > 0),
+			{ message: "INTEGRATION_TIMEOUT_POLICY_IN_SEC must be a positive integer" },
+		)
+		.describe(
+			"Idle database integration timeout in seconds for compiled workers (default 450 / 7.5 minutes)",
+		),
+
 	WORKER_PROJECT_ID: z
 		.string()
 		.optional()

--- a/apps/server/src/modules/requestRouter/compiledRuntime.ts
+++ b/apps/server/src/modules/requestRouter/compiledRuntime.ts
@@ -14,9 +14,14 @@ import type {
 	UnsealedProjectConfig,
 } from "../compiler/artifacts";
 import { hydrateAppConfig } from "../../loaders/appconfigLoader";
-import { hydrateIntegrations } from "../../loaders/integrationsLoader";
+import {
+	dbIntegrationsCache,
+	hydrateIntegrations,
+} from "../../loaders/integrationsLoader";
 import { hydrateProjectSettings } from "../../loaders/projectSettingsLoader";
 import { setBlocksExecutor } from "./executor";
+import { DbConnectionManager } from "@fluxify/adapters";
+import { setDbConnectionManager } from "./service";
 
 /**
  * Execution-side half of the compile pipeline: turns artifacts into a live
@@ -39,6 +44,7 @@ type CompiledRoute = {
 const routes = new Map<string, CompiledRoute>();
 /** custom block artifact id -> registered name, so a delete can unregister it */
 const customBlockNamesById = new Map<string, string>();
+const dbConnectionManager = new DbConnectionManager();
 /** one instance for the process — the router captured it, so rebuild in place */
 const parser = new HttpRouteParser();
 let built = false;
@@ -52,6 +58,7 @@ export function compiledRouteParser() {
  * route parser dispatch() matches against.
  */
 export function initCompiledRuntime(entries: ArtifactEntry[]): HttpRouteParser {
+	setDbConnectionManager(dbConnectionManager);
 	// custom blocks first: a route that invokes one needs it in the library
 	for (const { key, value } of entries) {
 		if (artifactKind(key) !== "route") applyArtifact(key, value);
@@ -80,6 +87,12 @@ export function initCompiledRuntime(entries: ArtifactEntry[]): HttpRouteParser {
 export function applyArtifactUpdate(key: string, value: any | null) {
 	applyArtifact(key, value);
 	if (artifactKind(key) === "route") rebuildParser();
+}
+
+/** Releases all long-lived database clients before the execution thread exits. */
+export async function shutdownCompiledRuntime() {
+	await dbConnectionManager.close();
+	setDbConnectionManager();
 }
 
 function applyArtifact(key: string, value: any | null) {
@@ -156,6 +169,9 @@ function applyProjectConfig(artifact: UnsealedProjectConfig) {
 		observability: payload.observabilityIntegrations,
 		ai: payload.aiIntegrations,
 	});
+	// The hydrated cache is the runtime's complete view. Swapping here makes
+	// changed credentials available to new requests before old clients drain.
+	dbConnectionManager.synchronize(dbIntegrationsCache);
 	hydrateProjectSettings(artifact.projectId, payload.projectSettings);
 	logger.info(
 		`[worker] project config applied (${artifact.compiledAt})`,

--- a/apps/server/src/modules/requestRouter/compiledRuntime.ts
+++ b/apps/server/src/modules/requestRouter/compiledRuntime.ts
@@ -44,7 +44,7 @@ type CompiledRoute = {
 const routes = new Map<string, CompiledRoute>();
 /** custom block artifact id -> registered name, so a delete can unregister it */
 const customBlockNamesById = new Map<string, string>();
-const dbConnectionManager = new DbConnectionManager();
+let dbConnectionManager: DbConnectionManager | undefined;
 /** one instance for the process — the router captured it, so rebuild in place */
 const parser = new HttpRouteParser();
 let built = false;
@@ -57,7 +57,13 @@ export function compiledRouteParser() {
  * Builds the runtime from the artifact set handed over at spawn. Returns the
  * route parser dispatch() matches against.
  */
-export function initCompiledRuntime(entries: ArtifactEntry[]): HttpRouteParser {
+export function initCompiledRuntime(
+	entries: ArtifactEntry[],
+	databaseIdleTimeoutMs?: number,
+): HttpRouteParser {
+	dbConnectionManager = new DbConnectionManager(undefined, {
+		idleTimeoutMs: databaseIdleTimeoutMs,
+	});
 	setDbConnectionManager(dbConnectionManager);
 	// custom blocks first: a route that invokes one needs it in the library
 	for (const { key, value } of entries) {
@@ -91,7 +97,8 @@ export function applyArtifactUpdate(key: string, value: any | null) {
 
 /** Releases all long-lived database clients before the execution thread exits. */
 export async function shutdownCompiledRuntime() {
-	await dbConnectionManager.close();
+	await dbConnectionManager?.close();
+	dbConnectionManager = undefined;
 	setDbConnectionManager();
 }
 
@@ -171,7 +178,7 @@ function applyProjectConfig(artifact: UnsealedProjectConfig) {
 	});
 	// The hydrated cache is the runtime's complete view. Swapping here makes
 	// changed credentials available to new requests before old clients drain.
-	dbConnectionManager.synchronize(dbIntegrationsCache);
+	dbConnectionManager?.synchronize(dbIntegrationsCache);
 	hydrateProjectSettings(artifact.projectId, payload.projectSettings);
 	logger.info(
 		`[worker] project config applied (${artifact.compiledAt})`,

--- a/apps/server/src/modules/requestRouter/executionThread.ts
+++ b/apps/server/src/modules/requestRouter/executionThread.ts
@@ -39,7 +39,7 @@ initializeLogger({
 	useOtlp: boot.logging.useOtlp,
 });
 
-const parser = initCompiledRuntime(boot.artifacts);
+const parser = initCompiledRuntime(boot.artifacts, boot.databaseIdleTimeoutMs);
 
 parentPort?.on("message", (message: ThreadMessage) => {
 	if (message.type === "artifact") {

--- a/apps/server/src/modules/requestRouter/executionThread.ts
+++ b/apps/server/src/modules/requestRouter/executionThread.ts
@@ -1,6 +1,10 @@
 import { workerData, parentPort } from "node:worker_threads";
 import { initializeLogger, logger } from "@fluxify/common";
-import { initCompiledRuntime, applyArtifactUpdate } from "./compiledRuntime";
+import {
+	initCompiledRuntime,
+	applyArtifactUpdate,
+	shutdownCompiledRuntime,
+} from "./compiledRuntime";
 import { createHttpContext } from "./httpContext";
 import { dispatch, envelopeFromHttp } from "./service";
 import type { ThreadBootstrap, ThreadMessage } from "./threadTypes";
@@ -41,6 +45,7 @@ parentPort?.on("message", (message: ThreadMessage) => {
 	if (message.type === "artifact") {
 		applyArtifactUpdate(message.entry.key, message.entry.value);
 	}
+	if (message.type === "shutdown") void shutdown();
 });
 
 const server = Bun.serve({
@@ -87,3 +92,12 @@ logger.info(
 	`[thread ${boot.threadId}] serving port ${server.port}`,
 	"WORKER.thread",
 );
+
+let shuttingDown = false;
+async function shutdown() {
+	if (shuttingDown) return;
+	shuttingDown = true;
+	server.stop(true);
+	await shutdownCompiledRuntime();
+	parentPort?.postMessage({ type: "stopped", threadId: boot.threadId });
+}

--- a/apps/server/src/modules/requestRouter/service.ts
+++ b/apps/server/src/modules/requestRouter/service.ts
@@ -22,7 +22,11 @@ import { JsVM } from "@fluxify/lib";
 import { runBlocks } from "./executor";
 import { getAppConfig } from "../../loaders/appconfigLoader";
 import { parseRequestSchema, ValidationError } from "../../lib/schemaParser";
-import { createObservabilityLogger, DbFactory } from "@fluxify/adapters";
+import {
+	createObservabilityLogger,
+	DbConnectionManager,
+	DbFactory,
+} from "@fluxify/adapters";
 import {
 	dbIntegrationsCache,
 	observabilityIntegrationsCache,
@@ -43,6 +47,12 @@ export type { RequestOverrides } from "./types";
 import type { RequestOverrides } from "./types";
 
 export const RESPONSE_TIMEOUT = 4 * 1000;
+let dbConnectionManager: DbConnectionManager | undefined;
+
+/** The compiled runtime supplies one manager per execution thread. */
+export function setDbConnectionManager(manager?: DbConnectionManager) {
+	dbConnectionManager = manager;
+}
 
 /** Default origin for in-process callers (test-suite runner) that predate the envelope. */
 const DEFAULT_TRIGGER: TriggerContext = {
@@ -228,24 +238,24 @@ export async function executeRouteInternal(
 		trigger,
 	);
 
-	const executionResult = await runBlocks(
-		{
-			projectId: routeInfo.projectId,
-			routeId: routeInfo.id,
-			projectName: routeInfo.projectName,
-		},
-		context,
-	);
+	try {
+		const executionResult = await runBlocks(
+			{
+				projectId: routeInfo.projectId,
+				routeId: routeInfo.id,
+				projectName: routeInfo.projectName,
+			},
+			context,
+		);
 
-	if (executionResult) {
-		return parseResult(executionResult);
+		if (executionResult) return parseResult(executionResult);
+		return {
+			status: 500,
+			data: { message: "Internal server error" },
+		};
+	} finally {
+		dbFactory.dispose();
 	}
-	return {
-		status: 500,
-		data: {
-			message: "Internal server error",
-		},
-	};
 }
 
 function parseResult(executionResult: BlockOutput) {
@@ -330,7 +340,7 @@ function createDbFactory(
 	integrationOverrides?: Array<{ existingId: string; newId: string }>,
 ) {
 	if (!integrationOverrides || integrationOverrides.length === 0) {
-		return new DbFactory(vm, dbIntegrationsCache);
+		return new DbFactory(vm, dbIntegrationsCache, dbConnectionManager);
 	}
 
 	const customDbCache = { ...dbIntegrationsCache };
@@ -341,7 +351,7 @@ function createDbFactory(
 		if (!target || !ownsIntegration(target, projectId)) continue;
 		customDbCache[override.existingId] = target;
 	}
-	return new DbFactory(vm, customDbCache);
+	return new DbFactory(vm, customDbCache, dbConnectionManager);
 }
 
 function setupContextVars(

--- a/apps/server/src/modules/requestRouter/threadTypes.ts
+++ b/apps/server/src/modules/requestRouter/threadTypes.ts
@@ -5,6 +5,8 @@ export type ThreadBootstrap = {
 	threadId: number;
 	projectId: string;
 	port: number;
+	/** idle database integration timeout, supplied by the supervisor in milliseconds */
+	databaseIdleTimeoutMs: number;
 	/** the full artifact set as of spawn, already unsealed */
 	artifacts: ArtifactEntry[];
 	/** the thread clears its env, so logging config has to travel with it */

--- a/apps/server/src/modules/requestRouter/threadTypes.ts
+++ b/apps/server/src/modules/requestRouter/threadTypes.ts
@@ -17,7 +17,11 @@ export type ThreadBootstrap = {
 };
 
 /** supervisor -> thread, after spawn */
-export type ThreadMessage = { type: "artifact"; entry: ArtifactEntry };
+export type ThreadMessage =
+	| { type: "artifact"; entry: ArtifactEntry }
+	| { type: "shutdown" };
 
 /** thread -> supervisor */
-export type ThreadEvent = { type: "ready"; threadId: number };
+export type ThreadEvent =
+	| { type: "ready"; threadId: number }
+	| { type: "stopped"; threadId: number };

--- a/docker/kit/Dockerfile
+++ b/docker/kit/Dockerfile
@@ -44,6 +44,8 @@
 #   NATS_TOKEN              NATS auth token
 #   ENABLE_AI               "true" to enable the AI assistant (default false)
 #   WORKER_THREADS          execution threads (default 1; scale out, not up)
+#   INTEGRATION_TIMEOUT_POLICY_IN_SEC
+#                           idle database-integration timeout (default 450 / 7.5 minutes)
 #   PROXY_PORT              published port (default 8080)
 #   SEED_USER_EMAIL / SEED_USER_PASSWORD / SEED_USER_NAME
 #                           first admin account created on an empty database
@@ -153,6 +155,7 @@ ENV NODE_ENV=production \
     SERVER_PORT=5500 \
     WORKER_PORT=5600 \
     WORKER_HEALTH_PORT=5601 \
+    INTEGRATION_TIMEOUT_POLICY_IN_SEC=450 \
     PROXY_PORT=8080 \
     AI_GATEWAY_PORT=8001 \
     ENABLE_ADMIN=true \

--- a/docker/kit/env.example
+++ b/docker/kit/env.example
@@ -40,6 +40,8 @@ WORKER_HEALTH_PORT=5601
 # logs. Create a project at /_/admin/ui, paste its id here, then bring the stack
 # up again. A compiled worker serves exactly one project.
 WORKER_PROJECT_ID=
+# Close an unused database integration after this many seconds (default 450 = 7.5 minutes).
+INTEGRATION_TIMEOUT_POLICY_IN_SEC=450
 # Local HTTP proxy server port (Caddy entrypoint)
 PROXY_PORT=8080
 # AI Gateway service server port

--- a/docker/production/docker-compose.yml
+++ b/docker/production/docker-compose.yml
@@ -101,6 +101,7 @@ services:
     environment:
       # Replace with the real project uuid from the admin UI.
       WORKER_PROJECT_ID: "${PROJECT_A_ID:?set PROJECT_A_ID in docker/production/.env}"
+      INTEGRATION_TIMEOUT_POLICY_IN_SEC: "${INTEGRATION_TIMEOUT_POLICY_IN_SEC:-450}"
     # No container_name: replicas each need a unique name.
     deploy:
       replicas: 2
@@ -137,6 +138,7 @@ services:
       - .env
     environment:
       WORKER_PROJECT_ID: "${PROJECT_B_ID:?set PROJECT_B_ID in docker/production/.env}"
+      INTEGRATION_TIMEOUT_POLICY_IN_SEC: "${INTEGRATION_TIMEOUT_POLICY_IN_SEC:-450}"
     deploy:
       replicas: 2
     depends_on:

--- a/docker/production/env.example
+++ b/docker/production/env.example
@@ -37,6 +37,8 @@ WORKER_PORT=5600
 WORKER_HEALTH_PORT=5601
 # Execution threads per worker container. Scale with replicas, not this.
 WORKER_THREADS=1
+# Close an unused database integration after this many seconds (default 450 = 7.5 minutes).
+INTEGRATION_TIMEOUT_POLICY_IN_SEC=450
 # Local HTTP proxy server port (Traefik entrypoint)
 PROXY_PORT=8080
 # AI Gateway service server port

--- a/docker/worker-compiled/Dockerfile
+++ b/docker/worker-compiled/Dockerfile
@@ -36,6 +36,8 @@
 #   WORKER_HEALTH_PORT      health port (default 5601)
 #   WORKER_THREADS          execution threads (default 1) — see the note on
 #                           EXPOSE below before raising this
+#   INTEGRATION_TIMEOUT_POLICY_IN_SEC
+#                           idle database-integration timeout (default 450 / 7.5 minutes)
 #   OTLP_*                  log shipping; see docker/kit/env.example
 #
 # DELIBERATELY NOT USED
@@ -135,7 +137,8 @@ EXPOSE 5600 5601
 ENV NODE_ENV=production \
     ENVIRONMENT=production \
     WORKER_PORT=5600 \
-    WORKER_HEALTH_PORT=5601
+    WORKER_HEALTH_PORT=5601 \
+    INTEGRATION_TIMEOUT_POLICY_IN_SEC=450
 
 # Readiness, not liveness: 200 only once compiled routes have been loaded, so a
 # worker that came up before the compiler published anything is not sent traffic.

--- a/docs/deployments/kit.md
+++ b/docs/deployments/kit.md
@@ -64,6 +64,7 @@ NATS_TOKEN=fluxify_nats_token
 #====================== THE PROJECT THIS KIT SERVES ======================
 # Leave empty for now — you don't have a project yet. Step 4 fills this in.
 WORKER_PROJECT_ID=
+INTEGRATION_TIMEOUT_POLICY_IN_SEC=450
 
 #====================== SECURITY & KEYS ======================
 MASTER_ENCRYPTION_KEY=<openssl rand -base64 32>

--- a/docs/deployments/production.md
+++ b/docs/deployments/production.md
@@ -171,6 +171,7 @@ set PROJECT_A_ID in docker/production/.env
    ```env
    PROJECT_A_ID=<first-project-id>
    PROJECT_B_ID=<second-project-id>
+   INTEGRATION_TIMEOUT_POLICY_IN_SEC=450
    ```
 
 4. Bring the stack up again:
@@ -225,6 +226,24 @@ Workers hold no state, so you can scale up and down freely.
 > [!IMPORTANT]
 > Scale **workers**, not the admin. Keep a single admin container so database
 > updates and the seed step run exactly once.
+
+---
+
+## Database integration idle timeout
+
+Compiled workers share database clients across requests. To avoid retaining a
+pool for an integration that has gone quiet, set
+`INTEGRATION_TIMEOUT_POLICY_IN_SEC` in `docker/production/.env`:
+
+```env
+INTEGRATION_TIMEOUT_POLICY_IN_SEC=450
+```
+
+`450` is the default and means 7.5 minutes. When an integration has no
+in-flight request or transaction for that period, its PostgreSQL, MySQL, or
+MongoDB client closes. The next request opens a fresh client. This never closes
+a client while a request is using it; choose a larger value when avoiding a
+connection cold-start matters more than releasing idle sockets.
 
 ---
 

--- a/packages/adapters/db/connectionManager.spec.ts
+++ b/packages/adapters/db/connectionManager.spec.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "bun:test";
+import {
+	DbConnectionManager,
+	DbFactory,
+	DbType,
+	type Connection,
+	type ManagedDbConnection,
+} from ".";
+
+const mysql: Connection = {
+	dbType: DbType.MYSQL,
+	host: "db.internal",
+	port: 3306,
+	username: "worker",
+	password: "secret",
+	database: "fluxify",
+};
+
+function createFakeManager() {
+	const closed: string[] = [];
+	let created = 0;
+	const manager = new DbConnectionManager((integrationId, config) => {
+		created += 1;
+		return {
+			type: config.dbType,
+			db: {},
+			pool: {} as any,
+			close: async () => {
+				closed.push(`${integrationId}:${config.password}`);
+			},
+		} satisfies ManagedDbConnection;
+	});
+	return {
+		manager,
+		closed,
+		created: () => created,
+	};
+}
+
+describe("DbConnectionManager", () => {
+	it("shares one MySQL pool across 10,000 request-local factories", () => {
+		const fake = createFakeManager();
+		for (let request = 0; request < 10_000; request++) {
+			const factory = new DbFactory({} as any, { mysql }, fake.manager);
+			factory.getDbAdapter("mysql");
+			factory.dispose();
+		}
+
+		expect(fake.created()).toBe(1);
+		expect(fake.manager.getStats()).toEqual({
+			active: 1,
+			retiring: 0,
+			leases: 0,
+		});
+	});
+
+	it("atomically swaps changed credentials and drains the borrowed pool", async () => {
+		const fake = createFakeManager();
+		const inFlight = new DbFactory({} as any, { mysql }, fake.manager);
+		inFlight.getDbAdapter("mysql");
+
+		fake.manager.synchronize({
+			mysql: { ...mysql, password: "rotated-secret" },
+		});
+		expect(fake.created()).toBe(2);
+		expect(fake.closed).toEqual([]);
+
+		const nextRequest = new DbFactory(
+			{} as any,
+			{ mysql: { ...mysql, password: "rotated-secret" } },
+			fake.manager,
+		);
+		nextRequest.getDbAdapter("mysql");
+		inFlight.dispose();
+		await Promise.resolve();
+		expect(fake.closed).toEqual(["mysql:secret"]);
+
+		nextRequest.dispose();
+		await fake.manager.close();
+		expect(fake.closed).toEqual(["mysql:secret", "mysql:rotated-secret"]);
+	});
+
+	it("closes active PostgreSQL, MySQL, and MongoDB clients on runtime shutdown", async () => {
+		const fake = createFakeManager();
+		const configs = {
+			pg: { ...mysql, dbType: DbType.POSTGRES },
+			mysql,
+			mongo: { ...mysql, dbType: DbType.MONGODB },
+		};
+		for (const integrationId of Object.keys(configs)) {
+			const factory = new DbFactory({} as any, configs, fake.manager);
+			factory.getDbAdapter(integrationId);
+		}
+
+		await fake.manager.close();
+		expect(fake.closed.sort()).toEqual([
+			"mongo:secret",
+			"mysql:secret",
+			"pg:secret",
+		]);
+	});
+});

--- a/packages/adapters/db/connectionManager.spec.ts
+++ b/packages/adapters/db/connectionManager.spec.ts
@@ -5,6 +5,7 @@ import {
 	DbType,
 	type Connection,
 	type ManagedDbConnection,
+	type DbConnectionTimer,
 } from ".";
 
 const mysql: Connection = {
@@ -16,7 +17,32 @@ const mysql: Connection = {
 	database: "fluxify",
 };
 
-function createFakeManager() {
+class FakeTimers implements DbConnectionTimer {
+	private currentTime = 0;
+	private nextId = 1;
+	private readonly tasks = new Map<number, { at: number; handler: () => void }>();
+
+	setTimeout(handler: () => void, timeoutMs: number) {
+		const id = this.nextId++;
+		this.tasks.set(id, { at: this.currentTime + timeoutMs, handler });
+		return id;
+	}
+
+	clearTimeout(handle: unknown) {
+		this.tasks.delete(handle as number);
+	}
+
+	advanceBy(timeoutMs: number) {
+		this.currentTime += timeoutMs;
+		for (const [id, task] of [...this.tasks]) {
+			if (task.at > this.currentTime) continue;
+			this.tasks.delete(id);
+			task.handler();
+		}
+	}
+}
+
+function createFakeManager(options = {}) {
 	const closed: string[] = [];
 	let created = 0;
 	const manager = new DbConnectionManager((integrationId, config) => {
@@ -29,7 +55,7 @@ function createFakeManager() {
 				closed.push(`${integrationId}:${config.password}`);
 			},
 		} satisfies ManagedDbConnection;
-	});
+	}, options);
 	return {
 		manager,
 		closed,
@@ -38,6 +64,52 @@ function createFakeManager() {
 }
 
 describe("DbConnectionManager", () => {
+	it("closes an unused pool after 7.5 minutes using fast-forwarded fake timers", async () => {
+		const timers = new FakeTimers();
+		const fake = createFakeManager({
+			idleTimeoutMs: 450_000,
+			timer: timers,
+		});
+		const factory = new DbFactory({} as any, { mysql }, fake.manager);
+		factory.getDbAdapter("mysql");
+		factory.dispose();
+
+		timers.advanceBy(449_999);
+		await Promise.resolve();
+		expect(fake.closed).toEqual([]);
+
+		timers.advanceBy(1);
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(fake.closed).toEqual(["mysql:secret"]);
+		expect(fake.manager.getStats()).toEqual({
+			active: 0,
+			retiring: 0,
+			leases: 0,
+		});
+	});
+
+	it("resets the idle timer when a pool is borrowed again", async () => {
+		const timers = new FakeTimers();
+		const fake = createFakeManager({ idleTimeoutMs: 450_000, timer: timers });
+		const firstRequest = new DbFactory({} as any, { mysql }, fake.manager);
+		firstRequest.getDbAdapter("mysql");
+		firstRequest.dispose();
+
+		timers.advanceBy(449_999);
+		const secondRequest = new DbFactory({} as any, { mysql }, fake.manager);
+		secondRequest.getDbAdapter("mysql");
+		timers.advanceBy(1);
+		await Promise.resolve();
+		expect(fake.closed).toEqual([]);
+
+		secondRequest.dispose();
+		timers.advanceBy(450_000);
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(fake.closed).toEqual(["mysql:secret"]);
+	});
+
 	it("shares one MySQL pool across 10,000 request-local factories", () => {
 		const fake = createFakeManager();
 		for (let request = 0; request < 10_000; request++) {

--- a/packages/adapters/db/connectionManager.ts
+++ b/packages/adapters/db/connectionManager.ts
@@ -1,0 +1,227 @@
+import { SQL } from "bun";
+import { createHash } from "node:crypto";
+import { Kysely } from "kysely";
+import { createPool, type Pool } from "mysql2";
+import { MongoClient } from "mongodb";
+import { Connection, DbType } from "./connection";
+import { MySqlAdapter } from "./mySqlAdapter";
+import { MongoAdapter, buildMongoUrl } from "./mongoDbAdapter";
+import { PostgresAdapter } from "./postgresAdapter";
+
+const DEFAULT_DRAIN_TIMEOUT_MS = 30_000;
+
+export type ManagedDbConnection = {
+	type: DbType;
+	db: any;
+	pool?: Pool;
+	sql?: SQL;
+	client?: MongoClient;
+	close(): Promise<void>;
+};
+
+export type DbConnectionLease = {
+	connection: ManagedDbConnection;
+	release(): void;
+};
+
+export type DbConnectionFactory = (
+	integrationId: string,
+	config: Connection,
+	fingerprint: string,
+) => ManagedDbConnection;
+
+type Entry = {
+	integrationId: string;
+	fingerprint: string;
+	connection: ManagedDbConnection;
+	leases: number;
+	retired: boolean;
+	drainTimer?: ReturnType<typeof setTimeout>;
+	closePromise?: Promise<void>;
+};
+
+/**
+ * Owns the database clients for one execution runtime. Factories borrow a
+ * client while keeping adapter and transaction state request-local.
+ */
+export class DbConnectionManager {
+	private readonly active = new Map<string, Entry>();
+	private readonly retiring = new Set<Entry>();
+
+	constructor(
+		private readonly createConnection: DbConnectionFactory = createManagedConnection,
+		private readonly drainTimeoutMs = DEFAULT_DRAIN_TIMEOUT_MS,
+	) {}
+
+	borrow(integrationId: string, config: Connection): DbConnectionLease {
+		const fingerprint = connectionFingerprint(config);
+		let entry = this.active.get(integrationId);
+		if (!entry || entry.fingerprint !== fingerprint) {
+			entry = this.replace(integrationId, config, fingerprint, entry);
+		}
+
+		entry.leases += 1;
+		let released = false;
+		return {
+			connection: entry.connection,
+			release: () => {
+				if (released) return;
+				released = true;
+				entry!.leases -= 1;
+				if (entry!.retired && entry!.leases === 0) void this.closeEntry(entry!);
+			},
+		};
+	}
+
+	/**
+	 * Applies a complete integration snapshot. Changed clients are swapped before
+	 * the old client starts draining, so new requests never borrow stale config.
+	 */
+	synchronize(configurations: Record<string, Connection>) {
+		for (const [integrationId, entry] of this.active) {
+			const config = configurations[integrationId];
+			if (!config) {
+				this.active.delete(integrationId);
+				this.retire(entry);
+				continue;
+			}
+
+			const fingerprint = connectionFingerprint(config);
+			if (entry.fingerprint !== fingerprint) {
+				this.replace(integrationId, config, fingerprint, entry);
+			}
+		}
+	}
+
+	async close() {
+		const entries = [...this.active.values(), ...this.retiring];
+		this.active.clear();
+		this.retiring.clear();
+		for (const entry of entries) {
+			entry.retired = true;
+			if (entry.drainTimer) clearTimeout(entry.drainTimer);
+		}
+		await Promise.all(entries.map((entry) => this.closeEntry(entry)));
+	}
+
+	getStats() {
+		return {
+			active: this.active.size,
+			retiring: this.retiring.size,
+			leases: [...this.active.values(), ...this.retiring].reduce(
+				(total, entry) => total + entry.leases,
+				0,
+			),
+		};
+	}
+
+	private replace(
+		integrationId: string,
+		config: Connection,
+		fingerprint: string,
+		previous?: Entry,
+	) {
+		// Create before replacing the map entry: a bad replacement leaves the
+		// current known-good client available to requests.
+		const connection = this.createConnection(integrationId, config, fingerprint);
+		const entry: Entry = {
+			integrationId,
+			fingerprint,
+			connection,
+			leases: 0,
+			retired: false,
+		};
+		this.active.set(integrationId, entry);
+		if (previous) this.retire(previous);
+		return entry;
+	}
+
+	private retire(entry: Entry) {
+		if (entry.retired) return;
+		entry.retired = true;
+		this.retiring.add(entry);
+		if (entry.leases === 0) {
+			void this.closeEntry(entry);
+			return;
+		}
+		entry.drainTimer = setTimeout(() => void this.closeEntry(entry), this.drainTimeoutMs);
+	}
+
+	private closeEntry(entry: Entry) {
+		if (entry.closePromise) return entry.closePromise;
+		if (entry.drainTimer) clearTimeout(entry.drainTimer);
+		entry.closePromise = Promise.resolve(entry.connection.close())
+			.catch(() => undefined)
+			.then(() => {
+				this.retiring.delete(entry);
+			});
+		return entry.closePromise;
+	}
+}
+
+/** Hashes only the fields that affect a database connection; the raw secret is never retained or logged. */
+export function connectionFingerprint(config: Connection) {
+	const material = JSON.stringify({
+		dbType: config.dbType,
+		host: config.host,
+		port: String(config.port),
+		username: config.username,
+		password: config.password,
+		database: config.database,
+		ssl: Boolean(config.ssl),
+	});
+	return createHash("sha256").update(material).digest("hex");
+}
+
+function createManagedConnection(
+	_integrationId: string,
+	config: Connection,
+): ManagedDbConnection {
+	if (config.dbType === DbType.POSTGRES) {
+		const sql = new SQL({
+			adapter: "postgres",
+			hostname: config.host,
+			port: Number(config.port),
+			username: config.username,
+			password: config.password,
+			database: config.database,
+			tls: config.ssl,
+		});
+		const db = PostgresAdapter.createKysely(sql);
+		return {
+			type: DbType.POSTGRES,
+			db,
+			sql,
+			close: () => db.destroy(),
+		};
+	}
+
+	if (config.dbType === DbType.MYSQL) {
+		const pool = createPool({
+			host: config.host,
+			port: Number(config.port),
+			user: config.username,
+			password: config.password,
+			database: config.database,
+			connectionLimit: 2,
+		});
+		return {
+			type: DbType.MYSQL,
+			db: MySqlAdapter.createKysely(pool),
+			pool,
+			close: () => pool.promise().end(),
+		};
+	}
+
+	if (config.dbType === DbType.MONGODB) {
+		const client = new MongoClient(buildMongoUrl(config));
+		return {
+			type: DbType.MONGODB,
+			db: client.db(config.database),
+			client,
+			close: () => client.close(),
+		};
+	}
+
+	throw new Error(`${config.dbType} Not implemented`);
+}

--- a/packages/adapters/db/connectionManager.ts
+++ b/packages/adapters/db/connectionManager.ts
@@ -9,6 +9,7 @@ import { MongoAdapter, buildMongoUrl } from "./mongoDbAdapter";
 import { PostgresAdapter } from "./postgresAdapter";
 
 const DEFAULT_DRAIN_TIMEOUT_MS = 30_000;
+const DEFAULT_IDLE_TIMEOUT_MS = 7.5 * 60_000;
 
 export type ManagedDbConnection = {
 	type: DbType;
@@ -30,13 +31,30 @@ export type DbConnectionFactory = (
 	fingerprint: string,
 ) => ManagedDbConnection;
 
+export type DbConnectionTimer = {
+	setTimeout(handler: () => void, timeoutMs: number): unknown;
+	clearTimeout(handle: unknown): void;
+};
+
+export type DbConnectionManagerOptions = {
+	drainTimeoutMs?: number;
+	idleTimeoutMs?: number;
+	timer?: DbConnectionTimer;
+};
+
+const systemTimer: DbConnectionTimer = {
+	setTimeout: (handler, timeoutMs) => setTimeout(handler, timeoutMs),
+	clearTimeout: (handle) => clearTimeout(handle as ReturnType<typeof setTimeout>),
+};
+
 type Entry = {
 	integrationId: string;
 	fingerprint: string;
 	connection: ManagedDbConnection;
 	leases: number;
 	retired: boolean;
-	drainTimer?: ReturnType<typeof setTimeout>;
+	drainTimer?: unknown;
+	idleTimer?: unknown;
 	closePromise?: Promise<void>;
 };
 
@@ -50,8 +68,16 @@ export class DbConnectionManager {
 
 	constructor(
 		private readonly createConnection: DbConnectionFactory = createManagedConnection,
-		private readonly drainTimeoutMs = DEFAULT_DRAIN_TIMEOUT_MS,
-	) {}
+		options: DbConnectionManagerOptions = {},
+	) {
+		this.drainTimeoutMs = options.drainTimeoutMs ?? DEFAULT_DRAIN_TIMEOUT_MS;
+		this.idleTimeoutMs = options.idleTimeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS;
+		this.timer = options.timer ?? systemTimer;
+	}
+
+	private readonly drainTimeoutMs: number;
+	private readonly idleTimeoutMs: number;
+	private readonly timer: DbConnectionTimer;
 
 	borrow(integrationId: string, config: Connection): DbConnectionLease {
 		const fingerprint = connectionFingerprint(config);
@@ -60,6 +86,7 @@ export class DbConnectionManager {
 			entry = this.replace(integrationId, config, fingerprint, entry);
 		}
 
+		this.cancelIdleClose(entry);
 		entry.leases += 1;
 		let released = false;
 		return {
@@ -68,7 +95,11 @@ export class DbConnectionManager {
 				if (released) return;
 				released = true;
 				entry!.leases -= 1;
-				if (entry!.retired && entry!.leases === 0) void this.closeEntry(entry!);
+				if (entry!.retired && entry!.leases === 0) {
+					void this.closeEntry(entry!);
+				} else if (entry!.leases === 0) {
+					this.scheduleIdleClose(entry!);
+				}
 			},
 		};
 	}
@@ -99,7 +130,8 @@ export class DbConnectionManager {
 		this.retiring.clear();
 		for (const entry of entries) {
 			entry.retired = true;
-			if (entry.drainTimer) clearTimeout(entry.drainTimer);
+			if (entry.drainTimer) this.timer.clearTimeout(entry.drainTimer);
+			this.cancelIdleClose(entry);
 		}
 		await Promise.all(entries.map((entry) => this.closeEntry(entry)));
 	}
@@ -144,12 +176,33 @@ export class DbConnectionManager {
 			void this.closeEntry(entry);
 			return;
 		}
-		entry.drainTimer = setTimeout(() => void this.closeEntry(entry), this.drainTimeoutMs);
+		entry.drainTimer = this.timer.setTimeout(
+			() => void this.closeEntry(entry),
+			this.drainTimeoutMs,
+		);
+	}
+
+	private scheduleIdleClose(entry: Entry) {
+		if (this.idleTimeoutMs <= 0 || entry.retired) return;
+		this.cancelIdleClose(entry);
+		entry.idleTimer = this.timer.setTimeout(() => {
+			entry.idleTimer = undefined;
+			if (entry.leases !== 0 || entry.retired) return;
+			if (this.active.get(entry.integrationId) !== entry) return;
+			this.active.delete(entry.integrationId);
+			this.retire(entry);
+		}, this.idleTimeoutMs);
+	}
+
+	private cancelIdleClose(entry: Entry) {
+		if (entry.idleTimer) this.timer.clearTimeout(entry.idleTimer);
+		entry.idleTimer = undefined;
 	}
 
 	private closeEntry(entry: Entry) {
 		if (entry.closePromise) return entry.closePromise;
-		if (entry.drainTimer) clearTimeout(entry.drainTimer);
+		if (entry.drainTimer) this.timer.clearTimeout(entry.drainTimer);
+		this.cancelIdleClose(entry);
 		entry.closePromise = Promise.resolve(entry.connection.close())
 			.catch(() => undefined)
 			.then(() => {

--- a/packages/adapters/db/index.ts
+++ b/packages/adapters/db/index.ts
@@ -1,14 +1,12 @@
-import { password, SQL } from "bun";
-import { Kysely } from "kysely";
+import { SQL } from "bun";
 import { operatorSchema } from "@fluxify/lib";
 import z from "zod";
 import { Connection, DbType } from "./connection";
 import { PostgresAdapter } from "./postgresAdapter";
 import { MySqlAdapter } from "./mySqlAdapter";
 import { JsVM } from "@fluxify/lib";
-import { BunSqlPostgresDialect, BunSqlMysqlDialect } from "./kyselySqlDialect";
 import { MongoAdapter, buildMongoUrl } from "./mongoDbAdapter";
-import { createPool } from "mysql2";
+import { DbConnectionManager, type DbConnectionLease } from "./connectionManager";
 
 export const whereConditionSchema = z.object({
 	attribute: z.string(),
@@ -94,10 +92,13 @@ export interface IDbAdapter {
 
 export class DbFactory {
 	private readonly connectionMap: Record<string, IDbAdapter> = {};
+	private readonly connectionLeases: Record<string, DbConnectionLease> = {};
+	private static readonly defaultConnectionManager = new DbConnectionManager();
 
 	constructor(
 		private readonly vm: JsVM,
 		private readonly dbConfig: Record<string, Connection>,
+		private readonly connectionManager: DbConnectionManager = DbFactory.defaultConnectionManager,
 	) {}
 
 	public getDbAdapter(connection: string): IDbAdapter {
@@ -107,105 +108,45 @@ export class DbFactory {
 		}
 		if (connection in this.connectionMap) return this.connectionMap[connection];
 
+		const lease = this.connectionManager.borrow(connection, cfg);
+		this.connectionLeases[connection] = lease;
+
 		if (cfg.dbType.toLowerCase() === DbType.POSTGRES.toLowerCase()) {
-			const { db, sql } = this.getBunPostgresSqlConnection(connection, cfg);
 			return (this.connectionMap[connection] = new PostgresAdapter(
-				db,
-				sql,
+				lease.connection.db,
+				lease.connection.sql!,
 				this.vm,
 			));
 		} else if (cfg.dbType.toLowerCase() === DbType.MYSQL.toLowerCase()) {
-			const pool = createPool({
-				host: cfg.host,
-				port: Number(cfg.port),
-				user: cfg.username,
-				password: cfg.password,
-				database: cfg.database,
-				connectionLimit: 2,
-			});
-			const db = MySqlAdapter.createKysely(pool);
 			return (this.connectionMap[connection] = new MySqlAdapter(
-				db,
-				pool,
+				lease.connection.db,
+				lease.connection.pool!,
 				this.vm,
 			));
 		} else if (cfg.dbType.toLowerCase() === DbType.MONGODB.toLowerCase()) {
-			const { client, db } = this.getMongoClient(connection, cfg);
 			return (this.connectionMap[connection] = new MongoAdapter(
-				client,
-				db,
+				lease.connection.client!,
+				lease.connection.db,
 				this.vm,
 			));
 		}
 
+		lease.release();
+		delete this.connectionLeases[connection];
 		throw new Error(`${cfg.dbType} Not implemented`);
 	}
 
-	private static connectionCache: Record<
-		string,
-		{ db: Kysely<any>; sql: SQL }
-	> = {};
-
-	private getBunPostgresSqlConnection(
-		connection: string,
-		cfg: Connection,
-	): { db: Kysely<any>; sql: SQL } {
-		if (connection in DbFactory.connectionCache) {
-			return DbFactory.connectionCache[connection];
+	/** Releases this request's database-client leases. */
+	public dispose() {
+		for (const connection of Object.keys(this.connectionLeases)) {
+			this.connectionLeases[connection].release();
+			delete this.connectionLeases[connection];
 		}
-
-		const sql = new SQL({
-			adapter: "postgres",
-			hostname: cfg.host,
-			port: Number(cfg.port),
-			username: cfg.username,
-			password: cfg.password,
-			database: cfg.database,
-			tls: cfg.ssl,
-		});
-
-		const dialect = new BunSqlPostgresDialect(sql);
-
-		const db = new Kysely<any>({ dialect });
-
-		return (DbFactory.connectionCache[connection] = { db, sql });
 	}
 
-	private static mongoConnectionCache: Record<
-		string,
-		{ client: any; db: any }
-	> = {};
-
-	private getMongoClient(
-		connection: string,
-		cfg: Connection,
-	): { client: any; db: any } {
-		if (connection in DbFactory.mongoConnectionCache) {
-			return DbFactory.mongoConnectionCache[connection];
-		}
-
-		// Lazy load to avoid requiring it if unused or to match current pattern
-		const { MongoClient } = require("mongodb");
-		const url = buildMongoUrl(cfg);
-		const client = new MongoClient(url);
-		const db = client.db(cfg.database);
-
-		return (DbFactory.mongoConnectionCache[connection] = { client, db });
-	}
-
-	/** Call when app config / integration credentials change. */
+	/** Compatibility hook for legacy workers that use the process-wide manager. */
 	public static async ResetConnections() {
-		const proms = Object.values(this.connectionCache).map(({ db, sql }) =>
-			db.destroy().then(() => sql.close()),
-		);
-		this.connectionCache = {};
-
-		const mongoProms = Object.values(this.mongoConnectionCache).map(
-			({ client }) => client.close(),
-		);
-		this.mongoConnectionCache = {};
-
-		await Promise.allSettled([...proms, ...mongoProms]);
+		await this.defaultConnectionManager.close();
 	}
 }
 
@@ -270,3 +211,4 @@ export * from "./postgresAdapter";
 export * from "./mySqlAdapter";
 export * from "./mongoDbAdapter";
 export * from "./connection";
+export * from "./connectionManager";


### PR DESCRIPTION
Closes #188.

## Summary
- Add a per-execution-thread database connection manager shared by request-local adapters.
- Key PostgreSQL, MySQL, and MongoDB clients by integration ID and a secret-safe configuration fingerprint.
- Atomically replace changed clients, drain in-flight leases, and close all clients during graceful worker shutdown.
- Close unused integration clients after INTEGRATION_TIMEOUT_POLICY_IN_SEC (default 450, or 7.5 minutes), resetting the timer on reuse.
- Document the policy and set Docker/Compose defaults for compiled workers and the Kit image.

## Verification
- bun test packages/adapters/db/connectionManager.spec.ts
- bun run --cwd packages/adapters lint
- bun run --cwd apps/server lint
- bun run docs:build