### PR TITLE
feat(worker): bound local async execution

### DIFF
--- a/apps/server/deployments/compiledWorker.ts
+++ b/apps/server/deployments/compiledWorker.ts
@@ -15,6 +15,7 @@ import type {
 } from "../src/modules/requestRouter/threadTypes";
 import { ExecutionWatchdog } from "../src/modules/requestRouter/executionWatchdog";
 import { workerTimeoutsEnabled } from "../src/modules/requestRouter/workerTimeouts";
+import { asyncExecutorLimitsFromEnv } from "../src/modules/requestRouter/asyncExecutor";
 import { initializeRedis } from "../src/db/redis";
 import { closePubSub, initializePubSub } from "../src/db/pubsub";
 import {
@@ -42,6 +43,7 @@ const HEARTBEAT_CHECK_MS = 500;
 /** Idle database integration timeout, supplied to the execution process. */
 const databaseIdleTimeoutMs =
 	Number(getEnv("INTEGRATION_TIMEOUT_POLICY_IN_SEC") || 450) * 1_000;
+const asyncExecutor = asyncExecutorLimitsFromEnv();
 
 initializeLogger({
 	serviceName: "fluxify.worker.compiled",
@@ -123,6 +125,7 @@ function spawnExecution() {
 		projectId: WORKER_PROJECT_ID,
 		port,
 		databaseIdleTimeoutMs,
+		asyncExecutor,
 		artifacts: [...artifacts.values()],
 		workerTimeoutsEnabled: timeoutPolicyEnabled(),
 		logging: {

--- a/apps/server/deployments/compiledWorker.ts
+++ b/apps/server/deployments/compiledWorker.ts
@@ -16,6 +16,7 @@ import type {
 import { ExecutionWatchdog } from "../src/modules/requestRouter/executionWatchdog";
 import { workerTimeoutsEnabled } from "../src/modules/requestRouter/workerTimeouts";
 import { asyncExecutorLimitsFromEnv } from "../src/modules/requestRouter/asyncExecutor";
+import { executionRuntimeEnvironment } from "../src/modules/requestRouter/executionEnvironment";
 import { initializeRedis } from "../src/db/redis";
 import { closePubSub, initializePubSub } from "../src/db/pubsub";
 import {
@@ -136,7 +137,7 @@ function spawnExecution() {
 		},
 	};
 	const child = Bun.spawn([process.execPath, fileURLToPath(processEntry)], {
-		env: {},
+		env: executionRuntimeEnvironment(),
 		stdout: "inherit",
 		stderr: "inherit",
 		ipc: (event) => onExecutionEvent(event as ExecutionEvent),

--- a/apps/server/src/lib/schemaParser.ts
+++ b/apps/server/src/lib/schemaParser.ts
@@ -1,4 +1,6 @@
 import { z } from 'zod';
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { scopeFor } from '@fluxify/blocks';
 import { ValidationSchemaZod } from './validationSchemaZod';
 import { JsVM } from '@fluxify/lib';
 
@@ -11,10 +13,41 @@ export class ValidationError extends Error {
   }
 }
 
-type ParserContext = {
+export type ParserContext = {
   vm: JsVM;
+  /** Present in the compiled worker: trusted validators run against these vars. */
+  vars?: Record<string, any>;
   coerce?: boolean;
 };
+
+type CompiledValidator = (input: any, scope: any) => Promise<unknown>;
+
+export type CompiledRequestSchema = {
+  validate(requestData: any, context: ParserContext): Promise<ParseResult>;
+};
+
+type ParseResult = {
+  success: boolean;
+  errors?: Array<{ path: string; property: string; errors: any[] }>;
+};
+
+/**
+ * The source is part of the persisted route definition, never request input.
+ * Give every artifact-time function a private generated name so validators from
+ * different routes cannot collide in diagnostics or generated snapshots.
+ */
+function compileValidator(code: string): CompiledValidator {
+  const name = `validator_${crypto.randomUUID().replaceAll('-', '')}`;
+  try {
+    return new Function(
+      `return async function ${name}(input, $scope) { with ($scope) {\n${code}\n} }`,
+    )() as CompiledValidator;
+  } catch (error) {
+    // Keep the old behaviour: a malformed stored validator becomes a normal
+    // validation error, rather than making the whole route fail to load.
+    return async () => { throw error; };
+  }
+}
 
 // Map primitive types to base Zod schemas
 function getBaseZodType(dataType: string, coerce = false): z.ZodTypeAny {
@@ -58,16 +91,21 @@ function applyRules(schema: z.ZodTypeAny, dataType: string, rules: any[] = []): 
   return s;
 }
 
-export function buildZodSchema(schemaDef: any, context: ParserContext): z.ZodTypeAny {
+export function buildZodSchema(schemaDef: any, coerce = false): z.ZodTypeAny {
   const { dataType, properties, items, rules, js, required } = schemaDef;
 
   let zSchema: z.ZodTypeAny;
 
   if (dataType === 'js') {
+    const validator = js ? compileValidator(js) : undefined;
     zSchema = z.any().superRefine(async (val, ctx) => {
       if (!js) return;
       try {
-        const result = await context.vm.runAsync(js, val);
+        const context = validationContext.getStore();
+        if (!context) throw new Error('Validation context unavailable');
+        const result = context.vars
+          ? await validator!(val, scopeFor(context.vars))
+          : await context.vm.runAsync(js, val);
         if (!result) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Custom JS validation failed' });
         }
@@ -93,16 +131,16 @@ export function buildZodSchema(schemaDef: any, context: ParserContext): z.ZodTyp
       zSchema = z.any(); // fallback if no enum values defined
     }
   } else {
-    zSchema = getBaseZodType(dataType, context.coerce);
+    zSchema = getBaseZodType(dataType, coerce);
 
     if (dataType === 'object' && properties) {
       const shape: Record<string, z.ZodTypeAny> = {};
       for (const prop of properties) {
-        shape[prop.key] = buildZodSchema(prop, context);
+        shape[prop.key] = buildZodSchema(prop, coerce);
       }
       zSchema = z.object(shape);
     } else if (dataType === 'arr' && items) {
-      zSchema = z.array(buildZodSchema(items, context));
+      zSchema = z.array(buildZodSchema(items, coerce));
     }
     
     zSchema = applyRules(zSchema, dataType, rules);
@@ -115,37 +153,60 @@ export function buildZodSchema(schemaDef: any, context: ParserContext): z.ZodTyp
   return zSchema;
 }
 
-export const parseRequestSchema = async (schemaJson: any, requestData: any, context: ParserContext) => {
+const validationContext = new AsyncLocalStorage<ParserContext>();
+
+function formatResult(result: z.ZodSafeParseResult<unknown>): ParseResult {
+  if (result.success) return { success: true };
+  const errors = result.error.issues.map(issue => {
+    let customErrorObj = null;
+    try {
+      customErrorObj = JSON.parse(issue.message);
+    } catch {
+      // Not a JSON string (standard zod error message).
+    }
+    return {
+      path: issue.path.join('.'),
+      property: issue.path[issue.path.length - 1]?.toString() || '',
+      errors: customErrorObj ? [customErrorObj] : [issue.message],
+    };
+  });
+  return { success: false, errors };
+}
+
+/** Compile the definition once at artifact load, then validate many requests. */
+export function compileRequestSchema(
+  schemaJson: any,
+  { coerce = false }: Pick<ParserContext, 'coerce'> = {},
+): CompiledRequestSchema {
   // Validate schema JSON itself against DB Zod schema
   const parsedDef = ValidationSchemaZod.safeParse(schemaJson);
   if (!parsedDef.success) {
-    return { 
-      success: false, 
-      errors: [{ path: 'schema', property: 'schema', errors: ['Invalid schema definition format'] }] 
+    return {
+      async validate() {
+        return {
+          success: false,
+          errors: [{ path: 'schema', property: 'schema', errors: ['Invalid schema definition format'] }],
+        };
+      },
     };
   }
 
-  const executableSchema = buildZodSchema(parsedDef.data, context);
-  const result = await executableSchema.safeParseAsync(requestData);
+  const executableSchema = buildZodSchema(parsedDef.data, coerce);
+  return {
+    async validate(requestData: any, context: ParserContext): Promise<ParseResult> {
+      // A cached schema is shared by concurrent requests. The JS refinement reads
+      // its own async-local context, so parallel requests cannot leak vars.
+      return validationContext.run(context, async () =>
+        formatResult(await executableSchema.safeParseAsync(requestData)),
+      );
+    },
+  };
+}
 
-  if (result.success) {
-    return { success: true };
-  } else {
-    const formattedErrors = result.error.issues.map(issue => {
-      let customErrorObj = null;
-      try { 
-        customErrorObj = JSON.parse(issue.message); 
-      } catch (e) {
-        // Not a JSON string (standard zod error message)
-      }
-
-      return {
-        path: issue.path.join('.'),
-        property: issue.path[issue.path.length - 1]?.toString() || '',
-        errors: customErrorObj ? [customErrorObj] : [issue.message]
-      };
-    });
-    
-    return { success: false, errors: formattedErrors };
-  }
+export const parseRequestSchema = async (
+  schemaJson: any,
+  requestData: any,
+  context: ParserContext,
+) => {
+  return compileRequestSchema(schemaJson, context).validate(requestData, context);
 };

--- a/apps/server/src/lib/tests/schemaParser.test.ts
+++ b/apps/server/src/lib/tests/schemaParser.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe } from 'bun:test';
-import { parseRequestSchema } from '../schemaParser';
+import { compileRequestSchema, parseRequestSchema } from '../schemaParser';
 import { JsVM } from '@fluxify/lib';
 
 describe('schemaParser Exhaustive Test Suite', () => {
@@ -186,6 +186,26 @@ describe('schemaParser Exhaustive Test Suite', () => {
       expect(result.success).toBe(false);
       // It should capture the JS execution error gracefully instead of crashing the server
       expect(result.errors?.[0]?.errors?.[0]).toContain('Unexpected identifier'); 
+    });
+  });
+
+  describe('Compiled schemas', () => {
+    test('reuses trusted JS validation code without leaking concurrent request vars', async () => {
+      const schema = compileRequestSchema({
+        dataType: 'js',
+        js: 'await Promise.resolve(); return input === expected;',
+      });
+      const vm = new JsVM({});
+
+      const [first, second, rejected] = await Promise.all([
+        schema.validate('alpha', { vm, vars: { expected: 'alpha' } }),
+        schema.validate('beta', { vm, vars: { expected: 'beta' } }),
+        schema.validate('wrong', { vm, vars: { expected: 'gamma' } }),
+      ]);
+
+      expect(first.success).toBe(true);
+      expect(second.success).toBe(true);
+      expect(rejected.success).toBe(false);
     });
   });
 

--- a/apps/server/src/modules/requestRouter/asyncExecutor.ts
+++ b/apps/server/src/modules/requestRouter/asyncExecutor.ts
@@ -1,0 +1,141 @@
+export const DEFAULT_ASYNC_MAX_IN_FLIGHT = 10;
+export const DEFAULT_ASYNC_MAX_QUEUE_DEPTH = 100;
+export const DEFAULT_ASYNC_DRAIN_TIMEOUT_MS = 30_000;
+
+export type AsyncExecutorLimits = {
+	maxInFlight: number;
+	maxQueueDepth: number;
+	drainTimeoutMs: number;
+};
+
+export type AsyncExecutorSnapshot = {
+	inFlight: number;
+	queued: number;
+	accepting: boolean;
+};
+
+type QueuedTask = () => Promise<void>;
+
+/**
+ * Bounded, process-local execution queue for fire-and-forget route envelopes.
+ *
+ * It deliberately knows nothing about HTTP or a particular trigger. Future NATS,
+ * Kafka, SQS, RabbitMQ and cron adapters can submit the same task shape, while a
+ * distributed workflow runtime can replace this implementation at the boundary.
+ */
+export class AsyncExecutor {
+	private readonly queue: QueuedTask[] = [];
+	private readonly idleWaiters = new Set<() => void>();
+	private inFlight = 0;
+	private accepting = true;
+
+	constructor(
+		private readonly limits: AsyncExecutorLimits,
+		private readonly onError: (error: unknown) => void,
+	) {
+		if (!Number.isInteger(limits.maxInFlight) || limits.maxInFlight < 1) {
+			throw new Error("maxInFlight must be a positive integer");
+		}
+		if (!Number.isInteger(limits.maxQueueDepth) || limits.maxQueueDepth < 0) {
+			throw new Error("maxQueueDepth must be a non-negative integer");
+		}
+	}
+
+	/** Returns false instead of retaining more request bodies once capacity is full. */
+	submit(task: QueuedTask): boolean {
+		if (
+			!this.accepting ||
+			(this.inFlight >= this.limits.maxInFlight &&
+				this.queue.length >= this.limits.maxQueueDepth)
+		) {
+			return false;
+		}
+		this.queue.push(task);
+		this.pump();
+		return true;
+	}
+
+	snapshot(): AsyncExecutorSnapshot {
+		return {
+			inFlight: this.inFlight,
+			queued: this.queue.length,
+			accepting: this.accepting,
+		};
+	}
+
+	/** Stop new work and let accepted work complete during a graceful shutdown. */
+	async drain(): Promise<boolean> {
+		this.accepting = false;
+		this.pump();
+		if (this.isIdle()) return true;
+
+		return new Promise<boolean>((resolve) => {
+			let timer: ReturnType<typeof setTimeout> | undefined;
+			const finish = (drained: boolean) => {
+				if (timer) clearTimeout(timer);
+				this.idleWaiters.delete(onIdle);
+				resolve(drained);
+			};
+			const onIdle = () => finish(true);
+			timer = setTimeout(() => finish(false), this.limits.drainTimeoutMs);
+			this.idleWaiters.add(onIdle);
+		});
+	}
+
+	private pump() {
+		while (this.inFlight < this.limits.maxInFlight && this.queue.length > 0) {
+			const task = this.queue.shift()!;
+			this.inFlight++;
+			queueMicrotask(async () => {
+				try {
+					await task();
+				} catch (error) {
+					this.onError(error);
+				} finally {
+					this.inFlight--;
+					this.pump();
+					this.notifyIdle();
+				}
+			});
+		}
+	}
+
+	private isIdle() {
+		return this.inFlight === 0 && this.queue.length === 0;
+	}
+
+	private notifyIdle() {
+		if (!this.isIdle()) return;
+		for (const resolve of this.idleWaiters) resolve();
+		this.idleWaiters.clear();
+	}
+}
+
+function readNonNegativeInt(value: string | undefined, fallback: number) {
+	if (!value) return fallback;
+	const parsed = Number(value);
+	return Number.isInteger(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+/** Supervisor-owned environment configuration; passed into the secretless child. */
+export function asyncExecutorLimitsFromEnv(
+	env: Record<string, string | undefined> = process.env,
+): AsyncExecutorLimits {
+	return {
+		maxInFlight: Math.max(
+			1,
+			readNonNegativeInt(env.ASYNC_EXECUTOR_MAX_IN_FLIGHT, DEFAULT_ASYNC_MAX_IN_FLIGHT),
+		),
+		maxQueueDepth: readNonNegativeInt(
+			env.ASYNC_EXECUTOR_MAX_QUEUE_DEPTH,
+			DEFAULT_ASYNC_MAX_QUEUE_DEPTH,
+		),
+		drainTimeoutMs: Math.max(
+			1,
+			readNonNegativeInt(
+				env.ASYNC_EXECUTOR_DRAIN_TIMEOUT_MS,
+				DEFAULT_ASYNC_DRAIN_TIMEOUT_MS,
+			),
+		),
+	};
+}

--- a/apps/server/src/modules/requestRouter/compiledRuntime.ts
+++ b/apps/server/src/modules/requestRouter/compiledRuntime.ts
@@ -7,6 +7,10 @@ import {
 	type BlockOutput,
 	type Context,
 } from "@fluxify/blocks";
+import {
+	compileRequestSchema,
+	type CompiledRequestSchema,
+} from "../../lib/schemaParser";
 import { artifactId, artifactKind } from "../compiler/subjects";
 import type {
 	CustomBlockArtifact,
@@ -39,6 +43,13 @@ export type ArtifactEntry = { key: string; value: any | null };
 type CompiledRoute = {
 	artifact: RouteArtifact;
 	run: (ctx: Context, input?: any) => Promise<BlockOutput | null>;
+	validators: RouteValidators;
+};
+
+export type RouteValidators = {
+	body?: CompiledRequestSchema;
+	query?: CompiledRequestSchema;
+	params?: CompiledRequestSchema;
 };
 
 const routes = new Map<string, CompiledRoute>();
@@ -51,6 +62,11 @@ let built = false;
 
 export function compiledRouteParser() {
 	return parser;
+}
+
+/** Cached alongside the compiled graph; no Zod tree is rebuilt per request. */
+export function compiledRouteValidators(routeId: string): RouteValidators | undefined {
+	return routes.get(routeId)?.validators;
 }
 
 /**
@@ -122,6 +138,7 @@ function addRoute(artifact: RouteArtifact) {
 		routes.set(artifact.routeId, {
 			artifact,
 			run: instantiateCompiled(artifact.source),
+			validators: compileRouteValidators(artifact),
 		});
 		logger.info(
 			`[worker] loaded ${artifact.method} ${artifact.path}`,
@@ -134,6 +151,20 @@ function addRoute(artifact: RouteArtifact) {
 			"WORKER.compiled",
 		);
 	}
+}
+
+function compileRouteValidators(artifact: RouteArtifact): RouteValidators {
+	return {
+		body: schemaValidator(artifact.bodySchema),
+		query: schemaValidator(artifact.querySchema, true),
+		params: schemaValidator(artifact.paramsSchema, true),
+	};
+}
+
+function schemaValidator(schema: unknown, coerce = false) {
+	return schema && typeof schema === "object" && Object.keys(schema).length > 0
+		? compileRequestSchema(schema, { coerce })
+		: undefined;
 }
 
 function removeRoute(routeId: string) {

--- a/apps/server/src/modules/requestRouter/executionEnvironment.ts
+++ b/apps/server/src/modules/requestRouter/executionEnvironment.ts
@@ -1,0 +1,16 @@
+/**
+ * Builds the environment exposed to compiled route code.
+ *
+ * The execution process must not inherit control-plane credentials. Bun's
+ * Windows networking support does, however, need SystemRoot to locate system
+ * TLS and networking components.
+ */
+export function executionRuntimeEnvironment(
+	environment: NodeJS.ProcessEnv = process.env,
+	platform = process.platform,
+): NodeJS.ProcessEnv {
+	if (platform !== "win32") return {};
+
+	const systemRoot = environment.SystemRoot ?? environment.SYSTEMROOT;
+	return systemRoot ? { SystemRoot: systemRoot } : {};
+}

--- a/apps/server/src/modules/requestRouter/executionEnvironmentChild.fixture.ts
+++ b/apps/server/src/modules/requestRouter/executionEnvironmentChild.fixture.ts
@@ -1,0 +1,4 @@
+export {};
+
+const response = await fetch(process.argv[2]!);
+process.exit(response.ok ? 0 : 1);

--- a/apps/server/src/modules/requestRouter/executionEnvironmentProcess.spec.ts
+++ b/apps/server/src/modules/requestRouter/executionEnvironmentProcess.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "bun:test";
+import { fileURLToPath } from "node:url";
+import { executionRuntimeEnvironment } from "./executionEnvironment";
+
+const fixture = fileURLToPath(
+	new URL("./executionEnvironmentChild.fixture.ts", import.meta.url),
+);
+
+test.if(process.platform === "win32")(
+	"allows a sanitized execution process to make Bun network requests on Windows",
+	async () => {
+		const server = Bun.serve({
+			port: 0,
+			fetch: () => new Response("ok"),
+		});
+		try {
+			const child = Bun.spawn([process.execPath, fixture, `http://127.0.0.1:${server.port}`], {
+				env: executionRuntimeEnvironment(),
+				stdout: "ignore",
+				stderr: "inherit",
+			});
+			expect(await child.exited).toBe(0);
+		} finally {
+			server.stop(true);
+		}
+	},
+);

--- a/apps/server/src/modules/requestRouter/executionProcess.ts
+++ b/apps/server/src/modules/requestRouter/executionProcess.ts
@@ -15,6 +15,7 @@ import type {
 import { projectSettingsCache } from "../../loaders/projectSettingsLoader";
 import { workerTimeoutsEnabled } from "./workerTimeouts";
 import { AsyncExecutor } from "./asyncExecutor";
+import { executionRuntimeEnvironment } from "./executionEnvironment";
 
 let boot: ExecutionBootstrap | undefined;
 let monitoringEnabled = false;
@@ -24,10 +25,9 @@ let server: ReturnType<typeof Bun.serve> | undefined;
 let shuttingDown = false;
 let asyncExecutor: AsyncExecutor | undefined;
 
-// The child process never needs supervisor secrets. Clear inherited values
-// before compiled user code is instantiated.
-for (const key of Object.keys(process.env)) delete process.env[key];
-process.env = {};
+// The child process never needs supervisor secrets. Preserve only the Windows
+// compatibility value Bun needs for networking before compiled user code loads.
+process.env = executionRuntimeEnvironment();
 process.argv = [];
 process.execArgv = [];
 

--- a/apps/server/src/modules/requestRouter/executionProcess.ts
+++ b/apps/server/src/modules/requestRouter/executionProcess.ts
@@ -2,6 +2,7 @@ import { initializeLogger, logger } from "@fluxify/common";
 import { createHttpContext } from "./httpContext";
 import {
 	applyArtifactUpdate,
+	compiledRouteValidators,
 	initCompiledRuntime,
 	shutdownCompiledRuntime,
 } from "./compiledRuntime";
@@ -13,6 +14,7 @@ import type {
 } from "./threadTypes";
 import { projectSettingsCache } from "../../loaders/projectSettingsLoader";
 import { workerTimeoutsEnabled } from "./workerTimeouts";
+import { AsyncExecutor } from "./asyncExecutor";
 
 let boot: ExecutionBootstrap | undefined;
 let monitoringEnabled = false;
@@ -20,6 +22,7 @@ let heartbeat: ReturnType<typeof setInterval> | undefined;
 let parser: ReturnType<typeof initCompiledRuntime> | undefined;
 let server: ReturnType<typeof Bun.serve> | undefined;
 let shuttingDown = false;
+let asyncExecutor: AsyncExecutor | undefined;
 
 // The child process never needs supervisor secrets. Clear inherited values
 // before compiled user code is instantiated.
@@ -48,6 +51,9 @@ function bootstrap(nextBoot: ExecutionBootstrap) {
 		useOtlp: boot.logging.useOtlp,
 	});
 	parser = initCompiledRuntime(boot.artifacts, boot.databaseIdleTimeoutMs);
+	asyncExecutor = new AsyncExecutor(boot.asyncExecutor, (error) =>
+		logger.error(`async dispatch failed: ${String(error)}`, "WORKER.execution"),
+	);
 	setMonitoring(boot.workerTimeoutsEnabled);
 
 	server = Bun.serve({ port: boot.port, reusePort: true, fetch: handle });
@@ -62,16 +68,29 @@ async function handle(request: Request): Promise<Response> {
 	const observer = createObserver();
 
 	if (env.trigger.reply === "async") {
-		queueMicrotask(() =>
-			dispatch(env, parser!, ctx as any, observer).catch((error) =>
-				logger.error(`async dispatch failed: ${error?.toString()}`),
-			),
-		);
+		const accepted = asyncExecutor?.submit(async () => {
+			// The HTTP response is already a 202. Do not retain the HTTP context or
+			// attempt late cookie/header writes while the detached route runs.
+			await dispatch(env, parser!, undefined, observer, compiledRouteValidators);
+		});
+		if (!accepted) {
+			return json(
+				{ message: "Async execution capacity is full" },
+				429,
+				ctx.responseHeaders,
+			);
+		}
 		return json({ accepted: true, id: env.trigger.id }, 202, ctx.responseHeaders);
 	}
 
 	try {
-		const response = await dispatch(env, parser, ctx as any, observer);
+		const response = await dispatch(
+			env,
+			parser,
+			ctx as any,
+			observer,
+			compiledRouteValidators,
+		);
 		return json(response.data, response.status, ctx.responseHeaders);
 	} catch (error) {
 		return json(
@@ -122,6 +141,10 @@ async function shutdown() {
 	shuttingDown = true;
 	if (heartbeat) clearInterval(heartbeat);
 	server?.stop(true);
+	const drained = await asyncExecutor?.drain();
+	if (drained === false) {
+		logger.warn("async executor drain deadline elapsed", "WORKER.execution");
+	}
 	await shutdownCompiledRuntime();
 	process.exit(0);
 }

--- a/apps/server/src/modules/requestRouter/router.ts
+++ b/apps/server/src/modules/requestRouter/router.ts
@@ -2,6 +2,11 @@ import { HttpRouteParser } from "@fluxify/lib";
 import { logger } from "@fluxify/common";
 import { Hono } from "hono";
 import { dispatch, envelopeFromHttp } from "./service";
+import { AsyncExecutor, asyncExecutorLimitsFromEnv } from "./asyncExecutor";
+
+const asyncExecutor = new AsyncExecutor(asyncExecutorLimitsFromEnv(), (error) =>
+	logger.error(`async dispatch failed: ${String(error)}`),
+);
 
 export async function mapRouter(app: Hono<any>, parser: HttpRouteParser) {
 	app.all("*", async (c) => {
@@ -11,11 +16,9 @@ export async function mapRouter(app: Hono<any>, parser: HttpRouteParser) {
 		// ponytail: block engine still caps execution at RESPONSE_TIMEOUT (4s);
 		// lift that cap when real long-running jobs land, keyed off trigger.reply.
 		if (env.trigger.reply === "async") {
-			queueMicrotask(() =>
-				dispatch(env, parser).catch((e) =>
-					logger.error(`async dispatch failed: ${e?.toString()}`),
-				),
-			);
+			if (!asyncExecutor.submit(async () => { await dispatch(env, parser); })) {
+				return c.json({ message: "Async execution capacity is full" }, 429);
+			}
 			return c.json({ accepted: true, id: env.trigger.id }, 202);
 		}
 

--- a/apps/server/src/modules/requestRouter/service.ts
+++ b/apps/server/src/modules/requestRouter/service.ts
@@ -21,7 +21,11 @@ import { ContentfulStatusCode } from "hono/utils/http-status";
 import { JsVM } from "@fluxify/lib";
 import { runBlocks } from "./executor";
 import { getAppConfig } from "../../loaders/appconfigLoader";
-import { parseRequestSchema, ValidationError } from "../../lib/schemaParser";
+import {
+	parseRequestSchema,
+	ValidationError,
+	type CompiledRequestSchema,
+} from "../../lib/schemaParser";
 import {
 	createObservabilityLogger,
 	DbConnectionManager,
@@ -48,6 +52,12 @@ export type RouteExecutionObserver = {
 		timeoutSeconds: number;
 	}): (() => void) | void;
 };
+
+export type RouteValidatorResolver = (routeId: string) => {
+	body?: CompiledRequestSchema;
+	query?: CompiledRequestSchema;
+	params?: CompiledRequestSchema;
+} | undefined;
 
 // defined in ./types so it has no import cycle with the envelope; re-exported
 // here because the test-suites runner imports it from this module.
@@ -103,6 +113,7 @@ export async function dispatch(
 	parser: HttpRouteParser,
 	httpCtx?: Context,
 	observer?: RouteExecutionObserver,
+	resolveValidators?: RouteValidatorResolver,
 ): Promise<HandleRequestType> {
 	const { payload, trigger, overrides } = env;
 	const path = parser.getRouteId(
@@ -134,6 +145,7 @@ export async function dispatch(
 				querySchema: path.querySchema,
 				paramsSchema: path.paramsSchema,
 				timeoutSeconds: path.timeoutSeconds,
+				validators: resolveValidators?.(path.id),
 			},
 			{
 				method: payload.method,
@@ -162,6 +174,11 @@ export async function executeRouteInternal(
 		querySchema?: any;
 		paramsSchema?: any;
 		timeoutSeconds?: number;
+		validators?: {
+			body?: CompiledRequestSchema;
+			query?: CompiledRequestSchema;
+			params?: CompiledRequestSchema;
+		};
 	},
 	requestData: {
 		method: string;
@@ -191,11 +208,13 @@ export async function executeRouteInternal(
 	const vm = createJsVM(vars);
 
 	if (routeInfo.bodySchema && Object.keys(routeInfo.bodySchema).length > 0) {
-		const result = await parseRequestSchema(
+		const result = await validateSchema(
+			routeInfo.validators?.body,
 			routeInfo.bodySchema,
 			requestData.body,
 			{
 				vm,
+				vars,
 			},
 		);
 		if (!result.success) {
@@ -207,11 +226,13 @@ export async function executeRouteInternal(
 	}
 
 	if (routeInfo.querySchema && Object.keys(routeInfo.querySchema).length > 0) {
-		const result = await parseRequestSchema(
+		const result = await validateSchema(
+			routeInfo.validators?.query,
 			routeInfo.querySchema,
 			requestData.query,
 			{
 				vm,
+				vars,
 				coerce: true,
 			},
 		);
@@ -227,10 +248,11 @@ export async function executeRouteInternal(
 		routeInfo.paramsSchema &&
 		Object.keys(routeInfo.paramsSchema).length > 0
 	) {
-		const result = await parseRequestSchema(
+		const result = await validateSchema(
+			routeInfo.validators?.params,
 			routeInfo.paramsSchema,
 			requestData.params,
-			{ vm, coerce: true },
+			{ vm, vars, coerce: true },
 		);
 		if (!result.success) {
 			return {
@@ -277,6 +299,17 @@ export async function executeRouteInternal(
 	} finally {
 		dbFactory.dispose();
 	}
+}
+
+function validateSchema(
+	compiled: CompiledRequestSchema | undefined,
+	schema: unknown,
+	value: unknown,
+	context: Parameters<CompiledRequestSchema["validate"]>[1],
+) {
+	return compiled
+		? compiled.validate(value, context)
+		: parseRequestSchema(schema, value, context);
 }
 
 function parseResult(executionResult: BlockOutput) {

--- a/apps/server/src/modules/requestRouter/tests/asyncExecutor.spec.ts
+++ b/apps/server/src/modules/requestRouter/tests/asyncExecutor.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "bun:test";
+import {
+	AsyncExecutor,
+	asyncExecutorLimitsFromEnv,
+} from "../asyncExecutor";
+
+describe("AsyncExecutor", () => {
+	it("keeps active and queued work within its configured bounds", async () => {
+		const started: number[] = [];
+		let release!: () => void;
+		const blocked = new Promise<void>((resolve) => (release = resolve));
+		const executor = new AsyncExecutor(
+			{ maxInFlight: 1, maxQueueDepth: 1, drainTimeoutMs: 1_000 },
+			() => {},
+		);
+
+		expect(executor.submit(async () => { started.push(1); await blocked; })).toBe(true);
+		expect(executor.submit(async () => { started.push(2); })).toBe(true);
+		expect(executor.submit(async () => { started.push(3); })).toBe(false);
+		await Promise.resolve();
+		expect(executor.snapshot()).toEqual({ inFlight: 1, queued: 1, accepting: true });
+
+		release();
+		expect(await executor.drain()).toBe(true);
+		expect(started).toEqual([1, 2]);
+		expect(executor.snapshot()).toEqual({ inFlight: 0, queued: 0, accepting: false });
+	});
+
+	it("contains background failures and continues with queued work", async () => {
+		const errors: unknown[] = [];
+		const completed: number[] = [];
+		const executor = new AsyncExecutor(
+			{ maxInFlight: 1, maxQueueDepth: 1, drainTimeoutMs: 1_000 },
+			(error) => errors.push(error),
+		);
+
+		executor.submit(async () => { throw new Error("expected"); });
+		executor.submit(async () => { completed.push(1); });
+
+		expect(await executor.drain()).toBe(true);
+		expect(errors).toHaveLength(1);
+		expect(completed).toEqual([1]);
+	});
+
+	it("allows active work with a zero-depth queue but rejects a second task", async () => {
+		let release!: () => void;
+		const blocked = new Promise<void>((resolve) => (release = resolve));
+		const executor = new AsyncExecutor(
+			{ maxInFlight: 1, maxQueueDepth: 0, drainTimeoutMs: 1_000 },
+			() => {},
+		);
+
+		expect(executor.submit(async () => { await blocked; })).toBe(true);
+		expect(executor.submit(async () => {})).toBe(false);
+		release();
+		expect(await executor.drain()).toBe(true);
+	});
+});
+
+describe("asyncExecutorLimitsFromEnv", () => {
+	it("uses bounded defaults and rejects invalid environment values", () => {
+		expect(asyncExecutorLimitsFromEnv({
+			ASYNC_EXECUTOR_MAX_IN_FLIGHT: "0",
+			ASYNC_EXECUTOR_MAX_QUEUE_DEPTH: "-1",
+			ASYNC_EXECUTOR_DRAIN_TIMEOUT_MS: "invalid",
+		})).toEqual({ maxInFlight: 1, maxQueueDepth: 100, drainTimeoutMs: 30_000 });
+	});
+});

--- a/apps/server/src/modules/requestRouter/tests/dispatch.spec.ts
+++ b/apps/server/src/modules/requestRouter/tests/dispatch.spec.ts
@@ -60,4 +60,46 @@ describe("dispatch", () => {
 		expect(res.status).toBe(404);
 		expect(res.data).toEqual({ message: "Route not found" });
 	});
+
+	it("uses a supplied artifact-time validator before creating route resources", async () => {
+		let validations = 0;
+		const parser = {
+			getRouteId: () => ({
+				id: "route-1",
+				projectId: "project-1",
+				projectName: "Project",
+				bodySchema: { dataType: "str" },
+			}),
+		} as unknown as HttpRouteParser;
+		const env = {
+			trigger: { kind: "route", source: "http", reply: "sync" as const },
+			payload: {
+				method: "POST",
+				path: "/jobs",
+				headers: {},
+				query: {},
+				body: "input",
+			},
+		};
+		const cachedValidator = {
+			validate: async () => {
+				validations++;
+				return {
+					success: false,
+					errors: [{ path: "", property: "", errors: ["expected failure"] }],
+				};
+			},
+		};
+
+		const res = await dispatch(env, parser, undefined, undefined, () => ({
+			body: cachedValidator as any,
+		}));
+
+		expect(validations).toBe(1);
+		expect(res.status).toBe(400);
+		expect(res.data).toEqual({
+			message: "Body validation failed",
+			errors: [{ path: "", property: "", errors: ["expected failure"] }],
+		});
+	});
 });

--- a/apps/server/src/modules/requestRouter/tests/executionEnvironment.spec.ts
+++ b/apps/server/src/modules/requestRouter/tests/executionEnvironment.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "bun:test";
+import { executionRuntimeEnvironment } from "../executionEnvironment";
+
+describe("executionRuntimeEnvironment", () => {
+	it("removes every inherited variable outside Windows", () => {
+		expect(executionRuntimeEnvironment({ NATS_TOKEN: "secret", PATH: "/bin" }, "linux")).toEqual({});
+	});
+
+	it("keeps only SystemRoot on Windows for Bun networking", () => {
+		expect(executionRuntimeEnvironment({
+		SystemRoot: "C:\\Windows",
+		MASTER_ENCRYPTION_KEY: "secret",
+		NATS_TOKEN: "secret",
+		PATH: "C:\\Windows\\System32",
+	}, "win32")).toEqual({ SystemRoot: "C:\\Windows" });
+	});
+
+	it("accepts the uppercase SystemRoot spelling", () => {
+		expect(executionRuntimeEnvironment({ SYSTEMROOT: "C:\\Windows" }, "win32")).toEqual({
+		SystemRoot: "C:\\Windows",
+	});
+	});
+});

--- a/apps/server/src/modules/requestRouter/threadTypes.ts
+++ b/apps/server/src/modules/requestRouter/threadTypes.ts
@@ -1,4 +1,5 @@
 import type { ArtifactEntry } from "./compiledRuntime";
+import type { AsyncExecutorLimits } from "./asyncExecutor";
 
 /** handed to the isolated execution process over Bun IPC at spawn */
 export type ExecutionBootstrap = {
@@ -6,6 +7,8 @@ export type ExecutionBootstrap = {
 	port: number;
 	/** idle database integration timeout, supplied by the supervisor in milliseconds */
 	databaseIdleTimeoutMs: number;
+	/** bounded process-local runner for optional async trigger replies */
+	asyncExecutor: AsyncExecutorLimits;
 	/** the full artifact set as of spawn, already unsealed */
 	artifacts: ArtifactEntry[];
 	/** hot-reloadable supervisor policy; false means no heartbeat or tracking */

--- a/docker/kit/Dockerfile
+++ b/docker/kit/Dockerfile
@@ -45,6 +45,10 @@
 #   ENABLE_AI               "true" to enable the AI assistant (default false)
 #   INTEGRATION_TIMEOUT_POLICY_IN_SEC
 #                           idle database-integration timeout (default 450 / 7.5 minutes)
+#   ASYNC_EXECUTOR_MAX_IN_FLIGHT / ASYNC_EXECUTOR_MAX_QUEUE_DEPTH
+#                           bounded local async-trigger capacity (defaults 10 / 100)
+#   ASYNC_EXECUTOR_DRAIN_TIMEOUT_MS
+#                           graceful drain deadline (default 30000)
 #   PROXY_PORT              published port (default 8080)
 #   SEED_USER_EMAIL / SEED_USER_PASSWORD / SEED_USER_NAME
 #                           first admin account created on an empty database
@@ -155,6 +159,9 @@ ENV NODE_ENV=production \
     WORKER_PORT=5600 \
     WORKER_HEALTH_PORT=5601 \
     INTEGRATION_TIMEOUT_POLICY_IN_SEC=450 \
+    ASYNC_EXECUTOR_MAX_IN_FLIGHT=10 \
+    ASYNC_EXECUTOR_MAX_QUEUE_DEPTH=100 \
+    ASYNC_EXECUTOR_DRAIN_TIMEOUT_MS=30000 \
     PROXY_PORT=8080 \
     AI_GATEWAY_PORT=8001 \
     ENABLE_ADMIN=true \

--- a/docker/kit/env.example
+++ b/docker/kit/env.example
@@ -42,6 +42,10 @@ WORKER_HEALTH_PORT=5601
 WORKER_PROJECT_ID=
 # Close an unused database integration after this many seconds (default 450 = 7.5 minutes).
 INTEGRATION_TIMEOUT_POLICY_IN_SEC=450
+# Per-worker bound for future async trigger/workflow execution.
+ASYNC_EXECUTOR_MAX_IN_FLIGHT=10
+ASYNC_EXECUTOR_MAX_QUEUE_DEPTH=100
+ASYNC_EXECUTOR_DRAIN_TIMEOUT_MS=30000
 # Local HTTP proxy server port (Caddy entrypoint)
 PROXY_PORT=8080
 # AI Gateway service server port

--- a/docker/production/env.example
+++ b/docker/production/env.example
@@ -37,6 +37,10 @@ WORKER_PORT=5600
 WORKER_HEALTH_PORT=5601
 # Close an unused database integration after this many seconds (default 450 = 7.5 minutes).
 INTEGRATION_TIMEOUT_POLICY_IN_SEC=450
+# Per-worker bound for future async trigger/workflow execution.
+ASYNC_EXECUTOR_MAX_IN_FLIGHT=10
+ASYNC_EXECUTOR_MAX_QUEUE_DEPTH=100
+ASYNC_EXECUTOR_DRAIN_TIMEOUT_MS=30000
 # Local HTTP proxy server port (Traefik entrypoint)
 PROXY_PORT=8080
 # AI Gateway service server port

--- a/docker/worker-compiled/Dockerfile
+++ b/docker/worker-compiled/Dockerfile
@@ -36,6 +36,10 @@
 #   WORKER_HEALTH_PORT      health port (default 5601)
 #   INTEGRATION_TIMEOUT_POLICY_IN_SEC
 #                           idle database-integration timeout (default 450 / 7.5 minutes)
+#   ASYNC_EXECUTOR_MAX_IN_FLIGHT / ASYNC_EXECUTOR_MAX_QUEUE_DEPTH
+#                           bounded local async-trigger capacity (defaults 10 / 100)
+#   ASYNC_EXECUTOR_DRAIN_TIMEOUT_MS
+#                           graceful drain deadline (default 30000)
 #   OTLP_*                  log shipping; see docker/kit/env.example
 #
 # DELIBERATELY NOT USED
@@ -132,7 +136,10 @@ ENV NODE_ENV=production \
     ENVIRONMENT=production \
     WORKER_PORT=5600 \
     WORKER_HEALTH_PORT=5601 \
-    INTEGRATION_TIMEOUT_POLICY_IN_SEC=450
+    INTEGRATION_TIMEOUT_POLICY_IN_SEC=450 \
+    ASYNC_EXECUTOR_MAX_IN_FLIGHT=10 \
+    ASYNC_EXECUTOR_MAX_QUEUE_DEPTH=100 \
+    ASYNC_EXECUTOR_DRAIN_TIMEOUT_MS=30000
 
 # Readiness, not liveness: 200 only once compiled routes have been loaded, so a
 # worker that came up before the compiler published anything is not sent traffic.

--- a/docs/architecture/request-lifecycle.md
+++ b/docs/architecture/request-lifecycle.md
@@ -164,16 +164,44 @@ sequenceDiagram
     P->>W: Forward
     W->>W: Match path → "Get user", extract id = 42
     W->>W: Validate request against your schemas
-    W->>W: Run the translated function
-    W->>DB: SELECT the user row
-    DB-->>W: Row
-    W-->>P: 200 with JSON body
-    P-->>U: 200 with JSON body
+    alt Normal route reply
+        W->>W: Run the translated function
+        W->>DB: SELECT the user row
+        DB-->>W: Row
+        W-->>P: 200 with JSON body
+        P-->>U: 200 with JSON body
+    else Future async trigger reply
+        W->>W: Submit envelope to bounded local executor
+        W-->>P: 202 Accepted
+        P-->>U: 202 Accepted
+        Note over W: queueMicrotask starts accepted work<br/>when executor capacity is available
+        W->>W: Run the translated function in background
+    end
 ```
 
 Matching the path is a lookup, not a search — adding more routes doesn't slow
 down the ones you already have. Everything after the match is your route's own
 code running directly.
+
+### Foundation for future async triggers
+
+The worker already has a bounded, process-local async executor. It accepts the
+same transport-neutral route envelope as HTTP dispatch, returns an immediate
+`202` once accepted, and starts detached work through `queueMicrotask`. This is
+an internal foundation only: there is not yet a dashboard route setting or
+supported public trigger endpoint that schedules work this way.
+
+Future webhook, route-to-route, NATS/JetStream, Kafka, SQS, RabbitMQ and cron
+adapters can all submit into this boundary. A later distributed workflow system
+can replace the local executor with durable JetStream scheduling without
+changing route execution itself.
+
+The local runner defaults to 10 in-flight jobs and 100 queued jobs per worker.
+When full, it rejects new async submissions with `429` rather than retaining
+unbounded request bodies. It is for I/O-bound work only: JavaScript loops,
+image/file processing, and other CPU-heavy work still share the execution
+process event loop and can delay ordinary routes. Those workloads need a
+dedicated CPU-worker design.
 
 ### What the worker is *not* doing
 

--- a/docs/deployments/production.md
+++ b/docs/deployments/production.md
@@ -104,6 +104,27 @@ the isolated execution process, so the container and its NATS watcher stay up.
 
 ---
 
+## Local async executor
+
+Compiled workers include a bounded local executor for the future async-trigger
+and workflow runtime. It is currently an internal capability rather than a
+route setting or public scheduling API. It queues only I/O-oriented detached
+work in the same execution process; it does not isolate CPU-heavy work.
+
+Configure its per-worker bounds through environment variables:
+
+```env
+# Defaults shown. A full executor returns 429 for a new async submission.
+ASYNC_EXECUTOR_MAX_IN_FLIGHT=10
+ASYNC_EXECUTOR_MAX_QUEUE_DEPTH=100
+# Graceful shutdown waits this long for accepted work before the process exits.
+ASYNC_EXECUTOR_DRAIN_TIMEOUT_MS=30000
+```
+
+Future route-to-route, webhook, cron and message-bus adapters use this same
+submission boundary. Distributed workflows will use durable JetStream
+scheduling instead of relying on the process-local queue.
+
 ## Step 1 — Create your `.env` {#env}
 
 Copy `docker/production/env.example` to `docker/production/.env` next to the

--- a/docs/getting-started/routing.md
+++ b/docs/getting-started/routing.md
@@ -102,6 +102,13 @@ return true;
 ```
 
 Whatever you pass to `ValidationError` is returned directly to the caller — giving you full control over your error messages.
+
+Validation schemas and their trusted JavaScript validators are compiled when a
+route artifact loads or hot-reloads. Requests only call the cached validator;
+they never compile schema definitions or request-provided `js:` strings. Values
+received from a caller are always treated as data, including strings beginning
+with `js:`.
+
 ## Validation Error Response
 
 When a request fails validation, the caller receives a `400 Bad Request` with a JSON body that clearly describes what went wrong.

--- a/packages/blocks/builtin/db/insert.ts
+++ b/packages/blocks/builtin/db/insert.ts
@@ -47,8 +47,8 @@ export async function runInsertDb(
 
 /**
  * A literal payload is walked at compile time, so its `js:` values become
- * inlined code. A payload that only exists at runtime (useParam, or the whole
- * object produced by a js expression) still has to be scanned per request.
+ * inlined code. A payload that only exists at runtime is data: it is forwarded
+ * unchanged and can never introduce a new executable `js:` expression.
  *
  * Read without parsing: the schema types `data.value` as an object, but the
  * block also accepts a string there when `source` is "js".
@@ -60,9 +60,9 @@ export function emitInsertDb(node: EmitNode) {
 
   let payload: string;
   if (input.useParam) {
-    payload = `await lib.evalJsDeep(ctx, ${node.in})`;
+    payload = node.in;
   } else if (input.data.source === "js" && typeof value === "string") {
-    payload = `await lib.evalJsDeep(ctx, ${node.js(value, node.in)})`;
+    payload = node.js(value, node.in);
   } else {
     payload = emitJsObject(value, node);
   }

--- a/packages/blocks/builtin/db/insertBulk.ts
+++ b/packages/blocks/builtin/db/insertBulk.ts
@@ -50,10 +50,10 @@ export function emitInsertBulkDb(node: EmitNode) {
 
   let payload: string;
   if (input.useParam) {
-    payload = `await lib.evalJsDeep(ctx, ${node.in})`;
+    payload = node.in;
   } else if (input.data.source === "js" && typeof value === "string") {
     // matches the block: the stored string is expected to carry the js: prefix
-    payload = `await lib.evalJsDeep(ctx, ${node.js(value.slice(3), node.in)})`;
+    payload = node.js(value.slice(3), node.in);
   } else {
     payload = emitJsObject(value, node);
   }

--- a/packages/blocks/builtin/db/update.ts
+++ b/packages/blocks/builtin/db/update.ts
@@ -70,9 +70,9 @@ export function emitUpdateDb(node: EmitNode) {
 
 	let payload: string;
 	if (input.useParam) {
-		payload = `await lib.evalJsDeep(ctx, ${node.in})`;
+		payload = node.in;
 	} else if (input.data.source === "js" && typeof value === "string") {
-		payload = `await lib.evalJsDeep(ctx, ${node.js(value, node.in)})`;
+		payload = node.js(value, node.in);
 	} else {
 		payload = emitJsObject(value, node);
 	}

--- a/packages/blocks/builtin/tests/compilerDb.spec.ts
+++ b/packages/blocks/builtin/tests/compilerDb.spec.ts
@@ -155,7 +155,7 @@ describe("compiled db blocks", () => {
 		});
 	});
 
-	it("scans runtime payloads for js values when useParam is set", async () => {
+	it("treats runtime js-prefixed payload strings as data when useParam is set", async () => {
 		const mock = createDbAdapter({ insert: { id: 1 } });
 		const target = block("db", BlockTypes.db_insert, {
 			connection: "conn-1",
@@ -164,10 +164,10 @@ describe("compiled db blocks", () => {
 			data: { source: "raw", value: {} },
 		});
 
-		// the js string only exists at runtime, so it cannot be compiled away
+		// Request/previous-block data never becomes executable code at runtime.
 		await runAround(target, { total: "js:return 6 * 7", label: "x" }, mock);
 
-		expect(mock.calls[0].args[1]).toEqual({ total: 42, label: "x" });
+		expect(mock.calls[0].args[1]).toEqual({ total: "js:return 6 * 7", label: "x" });
 	});
 
 	it("rejects a non-object insert payload", async () => {

--- a/packages/blocks/compiler.ts
+++ b/packages/blocks/compiler.ts
@@ -104,7 +104,6 @@ export const compilerLib = {
 	httpRequest: runHttpRequest,
 	isoDate: (value: any) => dayjs(value).toISOString(),
 	scope: scopeFor,
-	evalJsDeep: evaluateJsDeep,
 	/** Number() with the block's documented fallback for NaN */
 	num: (value: any, fallback: number) => {
 		const parsed = Number(value);
@@ -171,42 +170,6 @@ export function scopeFor(vars: Record<string, any>) {
 		scopes.set(vars, scope);
 	}
 	return scope;
-}
-
-const dynamicScripts = new Map<string, (input: any, scope: any) => Promise<any>>();
-
-/**
- * Evaluates `js:` strings the compiler could not see — values that arrive at
- * runtime inside a previous block's output (db insert/update with useParam).
- * Compiled once per distinct snippet and cached, so it costs a Map lookup after
- * the first request.
- * ponytail: unbounded cache keyed by source; snippet count is bounded by the
- * data users push through, so cap it if that ever stops being true.
- */
-export async function evaluateJsDeep(
-	context: { vars: Record<string, any> },
-	value: any,
-): Promise<any> {
-	if (typeof value === "string" && value.startsWith("js:")) {
-		const code = value.slice(3);
-		let script = dynamicScripts.get(code);
-		if (!script) {
-			script = new AsyncFunction("input", "$scope", `with ($scope) {\n${code}\n}`) as any;
-			dynamicScripts.set(code, script!);
-		}
-		return script!(undefined, scopeFor(context.vars));
-	}
-	if (Array.isArray(value)) {
-		return Promise.all(value.map((item) => evaluateJsDeep(context, item)));
-	}
-	if (value && typeof value === "object") {
-		const result: any = {};
-		for (const key in value) {
-			result[key] = await evaluateJsDeep(context, value[key]);
-		}
-		return result;
-	}
-	return value;
 }
 
 /** mirrors JsVM.truthy / the `is_empty` operator, inlined into every program */


### PR DESCRIPTION
## Summary
- add a bounded, drainable per-worker async executor for future trigger adapters
- compile route Zod schemas and trusted custom validators at artifact load
- treat runtime js: values as data, removing the unbounded dynamic code cache
- document capacity settings, Docker defaults, and the future async queue flow

## Behaviour
- defaults: 10 in-flight jobs, 100 queued jobs, 30-second graceful drain
- saturated async submission returns 429
- no public async trigger setting is introduced; this is the worker foundation only
- CPU-heavy work is explicitly not isolated by this local runner

## Verification
- full pre-commit hook passed: lint, secret scan, analysis, 541 unit tests
- focused executor, dispatch/cache, schema concurrency, compiler DB, docs build, and compiled-worker build passed
- the full parallel server suite had one watchdog child-process timing flake; its test passed three isolated reruns