### PR TITLE
fix(worker): dedupe artifact boot replay, incremental route trie

### DIFF
--- a/apps/server/deployments/compiledWorker.ts
+++ b/apps/server/deployments/compiledWorker.ts
@@ -1,9 +1,12 @@
 import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { initializeLogger, logger } from "@fluxify/common";
-import { healthResponse, markReady } from "../src/modules/requestRouter/health";
 import {
-	loadProjectArtifacts,
+	healthResponse,
+	markNotReady,
+	markReady,
+} from "../src/modules/requestRouter/health";
+import {
 	watchProjectArtifacts,
 } from "../src/modules/requestRouter/artifactHost";
 import type { UnsealedProjectConfig } from "../src/modules/compiler/artifacts";
@@ -17,6 +20,7 @@ import { ExecutionWatchdog } from "../src/modules/requestRouter/executionWatchdo
 import { workerTimeoutsEnabled } from "../src/modules/requestRouter/workerTimeouts";
 import { asyncExecutorLimitsFromEnv } from "../src/modules/requestRouter/asyncExecutor";
 import { executionRuntimeEnvironment } from "../src/modules/requestRouter/executionEnvironment";
+import type { ArtifactEntry } from "../src/modules/requestRouter/compiledRuntime";
 import { initializeRedis } from "../src/db/redis";
 import { closePubSub, initializePubSub } from "../src/db/pubsub";
 import {
@@ -76,10 +80,8 @@ const bundledProcess = new URL("./executionProcess.js", import.meta.url);
 const processEntry = existsSync(bundledProcess)
 	? bundledProcess
 	: new URL("../src/modules/requestRouter/executionProcess.ts", import.meta.url);
-const initialArtifacts = await loadProjectArtifacts(WORKER_PROJECT_ID);
-const artifacts = new Map(initialArtifacts.map((entry) => [entry.key, entry]));
+const artifacts = new Map<string, ArtifactEntry>();
 const timeoutProjects = new Map<string, boolean>();
-for (const entry of initialArtifacts) updateTimeoutPolicy(entry.key, entry.value);
 
 const watchdog = new ExecutionWatchdog();
 let execution: any;
@@ -144,6 +146,7 @@ function spawnExecution() {
 		onExit: (process, exitCode, signalCode, error) => {
 			if (execution !== process) return;
 			execution = undefined;
+			markNotReady();
 			watchdog.setEnabled(timeoutPolicyEnabled());
 			if (shuttingDown) return;
 			logger.error(
@@ -161,6 +164,7 @@ function spawnExecution() {
 function onExecutionEvent(event: ExecutionEvent) {
 	switch (event.type) {
 		case "ready":
+			markReady();
 			logger.info("execution process ready", "WORKER.execution");
 			return;
 		case "heartbeat":
@@ -171,6 +175,21 @@ function onExecutionEvent(event: ExecutionEvent) {
 			return watchdog.finish(event.requestId);
 	}
 }
+
+function handleArtifactChange(entry: ArtifactEntry) {
+	const policyChanged = artifactKind(entry.key) === "project-config";
+	if (entry.value === null) artifacts.delete(entry.key);
+	else artifacts.set(entry.key, entry);
+	if (policyChanged) updateTimeoutPolicy(entry.key, entry.value);
+	execution?.send({ type: "artifact", entry } satisfies ExecutionMessage);
+	if (policyChanged && execution) synchronizeMonitoring();
+}
+
+const artifactWatch = await watchProjectArtifacts(
+	WORKER_PROJECT_ID,
+	handleArtifactChange,
+);
+await artifactWatch.initialized;
 
 spawnExecution();
 synchronizeMonitoring();
@@ -187,16 +206,6 @@ function evaluateTimeouts() {
 	execution.kill();
 }
 
-await watchProjectArtifacts(WORKER_PROJECT_ID, (entry) => {
-	const policyChanged = artifactKind(entry.key) === "project-config";
-	if (entry.value === null) artifacts.delete(entry.key);
-	else artifacts.set(entry.key, entry);
-	if (policyChanged) updateTimeoutPolicy(entry.key, entry.value);
-	execution?.send({ type: "artifact", entry } satisfies ExecutionMessage);
-	if (policyChanged) synchronizeMonitoring();
-});
-
-markReady();
 logger.info(`compiled worker ready — isolated execution process on port ${port}`);
 
 async function shutdown(sig: string) {
@@ -206,6 +215,7 @@ async function shutdown(sig: string) {
 	logger.info(`received ${sig} — shutting down`);
 	try {
 		execution?.kill();
+		artifactWatch.stop();
 		healthServer.stop(true);
 		await closePubSub();
 	} catch (error) {

--- a/apps/server/src/db/natsKv.ts
+++ b/apps/server/src/db/natsKv.ts
@@ -1,5 +1,10 @@
 import { logger } from "@fluxify/common";
-import { StringCodec, type KV, type KvEntry } from "nats";
+import {
+	KvWatchInclude,
+	StringCodec,
+	type KV,
+	type KvEntry,
+} from "nats";
 import { natsConnection } from "./nats";
 
 /**
@@ -53,9 +58,8 @@ export async function listArtifacts<T>(
 }
 
 /**
- * Push updates for a key filter. The initial pass replays what is already
- * stored, so a booting worker gets the current state and every later change
- * through the same callback. Returns a stop function.
+ * Push updates for a key filter. Callers can request the initial replay and
+ * await `initialized` before treating the watched state as complete.
  */
 export async function watchArtifacts<T>(
 	filter: string | string[],
@@ -63,29 +67,64 @@ export async function watchArtifacts<T>(
 	options: { includeExisting?: boolean } = {},
 ) {
 	const store = await artifactStore();
+	const includeExisting = options.includeExisting === true;
+	let resolveInitialized: (() => void) | undefined;
+	let rejectInitialized: ((error: Error) => void) | undefined;
+	let initialized = !includeExisting;
+	const initialization = new Promise<void>((resolve, reject) => {
+		resolveInitialized = resolve;
+		rejectInitialized = reject;
+	});
 	const iterator = await store.watch({
 		key: filter,
-		initializedFn: options.includeExisting ? undefined : () => {},
+		// `initializedFn` signals replay completion; it does not disable replay.
+		include: includeExisting
+			? KvWatchInclude.LastValue
+			: KvWatchInclude.UpdatesOnly,
+		initializedFn: includeExisting
+			? () => {
+				initialized = true;
+				resolveInitialized?.();
+			}
+			: undefined,
 	});
 
-	(async () => {
-		for await (const entry of iterator) {
-			try {
-				await onChange(
-					entry.key,
-					entry.operation === "PUT" ? decode<T>(entry) : null,
+	void (async () => {
+		try {
+			for await (const entry of iterator) {
+				try {
+					await onChange(
+						entry.key,
+						entry.operation === "PUT" ? decode<T>(entry) : null,
+					);
+				} catch (error) {
+					logger.error(
+						`[KV] failed handling ${entry.key}: ${String(error)}`,
+						"KV.watch",
+					);
+				}
+			}
+		} catch (error) {
+			if (!initialized) {
+				rejectInitialized?.(
+					error instanceof Error ? error : new Error(String(error)),
 				);
-			} catch (error) {
-				logger.error(
-					`[KV] failed handling ${entry.key}: ${String(error)}`,
-					"KV.watch",
+			}
+			logger.error(`[KV] artifact watch stopped: ${String(error)}`, "KV.watch");
+		} finally {
+			if (!initialized) {
+				rejectInitialized?.(
+					new Error("artifact watch stopped before initial replay completed"),
 				);
 			}
 		}
 	})();
 
-	return async () => {
-		iterator.stop();
+	return {
+		initialized: includeExisting ? initialization : Promise.resolve(),
+		stop: () => {
+			iterator.stop();
+		},
 	};
 }
 

--- a/apps/server/src/db/natsKv.ts
+++ b/apps/server/src/db/natsKv.ts
@@ -43,20 +43,6 @@ export async function deleteArtifact(key: string) {
 	await store.delete(key);
 }
 
-/** every artifact whose key matches the filter, e.g. `route.<projectId>.*` */
-export async function listArtifacts<T>(
-	filter: string | string[],
-): Promise<{ key: string; value: T }[]> {
-	const store = await artifactStore();
-	const found: { key: string; value: T }[] = [];
-	const keys = await store.keys(filter);
-	for await (const key of keys) {
-		const value = await getArtifact<T>(key);
-		if (value) found.push({ key, value });
-	}
-	return found;
-}
-
 /**
  * Push updates for a key filter. Callers can request the initial replay and
  * await `initialized` before treating the watched state as complete.

--- a/apps/server/src/modules/requestRouter/artifactHost.ts
+++ b/apps/server/src/modules/requestRouter/artifactHost.ts
@@ -1,4 +1,4 @@
-import { listArtifacts, watchArtifacts } from "../../db/natsKv";
+import { watchArtifacts } from "../../db/natsKv";
 import { artifactKind, projectArtifactFilters } from "../compiler/subjects";
 import type {
 	ProjectConfigArtifact,
@@ -14,21 +14,18 @@ import type { ArtifactEntry } from "./compiledRuntime";
  * receive artifacts already unsealed and never open a connection of their own.
  */
 
-/** everything currently published for this project, ready to hand to a process */
-export async function loadProjectArtifacts(
-	projectId: string,
-): Promise<ArtifactEntry[]> {
-	const existing = await listArtifacts<any>(projectArtifactFilters(projectId));
-	return existing.map(({ key, value }) => ({ key, value: unseal(key, value) }));
-}
-
-/** every later change; the KV update is itself the fan-out signal */
+/**
+ * One watch supplies both initial snapshot and later changes. A separate
+ * snapshot read plus subscription can miss a write between those operations.
+ */
 export async function watchProjectArtifacts(
 	projectId: string,
 	onChange: (entry: ArtifactEntry) => void,
 ) {
-	await watchArtifacts<any>(projectArtifactFilters(projectId), (key, value) =>
-		onChange({ key, value: unseal(key, value) }),
+	return watchArtifacts<any>(
+		projectArtifactFilters(projectId),
+		(key, value) => onChange({ key, value: unseal(key, value) }),
+		{ includeExisting: true },
 	);
 }
 

--- a/apps/server/src/modules/requestRouter/compiledRuntime.ts
+++ b/apps/server/src/modules/requestRouter/compiledRuntime.ts
@@ -1,30 +1,30 @@
-import { logger } from "@fluxify/common";
-import { HttpRouteParser } from "@fluxify/lib";
+import { DbConnectionManager } from "@fluxify/adapters";
 import {
 	instantiateCompiled,
 	registerCompiledCustomBlock,
-	unregisterCustomBlock,
 	type BlockOutput,
 	type Context,
+	unregisterCustomBlock,
 } from "@fluxify/blocks";
+import { logger } from "@fluxify/common";
+import { HttpRouteParser, type HttpRoute } from "@fluxify/lib";
 import {
 	compileRequestSchema,
 	type CompiledRequestSchema,
 } from "../../lib/schemaParser";
-import { artifactId, artifactKind } from "../compiler/subjects";
-import type {
-	CustomBlockArtifact,
-	RouteArtifact,
-	UnsealedProjectConfig,
-} from "../compiler/artifacts";
 import { hydrateAppConfig } from "../../loaders/appconfigLoader";
 import {
 	dbIntegrationsCache,
 	hydrateIntegrations,
 } from "../../loaders/integrationsLoader";
 import { hydrateProjectSettings } from "../../loaders/projectSettingsLoader";
+import type {
+	CustomBlockArtifact,
+	RouteArtifact,
+	UnsealedProjectConfig,
+} from "../compiler/artifacts";
+import { artifactId, artifactKind } from "../compiler/subjects";
 import { setBlocksExecutor } from "./executor";
-import { DbConnectionManager } from "@fluxify/adapters";
 import { setDbConnectionManager } from "./service";
 
 /**
@@ -56,9 +56,8 @@ const routes = new Map<string, CompiledRoute>();
 /** custom block artifact id -> registered name, so a delete can unregister it */
 const customBlockNamesById = new Map<string, string>();
 let dbConnectionManager: DbConnectionManager | undefined;
-/** one instance for the process — the router captured it, so rebuild in place */
+/** one instance for the process — the router captured it, so update in place */
 const parser = new HttpRouteParser();
-let built = false;
 
 export function compiledRouteParser() {
 	return parser;
@@ -88,7 +87,6 @@ export function initCompiledRuntime(
 	for (const { key, value } of entries) {
 		if (artifactKind(key) === "route") applyArtifact(key, value);
 	}
-	rebuildParser();
 
 	setBlocksExecutor(async (target, context) => {
 		const compiled = routes.get(target.routeId);
@@ -108,7 +106,6 @@ export function initCompiledRuntime(
 /** a later update pushed down by the supervisor */
 export function applyArtifactUpdate(key: string, value: any | null) {
 	applyArtifact(key, value);
-	if (artifactKind(key) === "route") rebuildParser();
 }
 
 /** Releases all long-lived database clients before the execution process exits. */
@@ -140,6 +137,7 @@ function addRoute(artifact: RouteArtifact) {
 			run: instantiateCompiled(artifact.source),
 			validators: compileRouteValidators(artifact),
 		});
+		parser.upsertRoute(routeDefinition(artifact));
 		logger.info(
 			`[worker] loaded ${artifact.method} ${artifact.path}`,
 			"WORKER.compiled",
@@ -169,8 +167,23 @@ function schemaValidator(schema: unknown, coerce = false) {
 
 function removeRoute(routeId: string) {
 	if (routes.delete(routeId)) {
+		parser.removeRoute(routeId);
 		logger.info(`[worker] removed route ${routeId}`, "WORKER.compiled");
 	}
+}
+
+function routeDefinition(artifact: RouteArtifact): HttpRoute {
+	return {
+		method: artifact.method as HttpRoute["method"],
+		path: artifact.path,
+		routeId: artifact.routeId,
+		projectId: artifact.projectId,
+		projectName: artifact.projectName,
+		bodySchema: artifact.bodySchema,
+		querySchema: artifact.querySchema,
+		paramsSchema: artifact.paramsSchema,
+		timeoutSeconds: artifact.timeoutSeconds,
+	};
 }
 
 function addCustomBlock(artifact: CustomBlockArtifact) {
@@ -215,21 +228,4 @@ function applyProjectConfig(artifact: UnsealedProjectConfig) {
 		`[worker] project config applied (${artifact.compiledAt})`,
 		"WORKER.compiled",
 	);
-}
-
-function rebuildParser() {
-	const definitions = [...routes.values()].map(({ artifact }) => ({
-		method: artifact.method,
-		path: artifact.path,
-		routeId: artifact.routeId,
-		projectId: artifact.projectId,
-		projectName: artifact.projectName,
-		bodySchema: artifact.bodySchema,
-		querySchema: artifact.querySchema,
-		paramsSchema: artifact.paramsSchema,
-		timeoutSeconds: artifact.timeoutSeconds,
-	}));
-	// @ts-ignore — same loose shape routesLoader passes
-	built ? parser.rebuildRoutes(definitions) : parser.buildRoutes(definitions);
-	built = true;
 }

--- a/apps/server/src/modules/requestRouter/health.ts
+++ b/apps/server/src/modules/requestRouter/health.ts
@@ -10,6 +10,10 @@ export function markReady() {
 	depsReady = true;
 }
 
+export function markNotReady() {
+	depsReady = false;
+}
+
 /**
  * k8s-style probes. Register BEFORE mapRouter so its `all("*")` catch-all
  * doesn't swallow these paths.

--- a/packages/lib/routing/parser.ts
+++ b/packages/lib/routing/parser.ts
@@ -25,55 +25,101 @@ export type RouteTree = {
 
 export class HttpRouteParser {
   private routesTree: Record<string, RouteTree> = {};
+  private readonly routesById = new Map<string, HttpRoute>();
+
   public rebuildRoutes(routes: HttpRoute[]) {
     this.routesTree = {};
+    this.routesById.clear();
     this.buildRoutes(routes);
   }
-  public buildRoutes(routes: HttpRoute[]) {
-    for (let route of routes) {
-      let current = this.routesTree;
-      const path = route.path;
-      const parts = path.split("/").filter((p) => p.trim() != "");
-      if (route.method in current) {
-        current = current[route.method].children;
-      } else {
-        current[route.method] = {
-          children: {},
-          isParam: false,
-          subPath: "",
-        };
-        current = current[route.method].children;
-      }
-      for (let part of parts) {
-        let route = part;
-        const isParam = route.startsWith(":");
-        if (isParam) {
-          route = route.slice(1);
-        }
-        if (route in current) {
-          current = current[route].children;
-        } else {
-          current[route] = {
-            subPath: route,
-            isParam,
-            children: {},
-          };
-          current = current[route].children;
-        }
-      }
-      current["<ID>"] = {
+
+  /** Adds or replaces one route without rebuilding unrelated route branches. */
+  public upsertRoute(route: HttpRoute) {
+    if (this.routesById.has(route.routeId)) {
+      this.removeRoute(route.routeId);
+    }
+    this.routesById.set(route.routeId, route);
+
+    let current = this.routesTree;
+    if (route.method in current) {
+      current = current[route.method].children;
+    } else {
+      current[route.method] = {
         children: {},
         isParam: false,
         subPath: "",
-        id: route.routeId,
-        projectId: route.projectId,
-        projectName: route.projectName,
-        bodySchema: route.bodySchema,
-        querySchema: route.querySchema,
-        paramsSchema: route.paramsSchema,
-        timeoutSeconds: route.timeoutSeconds,
       };
+      current = current[route.method].children;
     }
+    for (let part of route.path.split("/").filter((p) => p.trim() != "")) {
+      const isParam = part.startsWith(":");
+      if (isParam) {
+        part = part.slice(1);
+      }
+      if (part in current) {
+        current = current[part].children;
+      } else {
+        current[part] = {
+          subPath: part,
+          isParam,
+          children: {},
+        };
+        current = current[part].children;
+      }
+    }
+    current["<ID>"] = {
+      children: {},
+      isParam: false,
+      subPath: "",
+      id: route.routeId,
+      projectId: route.projectId,
+      projectName: route.projectName,
+      bodySchema: route.bodySchema,
+      querySchema: route.querySchema,
+      paramsSchema: route.paramsSchema,
+      timeoutSeconds: route.timeoutSeconds,
+    };
+  }
+
+  /** Removes one route and prunes only branches that no longer contain routes. */
+  public removeRoute(routeId: string) {
+    const route = this.routesById.get(routeId);
+    if (!route) return;
+
+    const branches: { parent: Record<string, RouteTree>; key: string }[] = [];
+    let current = this.routesTree;
+    const method = current[route.method];
+    if (!method) {
+      this.routesById.delete(routeId);
+      return;
+    }
+    branches.push({ parent: current, key: route.method });
+    current = method.children;
+
+    for (let part of route.path.split("/").filter((p) => p.trim() != "")) {
+      const key = part.startsWith(":") ? part.slice(1) : part;
+      const branch = current[key];
+      if (!branch) {
+        this.routesById.delete(routeId);
+        return;
+      }
+      branches.push({ parent: current, key });
+      current = branch.children;
+    }
+
+    if (current["<ID>"]?.id === routeId) {
+      delete current["<ID>"];
+      for (const { parent, key } of branches.toReversed()) {
+        const branch = parent[key];
+        if (Object.keys(branch.children).length > 0) break;
+        delete parent[key];
+      }
+    }
+    this.routesById.delete(routeId);
+  }
+
+  public buildRoutes(routes: HttpRoute[]) {
+    for (const route of routes) this.upsertRoute(route);
   }
   public getRouteId(
     path: string,

--- a/packages/lib/tests/parser.spec.ts
+++ b/packages/lib/tests/parser.spec.ts
@@ -91,4 +91,40 @@ describe("Testing routing parser", () => {
     expect(result3?.routeParams?.tenant).toBe("example_company");
     expect(result3?.routeParams?.id).toBe("456");
   });
+
+  it("updates and removes one route without replacing unrelated routes", () => {
+    parser.buildRoutes([
+      {
+        routeId: "users",
+        path: "/api/users",
+        method: "GET",
+        projectId: "project",
+        projectName: "Project",
+      },
+      {
+        routeId: "posts",
+        path: "/api/posts",
+        method: "GET",
+        projectId: "project",
+        projectName: "Project",
+      },
+    ]);
+
+    parser.upsertRoute({
+      routeId: "users",
+      path: "/api/members",
+      method: "GET",
+      projectId: "project",
+      projectName: "Project",
+    });
+
+    expect(parser.getRouteId("/api/users", "GET")).toBeNull();
+    expect(parser.getRouteId("/api/members", "GET")?.id).toBe("users");
+    expect(parser.getRouteId("/api/posts", "GET")?.id).toBe("posts");
+
+    parser.removeRoute("users");
+
+    expect(parser.getRouteId("/api/members", "GET")).toBeNull();
+    expect(parser.getRouteId("/api/posts", "GET")?.id).toBe("posts");
+  });
 });


### PR DESCRIPTION
## Summary
- Fixes #191 — artifact boot replayed the initial snapshot twice, and every artifact update rebuilt the entire route trie from scratch.
- `watchArtifacts`/`watchProjectArtifacts` now use a single NATS KV watch (`includeExisting` toggles `LastValue` vs `UpdatesOnly`) instead of a separate `loadProjectArtifacts()` snapshot read followed by a watch — no more double replay of the initial state.
- `compiledWorker.ts` awaits the watch's initial replay before spawning the execution process, so it boots with a deduped snapshot exactly once.
- `HttpRouteParser` gained `upsertRoute`/`removeRoute` for incremental trie insert/prune; `compiledRuntime.ts` uses these per-artifact instead of `rebuildRoutes()` on every update.
- Removed `listArtifacts()` (`natsKv.ts`) — dead code left over from the old snapshot-read path, no remaining callers.

## Test plan
- [x] `bun test packages/lib/tests/parser.spec.ts` — 4/4 pass, covers upsert/remove without disturbing unrelated routes
- [x] `bun run --cwd apps/server lint` (`tsgo --noEmit`) — clean
- [x] Manually traced trie prune logic for shared-prefix routes (e.g. `/api/users` + `/api/users/:id`) and shared-method branches — correct, only prunes branches left with no children
- [x] Verified `KvWatchInclude.UpdatesOnly` / `LastValue` against the installed `nats` package's type defs

🤖 Generated with [Claude Code](https://claude.com/claude-code)