### PR TITLE
feat(blocks): codegen — emit each block once, per-block trace seam, multi-edge throw

### DIFF
--- a/packages/blocks/baseBlock.ts
+++ b/packages/blocks/baseBlock.ts
@@ -20,6 +20,30 @@ export interface TriggerContext {
 	id?: string;
 }
 
+/** One completed block execution within a request-level trace. */
+export type BlockTraceSpan = {
+	blockId: string;
+	blockType: string;
+	input: unknown;
+	output: unknown;
+	/** whether this block completed normally or threw */
+	outcome: "success" | "failure";
+	/** selected branch for condition blocks */
+	branch?: "success" | "failure";
+	error?: unknown;
+};
+
+/**
+ * Request-owned tracing hook for compiled graphs.
+ *
+ * The compiler only reports completed block spans through this hook. Buffering,
+ * transport, persistence, and request trace lifecycle belong to the worker
+ * telemetry pipeline, not the generated route code.
+ */
+export interface BlockTrace {
+	recordSpan(span: BlockTraceSpan): void;
+}
+
 export interface Context {
 	vm: JsVM;
 	route: string;
@@ -35,6 +59,8 @@ export interface Context {
 	};
 	/** origin of this execution; absent on legacy in-process callers */
 	trigger?: TriggerContext;
+	/** optional request-level trace; one Context represents one trace */
+	trace?: BlockTrace;
 	stopper: {
 		timeoutEnd: number;
 		duration: number;

--- a/packages/blocks/builderTypes.ts
+++ b/packages/blocks/builderTypes.ts
@@ -30,12 +30,10 @@ export type EdgeDTOSchemaType = z.infer<typeof edgeDTOSchema>;
 
 export type EdgesType = Record<
   string,
-  [
-    {
-      to: string;
-      handle: string;
-    },
-  ]
+  {
+    to: string;
+    handle: string;
+  }[]
 >;
 
 export interface BlockBuilderInterface {

--- a/packages/blocks/builtin/response.ts
+++ b/packages/blocks/builtin/response.ts
@@ -31,7 +31,9 @@ export interface ResponseBlockHTTPResult extends BlockOutput {
 /** terminal — nothing after a response block runs */
 export function emitResponse(node: EmitNode) {
   const { httpCode } = responseBlockSchema.parse(node.block.data);
-  return `return { successful: true, continueIfFail: true, output: { httpCode: ${JSON.stringify(httpCode)}, body: ${node.in} ?? null } };`;
+  return node.complete(
+    `{ successful: true, continueIfFail: true, output: { httpCode: ${JSON.stringify(httpCode)}, body: ${node.in} ?? null } }`,
+  );
 }
 
 export class ResponseBlock extends BaseBlock {

--- a/packages/blocks/builtin/tests/compiler.spec.ts
+++ b/packages/blocks/builtin/tests/compiler.spec.ts
@@ -1,35 +1,9 @@
 import { describe, it, expect } from "bun:test";
-import { JsVM } from "@fluxify/lib";
 import { compileGraph } from "../../compiler";
 import { BlockTypes } from "../../blockTypes";
-import type { BlockDTOType, EdgeDTOSchemaType } from "../../builderTypes";
-
-function createContext() {
-	const vars: Record<string, any> = {};
-	return {
-		vm: new JsVM(vars),
-		route: "/test",
-		apiId: "api-1",
-		projectId: "proj-1",
-		vars,
-		stopper: { timeoutEnd: 0, duration: 10000 },
-	} as any;
-}
-
-const block = (id: string, type: BlockTypes, data: any = {}): BlockDTOType => ({
-	id,
-	type,
-	data,
-	position: { x: 0, y: 0 },
-});
-
-const edge = (from: string, to: string, toHandle = "source") => ({
-	id: `e-${from}-${to}`,
-	from,
-	to,
-	fromHandle: "source",
-	toHandle,
-});
+import type { BlockTraceSpan } from "../../baseBlock";
+import type { EdgeDTOSchemaType } from "../../builderTypes";
+import { block, createContext, edge, occurrences } from "./compilerTestHelpers";
 
 describe("compileGraph", () => {
 	it("compiles entrypoint -> setvar -> getvar -> jsrunner -> response", async () => {
@@ -110,8 +84,27 @@ describe("compileGraph", () => {
 		const { run, source } = compileGraph(blocks, edges);
 		expect(source).not.toContain("ctx.vm");
 
-		expect((await run(createContext(), { n: 42 })).output.httpCode).toBe("200");
-		expect((await run(createContext(), { n: 1 })).output.httpCode).toBe("400");
+		const successSpans: BlockTraceSpan[] = [];
+		const successContext = createContext();
+		successContext.trace = {
+			recordSpan: (span: BlockTraceSpan) => successSpans.push(span),
+		};
+		expect((await run(successContext, { n: 42 })).output.httpCode).toBe("200");
+		expect(successSpans.find((span) => span.blockId === "2")).toMatchObject({
+			outcome: "success",
+			branch: "success",
+		});
+
+		const failureSpans: BlockTraceSpan[] = [];
+		const failureContext = createContext();
+		failureContext.trace = {
+			recordSpan: (span: BlockTraceSpan) => failureSpans.push(span),
+		};
+		expect((await run(failureContext, { n: 1 })).output.httpCode).toBe("400");
+		expect(failureSpans.find((span) => span.blockId === "2")).toMatchObject({
+			outcome: "success",
+			branch: "failure",
+		});
 	});
 
 	it("still routes through the sandbox when inlineJs is off", async () => {
@@ -127,6 +120,99 @@ describe("compileGraph", () => {
 		const ctx = createContext();
 		expect((await run(ctx, 21)).output.body).toBe(42);
 		expect(ctx.vars.shared).toBe(42);
+	});
+
+	it("emits a shared tail once and reuses its block function", async () => {
+		const blocks = [
+			block("entry", BlockTypes.entrypoint),
+			block("branch", BlockTypes.if, {
+				conditions: [
+					{ lhs: "js:return input", rhs: 0, operator: "gt", chain: "and" },
+				],
+			}),
+			block("shared", BlockTypes.jsrunner, { value: "return input * 2;" }),
+			block("response", BlockTypes.response, { httpCode: "200" }),
+		];
+		const edges: EdgeDTOSchemaType = [
+			edge("entry", "branch"),
+			edge("branch", "shared", "success"),
+			edge("branch", "shared", "failure"),
+			edge("shared", "response"),
+		];
+
+		const { run, source } = compileGraph(blocks, edges);
+		expect(source.startsWith("/* fluxify-compiled-route-factory */")).toBe(true);
+		expect(occurrences(source, "// jsrunner shared")).toBe(1);
+		expect(occurrences(source, "async function $block_")).toBe(4);
+		expect((await run(createContext(), 3)).output.body).toBe(6);
+		expect((await run(createContext(), -2)).output.body).toBe(-4);
+	});
+
+	it("keeps generated source linear across repeated diamonds", () => {
+		function graph(levels: number) {
+			const blocks = [block("entry", BlockTypes.entrypoint)];
+			const edges: EdgeDTOSchemaType = [edge("entry", "if-0")];
+
+			for (let index = 0; index < levels; index++) {
+				const id = "if-" + index;
+				const next = index === levels - 1 ? "response" : "if-" + (index + 1);
+				blocks.push(block(id, BlockTypes.if, { conditions: [] }));
+				edges.push(edge(id, next, "success"), edge(id, next, "failure"));
+			}
+			blocks.push(block("response", BlockTypes.response, { httpCode: "200" }));
+			return { blocks, edges };
+		}
+
+		const four = graph(4);
+		const eight = graph(8);
+		const shortSource = compileGraph(four.blocks, four.edges).source;
+		const longSource = compileGraph(eight.blocks, eight.edges).source;
+
+		expect(occurrences(longSource, "async function $block_")).toBe(10);
+		expect(longSource.length).toBeLessThan(shortSource.length * 3);
+	});
+
+	it("preserves a response from a loop executor", async () => {
+		const { run } = compileGraph(
+			[
+				block("entry", BlockTypes.entrypoint),
+				block("loop", BlockTypes.forloop, { start: 0, end: 2, step: 1 }),
+				block("inside", BlockTypes.response, { httpCode: "201" }),
+				block("after", BlockTypes.response, { httpCode: "200" }),
+			],
+			[
+				edge("entry", "loop"),
+				edge("loop", "inside", "executor"),
+				edge("loop", "after"),
+			],
+		);
+
+		expect((await run(createContext(), null)).output).toEqual({
+			httpCode: "201",
+			body: 0,
+		});
+	});
+
+	it("runs each loop executor before its source continuation", async () => {
+		const { run } = compileGraph(
+			[
+				block("entry", BlockTypes.entrypoint),
+				block("loop", BlockTypes.forloop, { start: 0, end: 3, step: 1 }),
+				block("executor", BlockTypes.jsrunner, {
+					value: "total = (total ?? 0) + input; return input;",
+				}),
+				block("total", BlockTypes.getvar, { key: "total" }),
+				block("response", BlockTypes.response, { httpCode: "200" }),
+			],
+			[
+				edge("entry", "loop"),
+				edge("loop", "executor", "executor"),
+				edge("loop", "total"),
+				edge("total", "response"),
+			],
+		);
+
+		expect((await run(createContext(), null)).output.body).toBe(3);
 	});
 
 	it("rejects cycles and unknown block types", () => {

--- a/packages/blocks/builtin/tests/compiler.trace.spec.ts
+++ b/packages/blocks/builtin/tests/compiler.trace.spec.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from "bun:test";
+import { compileGraph } from "../../compiler";
+import { BlockTypes } from "../../blockTypes";
+import type { BlockTraceSpan } from "../../baseBlock";
+import { block, createContext, edge } from "./compilerTestHelpers";
+
+describe("compileGraph tracing and edge validation", () => {
+	it("reports one span per completed block without changing route execution", async () => {
+		const spans: BlockTraceSpan[] = [];
+		const ctx = createContext();
+		ctx.trace = { recordSpan: (span: BlockTraceSpan) => spans.push(span) };
+		const { run, source } = compileGraph(
+			[
+				block("entry", BlockTypes.entrypoint),
+				block("double", BlockTypes.jsrunner, { value: "return input * 2;" }),
+				block("response", BlockTypes.response, { httpCode: "200" }),
+			],
+			[edge("entry", "double"), edge("double", "response")],
+		);
+
+		const result = await run(ctx, 21);
+
+		expect(result.output).toEqual({ httpCode: "200", body: 42 });
+		expect(source).toContain("if ($trace)");
+		expect(source).not.toContain("function $recordSpan");
+		expect(spans).toEqual([
+			{
+				blockId: "entry",
+				blockType: BlockTypes.entrypoint,
+				input: 21,
+				output: 21,
+				outcome: "success",
+			},
+			{
+				blockId: "double",
+				blockType: BlockTypes.jsrunner,
+				input: 21,
+				output: 42,
+				outcome: "success",
+			},
+			{
+				blockId: "response",
+				blockType: BlockTypes.response,
+				input: 42,
+				output: {
+					successful: true,
+					continueIfFail: true,
+					output: { httpCode: "200", body: 42 },
+				},
+				outcome: "success",
+			},
+		]);
+	});
+
+	it("records an error on the block that throws", async () => {
+		const spans: BlockTraceSpan[] = [];
+		const ctx = createContext();
+		ctx.trace = { recordSpan: (span: BlockTraceSpan) => spans.push(span) };
+		const { run } = compileGraph(
+			[
+				block("entry", BlockTypes.entrypoint),
+				block("explode", BlockTypes.jsrunner, { value: "throw new Error('boom');" }),
+			],
+			[edge("entry", "explode")],
+		);
+
+		const result = await run(ctx, "input");
+
+		expect(result.successful).toBe(false);
+		expect(spans).toHaveLength(2);
+		expect(spans[1]).toMatchObject({
+			blockId: "explode",
+			blockType: BlockTypes.jsrunner,
+			input: "input",
+			output: undefined,
+			outcome: "failure",
+		});
+		expect(spans[1]?.error).toBeInstanceOf(Error);
+	});
+
+	it("attributes a loop executor's error to the executor, not the loop block", async () => {
+		const spans: BlockTraceSpan[] = [];
+		const ctx = createContext();
+		ctx.trace = { recordSpan: (span: BlockTraceSpan) => spans.push(span) };
+		const { run } = compileGraph(
+			[
+				block("entry", BlockTypes.entrypoint),
+				block("loop", BlockTypes.forloop, { start: 0, end: 3, step: 1 }),
+				block("explode", BlockTypes.jsrunner, {
+					value: "throw new Error('boom');",
+				}),
+			],
+			[edge("entry", "loop"), edge("loop", "explode", "executor")],
+		);
+
+		const result = await run(ctx, null);
+
+		expect(result.successful).toBe(false);
+		const failures = spans.filter((span) => span.outcome === "failure");
+		expect(failures).toHaveLength(1);
+		expect(failures[0]?.blockId).toBe("explode");
+	});
+
+	it("does not let a trace recorder failure fail a route", async () => {
+		const ctx = createContext();
+		ctx.trace = {
+			recordSpan() {
+				throw new Error("telemetry unavailable");
+			},
+		};
+		const { run } = compileGraph(
+			[
+				block("entry", BlockTypes.entrypoint),
+				block("response", BlockTypes.response, { httpCode: "200" }),
+			],
+			[edge("entry", "response")],
+		);
+
+		expect((await run(ctx, "safe")).output.body).toBe("safe");
+	});
+
+	it("rejects multiple outgoing edges on one handle", () => {
+		expect(() =>
+			compileGraph(
+				[
+					block("entry", BlockTypes.entrypoint),
+					block("first", BlockTypes.response, { httpCode: "200" }),
+					block("second", BlockTypes.response, { httpCode: "201" }),
+				],
+				[edge("entry", "first"), edge("entry", "second")],
+			),
+		).toThrow(/multi-edge fan-out/);
+	});
+});

--- a/packages/blocks/builtin/tests/compilerTestHelpers.ts
+++ b/packages/blocks/builtin/tests/compilerTestHelpers.ts
@@ -1,0 +1,34 @@
+import { JsVM } from "@fluxify/lib";
+import type { BlockTypes } from "../../blockTypes";
+import type { BlockDTOType } from "../../builderTypes";
+
+export function createContext() {
+	const vars: Record<string, any> = {};
+	return {
+		vm: new JsVM(vars),
+		route: "/test",
+		apiId: "api-1",
+		projectId: "proj-1",
+		vars,
+		stopper: { timeoutEnd: 0, duration: 10000 },
+	} as any;
+}
+
+export const block = (id: string, type: BlockTypes, data: any = {}): BlockDTOType => ({
+	id,
+	type,
+	data,
+	position: { x: 0, y: 0 },
+});
+
+export const edge = (from: string, to: string, toHandle = "source") => ({
+	id: `e-${from}-${to}`,
+	from,
+	to,
+	fromHandle: "source",
+	toHandle,
+});
+
+export function occurrences(source: string, value: string) {
+	return source.split(value).length - 1;
+}

--- a/packages/blocks/compiler.ts
+++ b/packages/blocks/compiler.ts
@@ -1,6 +1,7 @@
 import dayjs from "dayjs";
 import { BlockTypes } from "./blockTypes";
 import type { BlockDTOType, EdgeDTOSchemaType, EdgesType } from "./builderTypes";
+import type { BlockOutput, Context } from "./baseBlock";
 import { emitArrayOps } from "./builtin/arrayOperations";
 import { emitEntrypoint } from "./builtin/entrypoint";
 import { emitGetVar } from "./builtin/getVar";
@@ -54,6 +55,8 @@ export type EmitNode = {
 	next(handle?: string): string;
 	/** nested chain (loop bodies): its own flowing variable, falls through at the end */
 	body(handle: string, initExpr: string): string;
+	/** record this terminal block's output, then return it from its block function */
+	complete(output: string): string;
 	/** JS expression for a value from block data (`js:` prefixed ones are evaluated) */
 	value(raw: unknown): string;
 	/**
@@ -173,17 +176,27 @@ export function scopeFor(vars: Record<string, any>) {
 }
 
 /** mirrors JsVM.truthy / the `is_empty` operator, inlined into every program */
-const PRELUDE = `const vars = ctx.vars;
-const $truthy = (v) => { const t = typeof v; return t === "bigint" || t === "number" || t === "string" || t === "boolean" ? !!v : (t === "object" && v !== null); };
-const $isEmpty = (v) => v === null || v === undefined || v === "" || (typeof v === "object" && Object.keys(v).length === 0);
-const $scope = lib.scope(vars);`;
+const PRELUDE = `const $truthy = (v) => { const t = typeof v; return t === "bigint" || t === "number" || t === "string" || t === "boolean" ? !!v : (t === "object" && v !== null); };
+const $isEmpty = (v) => v === null || v === undefined || v === "" || (typeof v === "object" && Object.keys(v).length === 0);`;
+
+/** marker lets a newer worker load older artifacts during a rolling update */
+const COMPILED_ROUTE_FACTORY = "/* fluxify-compiled-route-factory */";
+
+type CompiledRun = (
+	ctx: Context,
+	input?: unknown,
+) => Promise<BlockOutput>;
 
 const AsyncFunction = Object.getPrototypeOf(async function () {})
 	.constructor as new (...args: string[]) => (
-	ctx: any,
-	input: any,
+	ctx: Context,
+	input: unknown,
 	lib: typeof compilerLib,
-) => Promise<any>;
+) => Promise<BlockOutput>;
+
+const CompiledRouteFactory = Function as unknown as new (
+	...args: string[]
+) => (lib: typeof compilerLib) => CompiledRun;
 
 /** same handle normalisation BlockBuilder.loadEdges does */
 function buildEdgeMap(edges: EdgeDTOSchemaType): EdgesType {
@@ -223,8 +236,15 @@ export type CompileOptions = {
 
 /** turn compiled source back into a runnable graph (worker side, no compiler) */
 export function instantiateCompiled(source: string) {
+	if (source.startsWith(COMPILED_ROUTE_FACTORY)) {
+		const factory = new CompiledRouteFactory("lib", source);
+		return factory(compilerLib);
+	}
+
+	// Existing artifacts remain executable while workers are rolling over to the
+	// factory format. They disappear naturally on the next route compilation.
 	const compiled = new AsyncFunction("ctx", "input", "lib", source);
-	return (ctx: any, input?: any) => compiled(ctx, input, compilerLib);
+	return (ctx: Context, input?: unknown) => compiled(ctx, input, compilerLib);
 }
 
 export function compileGraph(
@@ -239,12 +259,54 @@ export function compileGraph(
 	const errorHandler = blocks.find((b) => b.type === BlockTypes.errorHandler);
 
 	let counter = 0;
-	// ponytail: a path set only rejects cycles, and a diamond re-emits its shared
-	// tail once per branch. Emit-shared-blocks-as-functions when a real graph hurts.
-	const path = new Set<string>();
+	const blockFunctionNames = new Map<string, string>();
+	const reachable = new Set<string>();
+	const visiting = new Set<string>();
+	const emissionOrder: string[] = [];
 
 	function edgeTo(id: string, handle: string) {
-		return edgeMap[id]?.find((e) => e.handle === handle)?.to;
+		const outgoing = edgeMap[id]?.filter((edge) => edge.handle === handle) ?? [];
+		if (outgoing.length > 1) {
+			throw new Error(
+				`Block ${id} has ${outgoing.length} outgoing edges on handle ${handle}; multi-edge fan-out is not supported yet`,
+			);
+		}
+		return outgoing[0]?.to;
+	}
+
+	function validateEdges() {
+		for (const [id, outgoing] of Object.entries(edgeMap)) {
+			const countByHandle = new Map<string, number>();
+			for (const edge of outgoing) {
+				countByHandle.set(edge.handle, (countByHandle.get(edge.handle) ?? 0) + 1);
+			}
+			for (const [handle, count] of countByHandle) {
+				if (count > 1) edgeTo(id, handle);
+			}
+		}
+	}
+
+	function blockFunctionName(id: string) {
+		let name = blockFunctionNames.get(id);
+		if (!name) {
+			name = `$block_${blockFunctionNames.size}`;
+			blockFunctionNames.set(id, name);
+		}
+		return name;
+	}
+
+	function collectReachable(id: string | undefined) {
+		if (!id || reachable.has(id)) return;
+		if (visiting.has(id)) {
+			throw new Error(`Cycle through block ${id} is not supported yet`);
+		}
+		if (!byId.has(id)) throw new Error(`Block not found: ${id}`);
+
+		visiting.add(id);
+		emissionOrder.push(id);
+		for (const edge of edgeMap[id] ?? []) collectReachable(edge.to);
+		visiting.delete(id);
+		reachable.add(id);
 	}
 
 	function js(code: string, extras?: string, sync = false) {
@@ -255,7 +317,7 @@ export function compileGraph(
 		return `(await (async function (input) { with ($scope) {\n${code}\n} })(${extras ?? "undefined"}))`;
 	}
 
-	function emit(id: string, inVar: string, tail: string): string {
+	function emitBlock(id: string): string {
 		const block = byId.get(id);
 		if (!block) throw new Error(`Block not found: ${id}`);
 		// anything not built in is a custom block, resolved from the worker-global
@@ -264,62 +326,129 @@ export function compileGraph(
 			? emitCustomBlock
 			: emitters[block.type as BlockTypes];
 		if (!emitter) throw new Error(`No codegen for block type: ${block.type}`);
-		if (path.has(id)) throw new Error(`Cycle through block ${id} is not supported yet`);
-		path.add(id);
+		const blockId = JSON.stringify(block.id);
+		const blockType = JSON.stringify(block.type);
+
+		function recordSpan(
+			output: string,
+			error?: string,
+			branch?: "success" | "failure",
+		) {
+			const outcome = error === undefined ? "success" : "failure";
+			const branchField = branch ? `, branch: ${JSON.stringify(branch)}` : "";
+			const errorField = error === undefined ? "" : `, error: ${error}`;
+			const span = `{ blockId: ${blockId}, blockType: ${blockType}, input: $input, output: ${output}, outcome: ${JSON.stringify(outcome)}${branchField}${errorField} }`;
+			return `$recorded = true;
+if ($trace) {
+try {
+$trace.recordSpan(${span});
+} catch {
+// Telemetry must never change route execution.
+}
+}`;
+		}
 
 		const code = emitter({
 			block,
-			in: inVar,
+			in: "$in",
 			v: (prefix) => `$${prefix}_${counter++}`,
 			next(handle = "source") {
 				const to = edgeTo(id, handle);
-				return to ? emit(to, inVar, tail) : tail;
+				const branch =
+					block.type === BlockTypes.if &&
+					(handle === "success" || handle === "failure")
+						? handle
+						: undefined;
+				const continuation = to
+					? `return await ${blockFunctionName(to)}($state, $in, $end);`
+					: "return $end($in);";
+				return `${recordSpan("$in", undefined, branch)}
+${continuation}`;
 			},
 			body(handle, initExpr) {
 				const to = edgeTo(id, handle);
 				if (!to) return "";
-				const scoped = `$b_${counter++}`;
-				return `let ${scoped} = ${initExpr};\n${emit(to, scoped, "")}`;
+				const result = `$bodyResult_${counter++}`;
+				// mark this block as reported before handing off — an executor's
+				// throw must not be misattributed to the loop block that called it
+				return `$recorded = true;
+const ${result} = await ${blockFunctionName(to)}($state, ${initExpr}, $endBody);
+if (${result} !== undefined) return ${result};`;
+			},
+			complete(output) {
+				const result = `$result_${counter++}`;
+				return `const ${result} = ${output};
+${recordSpan(result)}
+return ${result};`;
 			},
 			value(raw) {
 				if (typeof raw !== "string") return JSON.stringify(raw ?? null);
-				if (raw.startsWith("js:")) return js(raw.slice(3), inVar);
+				if (raw.startsWith("js:")) return js(raw.slice(3), "$in");
 				if (asCustomBlock && raw.startsWith("param:")) {
-					return `$params[${JSON.stringify(raw.slice(6))}]`;
+					return `$state.params[${JSON.stringify(raw.slice(6))}]`;
 				}
 				return JSON.stringify(raw);
 			},
 			js,
 		});
 
-		path.delete(id);
-		return `// ${block.type} ${id}\n${code}`;
+		return `// ${block.type} ${id}
+async function ${blockFunctionName(id)}($state, $input, $end) {
+const { ctx, vars, scope: $scope, trace: $trace } = $state;
+let $in = $input;
+let $recorded = false;
+try {
+${code}
+} catch ($error) {
+if (!$recorded) {
+${recordSpan("undefined", "$error")}
+}
+throw $error;
+}
+}`;
 	}
-
-	const IN = "$in";
-	const done = `return { successful: true, continueIfFail: true, output: ${IN} };`;
-	const main = `let ${IN} = input;\n${emit(entry.id, IN, done)}`;
 
 	// the error handler is unreachable by edges — the engine jumps to it on failure
 	const handlerEntry = errorHandler && edgeTo(errorHandler.id, "source");
-	const body = handlerEntry
-		? `try {
-${main}
-} catch ($e) {
-let $err = $e?.toString();
-${emit(handlerEntry, "$err", `return { successful: false, continueIfFail: false, error: $err };`)}
-}`
-		: `try {
-${main}
-} catch ($e) {
-return { successful: false, continueIfFail: false, error: $e };
-}`;
+	validateEdges();
+	collectReachable(entry.id);
+	collectReachable(handlerEntry);
 
-	const params = asCustomBlock ? "const $params = input ?? {};\n" : "";
-	const source = `${PRELUDE}\n${params}${body}`;
-	const compiled = new AsyncFunction("ctx", "input", "lib", source);
+	for (const id of emissionOrder) blockFunctionName(id);
+	const functions = emissionOrder.map(emitBlock).join("\n\n");
+	const errorHandlerBody = handlerEntry
+		? [
+				"const $err = $error?.toString();",
+				`return await ${blockFunctionName(handlerEntry)}($state, $err, $endFailure);`,
+			].join("\n")
+		: "return $endFailure($error);";
+	const source = [
+		COMPILED_ROUTE_FACTORY,
+		PRELUDE,
+		"const $endSuccess = (output) => ({ successful: true, continueIfFail: true, output });",
+		"const $endFailure = (error) => ({ successful: false, continueIfFail: false, error });",
+		"const $endBody = () => undefined;",
+		functions,
+		"",
+		"return async function $run(ctx, input) {",
+		"const vars = ctx.vars;",
+		"const $state = {",
+		"ctx,",
+		"vars,",
+		"scope: lib.scope(vars),",
+		"trace: ctx.trace,",
+		`params: ${asCustomBlock ? "input ?? {}" : "undefined"},`,
+		"};",
+		"try {",
+		`return await ${blockFunctionName(entry.id)}($state, input, $endSuccess);`,
+		"} catch ($error) {",
+		errorHandlerBody,
+		"}",
+		"}",
+	].join("\n");
+	const run = instantiateCompiled(source);
 	return {
 		source,
-		run: (ctx: any, input?: any) => compiled(ctx, input, compilerLib),
+		run,
 	};
 }


### PR DESCRIPTION
## Why
Codegen inlined each block's continuation as a source string, so a shared tail downstream of a diamond was re-emitted once per branch (multiplying artifact size, compile time, JIT work), and `edgeTo` silently dropped every edge past the first on a handle. This also blocked per-block tracing and orchestration backtracking, which both need a stable per-block boundary.

## What
- Compiles each reachable block to a named async function (`$block_N`); a shared continuation is called, never duplicated. Reachability/emission order computed via one DFS pass (`collectReachable`), separate from emission.
- `edgeTo` throws when a handle has more than one outgoing edge instead of dropping the extras; `validateEdges()` surfaces this at compile time for the whole graph, not just the reachable subset.
- New per-block trace seam: `ctx.trace?.recordSpan(...)`, gated by a `$trace` hoisted once per invocation — zero allocation/emission when unset. Terminal blocks report via a new `node.complete()` on `EmitNode`; `response.ts` migrated.
- Artifacts compile to a small factory (`/* fluxify-compiled-route-factory */` marker) instantiated via `instantiateCompiled`; old inline-function artifacts still run so a rolling worker update doesn't break in-flight artifacts.

## Bug found + fixed in review
Loop bodies (`for`/`foreach`, via `EmitNode.body()`) never marked their own block as "reported" before calling into the executor block, unlike `next()`. So when an executor block inside a loop threw, the loop block's own `catch` also fired — recording a second, misattributed failure span under the *loop's* `blockId` in addition to the executor's correct one. Fixed by setting `$recorded = true` before the body call, matching `next()`. Covered by a new regression test.

## Test plan
- [x] `bun test packages/blocks` — 118 pass, 0 fail (added: shared-tail dedup, linear-source-across-diamonds, loop executor precedence/response propagation, trace span emission, error-span attribution incl. the loop misattribution fix, multi-edge-throw)
- [x] `bun run --cwd packages/blocks lint` (`tsgo --noEmit`) — clean
- [x] Manually reverted the fix and reran the new regression test to confirm it fails without it

Closes #193