### PR TITLE
ci: allow manual workflow runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI/CD
 
 on:
+  workflow_dispatch:
   push:
     branches: ["main"]
     tags: ["v*"] # version tags trigger the admin + worker release build


### PR DESCRIPTION
## Summary
- add workflow_dispatch trigger to CI/CD workflow

## Why
CI runs were not dispatched for the prior merged PR. This enables maintainers to start CI/CD from the Actions UI or with gh workflow run.

## Validation
- normal pre-commit hook
- 629 passed, 2 skipped, 0 failed