### PR TITLE
fix(adapters): stabilize KV container tests

### DIFF
--- a/packages/adapters/containerTestHelpers.ts
+++ b/packages/adapters/containerTestHelpers.ts
@@ -47,3 +47,13 @@ export function pullImage(image: string): Promise<void> {
 		});
 	});
 }
+
+/** Pull an image only when the local Docker daemon does not already have it. */
+export async function ensureImage(image: string): Promise<void> {
+	try {
+		await docker.getImage(image).inspect();
+	} catch (error: any) {
+		if (error.statusCode !== 404) throw error;
+		await pullImage(image);
+	}
+}

--- a/packages/adapters/kv/memcached.test.ts
+++ b/packages/adapters/kv/memcached.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, beforeAll, afterAll } from "bun:test";
 import { faker } from "@faker-js/faker";
 import { MemcachedIntegration } from "./memcached";
 import type Docker from "dockerode";
-import { docker, startContainerWithRandomPort } from "../containerTestHelpers";
+import { docker, ensureImage, startContainerWithRandomPort } from "../containerTestHelpers";
+
+const MEMCACHED_IMAGE = "memcached:1.6-alpine";
 
 describe("MemcachedIntegration", () => {
 	const containerName = "fluxify-memcached-test";
@@ -12,9 +14,10 @@ describe("MemcachedIntegration", () => {
 
 	beforeAll(async () => {
 		await docker.getContainer(containerName).remove({ force: true }).catch(() => {});
+		await ensureImage(MEMCACHED_IMAGE);
 		const started = await startContainerWithRandomPort((hostPort) =>
 			docker.createContainer({
-				Image: "memcached:latest",
+				Image: MEMCACHED_IMAGE,
 				name: containerName,
 				HostConfig: {
 					PortBindings: { "11211/tcp": [{ HostPort: String(hostPort) }] },
@@ -23,8 +26,6 @@ describe("MemcachedIntegration", () => {
 		);
 		container = started.container;
 		port = started.port;
-		
-		await new Promise((r) => setTimeout(r, 2000));
 
 		integration = new MemcachedIntegration({
 			host: "127.0.0.1",

--- a/packages/adapters/kv/memcached.ts
+++ b/packages/adapters/kv/memcached.ts
@@ -90,13 +90,14 @@ export class MemcachedIntegration extends BaseKVIntegration {
 		appConfigs: Map<string, string>,
 	): Promise<{ success: boolean; error?: string }> {
 		let integration: MemcachedIntegration | null = null;
+		let timeout: ReturnType<typeof setTimeout> | undefined;
 		try {
 			const extractedConfig = this.ExtractConnectionInfo(config, appConfigs);
 			integration = new MemcachedIntegration(extractedConfig, true);
 			
 			const pingPromise = integration.set("test_ping", "1");
 			const timeoutPromise = new Promise<never>((_, reject) => 
-				setTimeout(() => reject(new Error("Connection timed out after 5 seconds")), 5000)
+				timeout = setTimeout(() => reject(new Error("Connection timed out after 5 seconds")), 5000)
 			);
 			await Promise.race([pingPromise, timeoutPromise]);
 			
@@ -104,6 +105,7 @@ export class MemcachedIntegration extends BaseKVIntegration {
 		} catch (error: any) {
 			return { success: false, error: error.message };
 		} finally {
+			if (timeout) clearTimeout(timeout);
 			if (integration) {
 				await integration.disconnect();
 			}

--- a/packages/adapters/kv/redis.test.ts
+++ b/packages/adapters/kv/redis.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, beforeAll, afterAll } from "bun:test";
 import { faker } from "@faker-js/faker";
 import { RedisIntegration } from "./redis";
 import type Docker from "dockerode";
-import { docker, startContainerWithRandomPort } from "../containerTestHelpers";
+import { docker, ensureImage, startContainerWithRandomPort } from "../containerTestHelpers";
+
+const REDIS_IMAGE = "redis:7.4-alpine";
 
 describe("RedisIntegration", () => {
 	const containerName = "fluxify-redis-test";
@@ -12,9 +14,10 @@ describe("RedisIntegration", () => {
 
 	beforeAll(async () => {
 		await docker.getContainer(containerName).remove({ force: true }).catch(() => {});
+		await ensureImage(REDIS_IMAGE);
 		const started = await startContainerWithRandomPort((hostPort) =>
 			docker.createContainer({
-				Image: "redis:latest",
+				Image: REDIS_IMAGE,
 				name: containerName,
 				HostConfig: {
 					PortBindings: { "6379/tcp": [{ HostPort: String(hostPort) }] },
@@ -23,8 +26,6 @@ describe("RedisIntegration", () => {
 		);
 		container = started.container;
 		port = started.port;
-		
-		await new Promise((r) => setTimeout(r, 2000));
 
 		integration = new RedisIntegration({
 			host: "127.0.0.1",

--- a/packages/adapters/kv/redis.ts
+++ b/packages/adapters/kv/redis.ts
@@ -80,13 +80,14 @@ export class RedisIntegration extends BaseKVIntegration {
 		appConfigs: Map<string, string>,
 	): Promise<{ success: boolean; error?: string }> {
 		let integration: RedisIntegration | null = null;
+		let timeout: ReturnType<typeof setTimeout> | undefined;
 		try {
 			const extractedConfig = this.ExtractConnectionInfo(config, appConfigs);
 			integration = new RedisIntegration(extractedConfig, true);
 			
 			const pingPromise = integration.client.ping();
 			const timeoutPromise = new Promise<never>((_, reject) => 
-				setTimeout(() => reject(new Error("Connection timed out after 5 seconds")), 5000)
+				timeout = setTimeout(() => reject(new Error("Connection timed out after 5 seconds")), 5000)
 			);
 			await Promise.race([pingPromise, timeoutPromise]);
 			
@@ -94,6 +95,7 @@ export class RedisIntegration extends BaseKVIntegration {
 		} catch (error: any) {
 			return { success: false, error: error.message };
 		} finally {
+			if (timeout) clearTimeout(timeout);
 			if (integration) {
 				await integration.disconnect();
 			}


### PR DESCRIPTION
## Why
The adapters CI job fails when Redis and Memcached images are absent, and successful probes leave five-second timeout handles alive.

## What
- ensure pinned KV images are available before creating containers
- clear completed connection-test timers
- remove fixed container startup delays

## Validation
- un test --timeout 600000 kv/redis.test.ts kv/memcached.test.ts (6 passing, 4.73s)
- pre-commit checks (171 passing tests)