### PR TITLE
fix(web): allow route timeout default

### DIFF
--- a/apps/web/src/services/routes.ts
+++ b/apps/web/src/services/routes.ts
@@ -48,7 +48,7 @@ export const routesService = {
     return result.data;
   },
   async create(
-    data: z.infer<typeof createRequestSchema>
+    data: z.input<typeof createRequestSchema>
   ): Promise<z.infer<typeof createResponseSchema>> {
     const result = await httpClient.post(`${baseUrl}`, data);
     return result.data;


### PR DESCRIPTION
## Why

Route creation failed the production web build because the client typed the request as Zod's post-default output, requiring timeoutSeconds even though the API supplies its default.

## What

Use the Zod input type for route creation requests so callers may omit timeoutSeconds and the API applies its 30-second default.

## Verification

- bun run --cwd apps/web build
- Pre-commit checks (lint, secret scan, analysis, 545 tests)