### PR TITLE
feat(worker): bound async runtime

### DIFF
--- a/apps/server/src/api/v1/routes/openapi/service.ts
+++ b/apps/server/src/api/v1/routes/openapi/service.ts
@@ -5,7 +5,6 @@ import {
 	deleteCacheKeysByPattern,
 } from "../../../../db/redis";
 import { getProject, getActiveRoutes } from "./repository";
-import { JsVM } from "@fluxify/lib";
 import z from "zod";
 import { requestParamSchema } from "./dto";
 import { NotFoundError } from "../../../../errors/notFoundError";
@@ -123,8 +122,6 @@ export async function generateOpenApiSpec(
 
 	const routes = await getActiveRoutes(projectId);
 	const paths: Record<string, any> = {};
-	const vm = new JsVM({});
-	const context = { vm };
 
 	for (const route of routes) {
 		const method = (route.method || "get").toLowerCase();

--- a/apps/server/src/lib/schemaParser.ts
+++ b/apps/server/src/lib/schemaParser.ts
@@ -2,7 +2,6 @@ import { z } from 'zod';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { scopeFor } from '@fluxify/blocks';
 import { ValidationSchemaZod } from './validationSchemaZod';
-import { JsVM } from '@fluxify/lib';
 
 export class ValidationError extends Error {
   payload: any;
@@ -14,9 +13,8 @@ export class ValidationError extends Error {
 }
 
 export type ParserContext = {
-  vm: JsVM;
-  /** Present in the compiled worker: trusted validators run against these vars. */
-  vars?: Record<string, any>;
+  /** Trusted validators run against these request-scoped vars. */
+  vars: Record<string, any>;
   coerce?: boolean;
 };
 
@@ -103,9 +101,7 @@ export function buildZodSchema(schemaDef: any, coerce = false): z.ZodTypeAny {
       try {
         const context = validationContext.getStore();
         if (!context) throw new Error('Validation context unavailable');
-        const result = context.vars
-          ? await validator!(val, scopeFor(context.vars))
-          : await context.vm.runAsync(js, val);
+        const result = await validator!(val, scopeFor(context.vars));
         if (!result) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Custom JS validation failed' });
         }

--- a/apps/server/src/lib/tests/schemaParser.test.ts
+++ b/apps/server/src/lib/tests/schemaParser.test.ts
@@ -1,9 +1,8 @@
 import { test, expect, describe } from 'bun:test';
 import { compileRequestSchema, parseRequestSchema } from '../schemaParser';
-import { JsVM } from '@fluxify/lib';
 
 describe('schemaParser Exhaustive Test Suite', () => {
-  const context = { vm: new JsVM({}) };
+  const context = { vars: {} };
 
   describe('Primitive Types and Boundary Rules', () => {
     test('String validations (length, regex, startsWith, endsWith, contains, notContains)', async () => {
@@ -130,7 +129,7 @@ describe('schemaParser Exhaustive Test Suite', () => {
     });
   });
 
-  describe('Custom JavaScript Validations in VM', () => {
+  describe('Compiled Custom JavaScript Validations', () => {
     test('Returns boolean pass/fail', async () => {
       const schema = {
         dataType: 'js',
@@ -195,12 +194,10 @@ describe('schemaParser Exhaustive Test Suite', () => {
         dataType: 'js',
         js: 'await Promise.resolve(); return input === expected;',
       });
-      const vm = new JsVM({});
-
       const [first, second, rejected] = await Promise.all([
-        schema.validate('alpha', { vm, vars: { expected: 'alpha' } }),
-        schema.validate('beta', { vm, vars: { expected: 'beta' } }),
-        schema.validate('wrong', { vm, vars: { expected: 'gamma' } }),
+        schema.validate('alpha', { vars: { expected: 'alpha' } }),
+        schema.validate('beta', { vars: { expected: 'beta' } }),
+        schema.validate('wrong', { vars: { expected: 'gamma' } }),
       ]);
 
       expect(first.success).toBe(true);

--- a/apps/server/src/modules/requestRouter/service.ts
+++ b/apps/server/src/modules/requestRouter/service.ts
@@ -205,7 +205,6 @@ export async function executeRouteInternal(
 		overrides,
 		trigger,
 	);
-	const vm = createJsVM(vars);
 
 	if (routeInfo.bodySchema && Object.keys(routeInfo.bodySchema).length > 0) {
 		const result = await validateSchema(
@@ -213,7 +212,6 @@ export async function executeRouteInternal(
 			routeInfo.bodySchema,
 			requestData.body,
 			{
-				vm,
 				vars,
 			},
 		);
@@ -231,7 +229,6 @@ export async function executeRouteInternal(
 			routeInfo.querySchema,
 			requestData.query,
 			{
-				vm,
 				vars,
 				coerce: true,
 			},
@@ -252,7 +249,7 @@ export async function executeRouteInternal(
 			routeInfo.validators?.params,
 			routeInfo.paramsSchema,
 			requestData.params,
-			{ vm, vars, coerce: true },
+			{ vars, coerce: true },
 		);
 		if (!result.success) {
 			return {
@@ -265,6 +262,7 @@ export async function executeRouteInternal(
 		}
 	}
 
+	const vm = createJsVM(vars);
 	const dbFactory = createDbFactory(
 		vm,
 		routeInfo.projectId,


### PR DESCRIPTION
## Summary
- add bounded per-worker async execution infrastructure for future trigger adapters
- compile and cache request Zod schemas and trusted custom validators at artifact load
- remove runtime dynamic JavaScript evaluation from compiled database paths
- preserve Windows SystemRoot for Bun network requests without exposing supervisor secrets
- remove JsVM from request-schema validation and defer executor VM allocation until validation succeeds

## Behaviour
- default async limits: 10 in-flight, 100 queued, 30-second graceful drain
- rejects saturated async submissions with 429
- this is local I/O concurrency only; CPU-bound work still blocks the worker

## Verification
- full pre-commit suite: 545 tests passed
- compiled-worker bundle build passed
- Windows sanitized-child network fetch test passed