### PR TITLE
feat(routes): support URL-encoded and multipart request bodies

### DIFF
--- a/apps/portal/src/routes/_authed/$projectId/routes.tsx
+++ b/apps/portal/src/routes/_authed/$projectId/routes.tsx
@@ -6,6 +6,7 @@ import {
 	Input,
 	Label,
 	Modal,
+	MultiSelect,
 	Spinner,
 	Table,
 	TextField,
@@ -15,8 +16,21 @@ import { TbPlus, TbTrash } from "react-icons/tb";
 import { routesQuery } from "@/query/routesQuery";
 import { showErrorNotification } from "@/lib/errorNotifier";
 import { ConfirmDialog } from "@/components/common/ConfirmDialog";
+import {
+	CONTENT_TYPES,
+	DEFAULT_CONTENT_TYPES,
+	type ContentType,
+} from "@fluxify/server/src/lib/routeConfig";
 
 const METHODS = ["GET", "POST", "PUT", "DELETE"] as const;
+
+// only these carry a body — see the request body reader on the server
+const METHODS_WITH_BODY: readonly string[] = ["POST", "PUT"];
+
+const CONTENT_TYPE_OPTIONS = CONTENT_TYPES.map((value) => ({
+	value,
+	label: value,
+}));
 
 export const Route = createFileRoute("/_authed/$projectId/routes")({
 	component: RoutesPage,
@@ -158,11 +172,14 @@ function CreateRouteButton({ projectId }: { projectId: string }) {
 	const [name, setName] = useState("");
 	const [path, setPath] = useState("");
 	const [method, setMethod] = useState<string>("GET");
+	const [contentTypes, setContentTypes] =
+		useState<string[]>(DEFAULT_CONTENT_TYPES);
 
 	function reset() {
 		setName("");
 		setPath("");
 		setMethod("GET");
+		setContentTypes(DEFAULT_CONTENT_TYPES);
 	}
 
 	function submit(e: React.FormEvent) {
@@ -175,6 +192,7 @@ function CreateRouteButton({ projectId }: { projectId: string }) {
 				projectId,
 				active: true,
 				timeoutSeconds: 30,
+				acceptedContentTypes: contentTypes as [ContentType, ...ContentType[]],
 			},
 			{
 				onSuccess: () => {
@@ -226,6 +244,19 @@ function CreateRouteButton({ projectId }: { projectId: string }) {
 										<Label>Path</Label>
 										<Input placeholder="/users" />
 									</TextField>
+									{METHODS_WITH_BODY.includes(method) && (
+										<MultiSelect
+											label="Accepted content types"
+											description="Requests sent with any other content type are rejected."
+											options={CONTENT_TYPE_OPTIONS}
+											value={contentTypes}
+											onChange={(next) =>
+												setContentTypes(
+													next.length > 0 ? next : DEFAULT_CONTENT_TYPES,
+												)
+											}
+										/>
+									)}
 								</div>
 							</Modal.Body>
 							<Modal.Footer>

--- a/apps/server/deployments/compiledWorker.ts
+++ b/apps/server/deployments/compiledWorker.ts
@@ -29,6 +29,7 @@ import {
 	OTLP_LOGGER_ENABLED,
 	OTLP_LOGGER_LEVEL,
 	WORKER_PROJECT_ID,
+	MAX_REQUEST_BODY_BYTES,
 	getEnv,
 } from "../src/lib/env";
 
@@ -127,6 +128,7 @@ function spawnExecution() {
 		asyncExecutor,
 		artifacts: [...artifacts.values()],
 		workerTimeoutsEnabled: timeoutPolicyEnabled(),
+		maxRequestBodyBytes: MAX_REQUEST_BODY_BYTES,
 		logging: {
 			level: OTLP_LOGGER_LEVEL,
 			otlpEndpoint: OTLP_ENDPOINT,

--- a/apps/server/deployments/worker.ts
+++ b/apps/server/deployments/worker.ts
@@ -14,6 +14,7 @@ import {
 	OTLP_ENDPOINT,
 	OTLP_LOGGER_ENABLED,
 	OTLP_LOGGER_LEVEL,
+	MAX_REQUEST_BODY_BYTES,
 	getEnv,
 } from "../src/lib/env";
 
@@ -38,7 +39,11 @@ initializeLogger({
 const app = new Hono();
 registerHealthRoutes(app);
 
-const server = serve({ fetch: app.fetch, port });
+const server = serve({
+	fetch: app.fetch,
+	port,
+	maxRequestBodySize: MAX_REQUEST_BODY_BYTES,
+});
 logger.info(
 	`request worker running at http://${server.hostname}:${server.port}`,
 );

--- a/apps/server/src/api/v1/routes/create/dto.ts
+++ b/apps/server/src/api/v1/routes/create/dto.ts
@@ -1,6 +1,7 @@
 import z from "zod";
 import { ROUTE_REGEX } from "../constants";
 import { routeSchemaValidationRefinement } from "../schema-validator";
+import { CONTENT_TYPES } from "../../../../lib/routeConfig";
 
 export const requestBodySchema = z.object({
   name: z.string().min(2).max(255),
@@ -14,6 +15,7 @@ export const requestBodySchema = z.object({
   paramsSchema: z.any().optional(),
   timeoutSeconds: z.number().int().min(30).default(30),
   active: z.boolean().optional(),
+  acceptedContentTypes: z.array(z.enum(CONTENT_TYPES)).min(1).optional(),
 }).superRefine(routeSchemaValidationRefinement);
 
 export const responseSchema = z.object({

--- a/apps/server/src/api/v1/routes/create/service.ts
+++ b/apps/server/src/api/v1/routes/create/service.ts
@@ -12,6 +12,8 @@ import { CHAN_ON_ROUTE_CHANGE, publishMessage } from "../../../../db/redis";
 import { generateID } from "@fluxify/lib";
 import { NotFoundError } from "../../../../errors/notFoundError";
 import { HttpMethod } from "../../../../db/schema";
+import { patchRouteConfig } from "../routeConfigRepository";
+import { DEFAULT_CONTENT_TYPES } from "../../../../lib/routeConfig";
 
 /**
  * `outer` joins a transaction already in progress, so the ops bus can create a
@@ -40,11 +42,18 @@ export default async function handleRequest(
       throw new ConflictError(`route with name or path already exist`);
     }
     const id = generateID();
+    const { acceptedContentTypes, ...route } = data;
     const newRouteId = await createRoute(
-      { ...data, id, createdBy: userId },
+      { ...route, id, createdBy: userId },
       tx
     );
     await createDependency(newRouteId, tx);
+    await patchRouteConfig(
+      newRouteId,
+      data.projectId,
+      { acceptedContentTypes: acceptedContentTypes ?? DEFAULT_CONTENT_TYPES },
+      tx
+    );
     return {
       id: newRouteId,
     };

--- a/apps/server/src/api/v1/routes/get-by-id/dto.ts
+++ b/apps/server/src/api/v1/routes/get-by-id/dto.ts
@@ -18,6 +18,7 @@ export const responseSchema = z.object({
 	timeoutSeconds: z.number().int(),
 	tracingEnabled: z.boolean(),
 	recordExecution: z.boolean(),
+	acceptedContentTypes: z.array(z.string()),
 	createdAt: z.string(),
 	createdBy: z.string(),
 	updatedAt: z.string(),

--- a/apps/server/src/api/v1/routes/get-by-id/repository.ts
+++ b/apps/server/src/api/v1/routes/get-by-id/repository.ts
@@ -1,6 +1,10 @@
 import { eq } from "drizzle-orm";
 import { db, DbTransactionType } from "../../../../db";
-import { projectsEntity, routesEntity } from "../../../../db/schema";
+import {
+	httpRouteConfigEntity,
+	projectsEntity,
+	routesEntity,
+} from "../../../../db/schema";
 
 export async function getRouteById(id: string, tx?: DbTransactionType) {
 	const route = await (tx ?? db)
@@ -21,9 +25,14 @@ export async function getRouteById(id: string, tx?: DbTransactionType) {
 			timeoutSeconds: routesEntity.timeoutSeconds,
 			tracingEnabled: routesEntity.tracingEnabled,
 			recordExecution: routesEntity.recordExecution,
+			routeConfig: httpRouteConfigEntity.routeConfig,
 		})
 		.from(routesEntity)
 		.leftJoin(projectsEntity, eq(routesEntity.projectId, projectsEntity.id))
+		.leftJoin(
+			httpRouteConfigEntity,
+			eq(httpRouteConfigEntity.routeId, routesEntity.id),
+		)
 		.where(eq(routesEntity.id, id))
 		.limit(1);
 	return route.length > 0 ? route[0] : null;

--- a/apps/server/src/api/v1/routes/get-by-id/service.ts
+++ b/apps/server/src/api/v1/routes/get-by-id/service.ts
@@ -4,6 +4,7 @@ import { getRouteById } from "./repository";
 import { responseSchema } from "./dto";
 import { AuthACL } from "../../../../db/schema";
 import { ForbiddenError } from "../../../../errors/forbidError";
+import { acceptedContentTypes } from "../../../../lib/routeConfig";
 
 export default async function handleRequest(
 	id: string,
@@ -36,5 +37,6 @@ export default async function handleRequest(
 		timeoutSeconds: route.timeoutSeconds,
 		tracingEnabled: route.tracingEnabled,
 		recordExecution: route.recordExecution,
+		acceptedContentTypes: acceptedContentTypes(route.routeConfig),
 	};
 }

--- a/apps/server/src/api/v1/routes/openapi/repository.ts
+++ b/apps/server/src/api/v1/routes/openapi/repository.ts
@@ -1,5 +1,9 @@
 import { db } from "../../../../db";
-import { projectsEntity, routesEntity } from "../../../../db/schema";
+import {
+  httpRouteConfigEntity,
+  projectsEntity,
+  routesEntity,
+} from "../../../../db/schema";
 import { eq, and } from "drizzle-orm";
 
 export async function getProject(projectId: string) {
@@ -8,8 +12,13 @@ export async function getProject(projectId: string) {
 }
 
 export async function getActiveRoutes(projectId: string) {
-  return await db
-    .select()
+  const rows = await db
+    .select({ route: routesEntity, routeConfig: httpRouteConfigEntity.routeConfig })
     .from(routesEntity)
+    .leftJoin(
+      httpRouteConfigEntity,
+      eq(httpRouteConfigEntity.routeId, routesEntity.id),
+    )
     .where(and(eq(routesEntity.projectId, projectId), eq(routesEntity.active, true)));
+  return rows.map(({ route, routeConfig }) => ({ ...route, routeConfig }));
 }

--- a/apps/server/src/api/v1/routes/openapi/service.ts
+++ b/apps/server/src/api/v1/routes/openapi/service.ts
@@ -9,6 +9,7 @@ import z from "zod";
 import { requestParamSchema } from "./dto";
 import { NotFoundError } from "../../../../errors/notFoundError";
 import { logger } from "@fluxify/common";
+import { acceptedContentTypes } from "../../../../lib/routeConfig";
 
 export async function invalidateOpenApiCache(projectId?: string) {
 	if (projectId) {
@@ -146,12 +147,14 @@ export async function generateOpenApiSpec(
 				const parsedDef = typeof route.bodySchema === "string" ? safelyParseJSON(route.bodySchema) : route.bodySchema;
 				if (parsedDef && typeof parsedDef === "object") {
 					const jsonSchema = schemaDefToOpenApi(parsedDef);
+					// one entry per content type the route actually accepts
 					operation.requestBody = {
-						content: {
-							"application/json": {
-								schema: jsonSchema,
-							},
-						},
+						content: Object.fromEntries(
+							acceptedContentTypes(route.routeConfig).map((contentType) => [
+								contentType,
+								{ schema: jsonSchema },
+							]),
+						),
 					};
 				}
 			} catch (e) {

--- a/apps/server/src/api/v1/routes/routeConfigRepository.ts
+++ b/apps/server/src/api/v1/routes/routeConfigRepository.ts
@@ -1,0 +1,26 @@
+import { sql } from "drizzle-orm";
+import { db, DbTransactionType } from "../../../db";
+import { httpRouteConfigEntity } from "../../../db/schema";
+
+/**
+ * `route_config` is an open bag, so a patch merges into whatever is already
+ * stored (`||` is a top-level jsonb merge) instead of replacing it. A caller
+ * that only knows about content types must not drop a key added later.
+ */
+export async function patchRouteConfig(
+	routeId: string,
+	projectId: string | null | undefined,
+	patch: Record<string, unknown>,
+	tx?: DbTransactionType,
+) {
+	await (tx ?? db)
+		.insert(httpRouteConfigEntity)
+		.values({ routeId, projectId: projectId ?? undefined, routeConfig: patch })
+		.onConflictDoUpdate({
+			target: httpRouteConfigEntity.routeId,
+			set: {
+				routeConfig: sql`${httpRouteConfigEntity.routeConfig} || ${JSON.stringify(patch)}::jsonb`,
+				updatedAt: new Date(),
+			},
+		});
+}

--- a/apps/server/src/api/v1/routes/update-partial/dto.ts
+++ b/apps/server/src/api/v1/routes/update-partial/dto.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { ROUTE_REGEX } from "../constants";
+import { CONTENT_TYPES } from "../../../../lib/routeConfig";
 
 export const requestBodySchema = z.object({
   name: z.string().min(2).max(255).optional(),
@@ -15,6 +16,7 @@ export const requestBodySchema = z.object({
   timeoutSeconds: z.number().int().min(30).optional(),
   tracingEnabled: z.boolean().optional(),
   recordExecution: z.boolean().optional(),
+  acceptedContentTypes: z.array(z.enum(CONTENT_TYPES)).min(1).optional(),
 });
 
 export const requestRouteSchema = z.object({

--- a/apps/server/src/api/v1/routes/update-partial/service.ts
+++ b/apps/server/src/api/v1/routes/update-partial/service.ts
@@ -8,6 +8,7 @@ import { publishMessage, CHAN_ON_ROUTE_CHANGE } from "../../../../db/redis";
 import { ServerError } from "../../../../errors/serverError";
 import { AuthACL } from "../../../../db/schema";
 import { ForbiddenError } from "../../../../errors/forbidError";
+import { patchRouteConfig } from "../routeConfigRepository";
 
 export default async function handleRequest(
   id: string,
@@ -48,6 +49,14 @@ export default async function handleRequest(
 		}
 		if (data.recordExecution !== undefined) {
 			patchedRoute.recordExecution = data.recordExecution;
+		}
+		if (data.acceptedContentTypes !== undefined) {
+			await patchRouteConfig(
+				id,
+				existingRoute.projectId,
+				{ acceptedContentTypes: data.acceptedContentTypes },
+				tx,
+			);
 		}
     return await updateRoute(
       {

--- a/apps/server/src/db/migrations/0051_curvy_storm.sql
+++ b/apps/server/src/db/migrations/0051_curvy_storm.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "http_route_config" (
+	"route_id" varchar(50) PRIMARY KEY NOT NULL,
+	"project_id" varchar(50),
+	"route_config" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "http_route_config" ADD CONSTRAINT "http_route_config_route_id_routes_id_fk" FOREIGN KEY ("route_id") REFERENCES "public"."routes"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "http_route_config" ADD CONSTRAINT "http_route_config_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_http_route_config_project_id" ON "http_route_config" USING btree ("project_id");

--- a/apps/server/src/db/migrations/meta/0051_snapshot.json
+++ b/apps/server/src/db/migrations/meta/0051_snapshot.json
@@ -1,0 +1,3056 @@
+{
+  "id": "b370654d-2b96-43cb-93b8-bf177366a719",
+  "prevId": "7fbd2616-a1bb-4bb8-a7ce-519a623a3858",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.access_control": {
+      "name": "access_control",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "access_control_roles",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_access_control_user_id": {
+          "name": "idx_access_control_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_access_control_project_id": {
+          "name": "idx_access_control_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "access_control_user_id_system_users_id_fk": {
+          "name": "access_control_user_id_system_users_id_fk",
+          "tableFrom": "access_control",
+          "tableTo": "system_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "access_control_project_id_projects_id_fk": {
+          "name": "access_control_project_id_projects_id_fk",
+          "tableFrom": "access_control",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_config": {
+      "name": "app_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key_name": {
+          "name": "key_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_encrypted": {
+          "name": "is_encrypted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "encoding_type": {
+          "name": "encoding_type",
+          "type": "encoding_types",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "app_config_data_types",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'string'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_app_config_key_name": {
+          "name": "idx_app_config_key_name",
+          "columns": [
+            {
+              "expression": "key_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_app_config_project_id": {
+          "name": "idx_app_config_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_app_config_is_encrypted": {
+          "name": "idx_app_config_is_encrypted",
+          "columns": [
+            {
+              "expression": "is_encrypted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_app_config_encoding_type": {
+          "name": "idx_app_config_encoding_type",
+          "columns": [
+            {
+              "expression": "encoding_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_app_config_key_name_fts": {
+          "name": "idx_app_config_key_name_fts",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', \"key_name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_app_config_desc_fts": {
+          "name": "idx_app_config_desc_fts",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', coalesce(\"description\", ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_config_project_id_projects_id_fk": {
+          "name": "app_config_project_id_projects_id_fk",
+          "tableFrom": "app_config",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocks": {
+      "name": "blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_id": {
+          "name": "route_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_block_id": {
+          "name": "custom_block_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_type": {
+          "name": "parent_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "CASE WHEN custom_block_id IS NOT NULL THEN 'custom_block' ELSE 'route' END",
+            "type": "stored"
+          }
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "COALESCE(route_id, custom_block_id)",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "idx_blocks_route_id": {
+          "name": "idx_blocks_route_id",
+          "columns": [
+            {
+              "expression": "route_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_blocks_custom_block_id": {
+          "name": "idx_blocks_custom_block_id",
+          "columns": [
+            {
+              "expression": "custom_block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_blocks_parent": {
+          "name": "idx_blocks_parent",
+          "columns": [
+            {
+              "expression": "parent_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blocks_route_id_routes_id_fk": {
+          "name": "blocks_route_id_routes_id_fk",
+          "tableFrom": "blocks",
+          "tableTo": "routes",
+          "columnsFrom": [
+            "route_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "blocks_custom_block_id_custom_blocks_list_id_fk": {
+          "name": "blocks_custom_block_id_custom_blocks_list_id_fk",
+          "tableFrom": "blocks",
+          "tableTo": "custom_blocks_list",
+          "columnsFrom": [
+            "custom_block_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_blocks_list": {
+      "name": "custom_blocks_list",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "custom_block_icon_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_params": {
+          "name": "input_params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "custom_block_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user-defined'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_custom_blocks_list_project_id": {
+          "name": "idx_custom_blocks_list_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_custom_blocks_list_name": {
+          "name": "idx_custom_blocks_list_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "custom_blocks_list_project_id_projects_id_fk": {
+          "name": "custom_blocks_list_project_id_projects_id_fk",
+          "tableFrom": "custom_blocks_list",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.edges": {
+      "name": "edges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "from": {
+          "name": "from",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to": {
+          "name": "to",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_handle": {
+          "name": "from_handle",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_handle": {
+          "name": "to_handle",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_id": {
+          "name": "route_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_block_id": {
+          "name": "custom_block_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_type": {
+          "name": "parent_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "CASE WHEN custom_block_id IS NOT NULL THEN 'custom_block' ELSE 'route' END",
+            "type": "stored"
+          }
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "COALESCE(route_id, custom_block_id)",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "idx_edges_from": {
+          "name": "idx_edges_from",
+          "columns": [
+            {
+              "expression": "from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_edges_to": {
+          "name": "idx_edges_to",
+          "columns": [
+            {
+              "expression": "to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_edges_route_id": {
+          "name": "idx_edges_route_id",
+          "columns": [
+            {
+              "expression": "route_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_edges_custom_block_id": {
+          "name": "idx_edges_custom_block_id",
+          "columns": [
+            {
+              "expression": "custom_block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_edges_parent": {
+          "name": "idx_edges_parent",
+          "columns": [
+            {
+              "expression": "parent_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "edges_from_blocks_id_fk": {
+          "name": "edges_from_blocks_id_fk",
+          "tableFrom": "edges",
+          "tableTo": "blocks",
+          "columnsFrom": [
+            "from"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edges_to_blocks_id_fk": {
+          "name": "edges_to_blocks_id_fk",
+          "tableFrom": "edges",
+          "tableTo": "blocks",
+          "columnsFrom": [
+            "to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edges_route_id_routes_id_fk": {
+          "name": "edges_route_id_routes_id_fk",
+          "tableFrom": "edges",
+          "tableTo": "routes",
+          "columnsFrom": [
+            "route_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edges_custom_block_id_custom_blocks_list_id_fk": {
+          "name": "edges_custom_block_id_custom_blocks_list_id_fk",
+          "tableFrom": "edges",
+          "tableTo": "custom_blocks_list",
+          "columnsFrom": [
+            "custom_block_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.http_route_config": {
+      "name": "http_route_config",
+      "schema": "",
+      "columns": {
+        "route_id": {
+          "name": "route_id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_config": {
+          "name": "route_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_http_route_config_project_id": {
+          "name": "idx_http_route_config_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "http_route_config_route_id_routes_id_fk": {
+          "name": "http_route_config_route_id_routes_id_fk",
+          "tableFrom": "http_route_config",
+          "tableTo": "routes",
+          "columnsFrom": [
+            "route_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "http_route_config_project_id_projects_id_fk": {
+          "name": "http_route_config_project_id_projects_id_fk",
+          "tableFrom": "http_route_config",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instance_settings": {
+      "name": "instance_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "instance_setting_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "instance_settings_key_unique": {
+          "name": "instance_settings_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integrations": {
+      "name": "integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group": {
+          "name": "group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_integrations_name": {
+          "name": "idx_integrations_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integrations_group": {
+          "name": "idx_integrations_group",
+          "columns": [
+            {
+              "expression": "group",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integrations_variant": {
+          "name": "idx_integrations_variant",
+          "columns": [
+            {
+              "expression": "variant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integrations_tags": {
+          "name": "idx_integrations_tags",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integrations_project_id": {
+          "name": "idx_integrations_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integrations_name_fts": {
+          "name": "idx_integrations_name_fts",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', \"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_integrations_meta_fts": {
+          "name": "idx_integrations_meta_fts",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', coalesce(\"group\", '') || ' ' || coalesce(\"variant\", '') || ' ' || coalesce(\"tags\", ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integrations_project_id_projects_id_fk": {
+          "name": "integrations_project_id_projects_id_fk",
+          "tableFrom": "integrations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_settings": {
+      "name": "project_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_project_settings_project_id": {
+          "name": "idx_project_settings_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_settings_key": {
+          "name": "idx_project_settings_key",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_settings_project_id_projects_id_fk": {
+          "name": "project_settings_project_id_projects_id_fk",
+          "tableFrom": "project_settings",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_projects_id": {
+          "name": "idx_projects_id",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_projects_name": {
+          "name": "idx_projects_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_projects_updated_at": {
+          "name": "idx_projects_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.routes": {
+      "name": "routes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "NULL"
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_schema": {
+          "name": "body_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query_schema": {
+          "name": "query_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "params_schema": {
+          "name": "params_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeout_seconds": {
+          "name": "timeout_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "tracing_enabled": {
+          "name": "tracing_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "record_execution": {
+          "name": "record_execution",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_routes_project_id": {
+          "name": "idx_routes_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_routes_path": {
+          "name": "idx_routes_path",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_routes_name_fts": {
+          "name": "idx_routes_name_fts",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', \"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_routes_path_fts": {
+          "name": "idx_routes_path_fts",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', translate(coalesce(\"path\", ''), '/:-_', '    '))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "routes_project_id_projects_id_fk": {
+          "name": "routes_project_id_projects_id_fk",
+          "tableFrom": "routes",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_suites": {
+      "name": "test_suites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_id": {
+          "name": "route_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "query_params": {
+          "name": "query_params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "route_params": {
+          "name": "route_params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "body": {
+          "name": "body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assertions": {
+          "name": "assertions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "integration_overrides": {
+          "name": "integration_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "app_config_overrides": {
+          "name": "app_config_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_suites_route_id_routes_id_fk": {
+          "name": "test_suites_route_id_routes_id_fk",
+          "tableFrom": "test_suites",
+          "tableTo": "routes",
+          "columnsFrom": [
+            "route_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_harness_artifacts": {
+      "name": "agent_harness_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_harness_artifacts_conv_id": {
+          "name": "idx_harness_artifacts_conv_id",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_harness_artifacts_run_id": {
+          "name": "idx_harness_artifacts_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_harness_artifacts_conversation_id_agent_harness_conversations_id_fk": {
+          "name": "agent_harness_artifacts_conversation_id_agent_harness_conversations_id_fk",
+          "tableFrom": "agent_harness_artifacts",
+          "tableTo": "agent_harness_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_harness_artifacts_run_id_agent_harness_runs_id_fk": {
+          "name": "agent_harness_artifacts_run_id_agent_harness_runs_id_fk",
+          "tableFrom": "agent_harness_artifacts",
+          "tableTo": "agent_harness_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_harness_conversations": {
+      "name": "agent_harness_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'New Chat'"
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_harness_conversation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "active_run_id": {
+          "name": "active_run_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_harness_conv_user_id": {
+          "name": "idx_harness_conv_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_harness_conv_project_id": {
+          "name": "idx_harness_conv_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_harness_conv_user_archived_pinned": {
+          "name": "idx_harness_conv_user_archived_pinned",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_harness_conversations_user_id_system_users_id_fk": {
+          "name": "agent_harness_conversations_user_id_system_users_id_fk",
+          "tableFrom": "agent_harness_conversations",
+          "tableTo": "system_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_harness_conversations_project_id_projects_id_fk": {
+          "name": "agent_harness_conversations_project_id_projects_id_fk",
+          "tableFrom": "agent_harness_conversations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_harness_hitl_actions": {
+      "name": "agent_harness_hitl_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_id": {
+          "name": "step_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "agent_harness_hitl_action_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_response": {
+          "name": "user_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_harness_hitl_run_id": {
+          "name": "idx_harness_hitl_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_harness_hitl_step_id": {
+          "name": "idx_harness_hitl_step_id",
+          "columns": [
+            {
+              "expression": "step_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_harness_hitl_actions_run_id_agent_harness_runs_id_fk": {
+          "name": "agent_harness_hitl_actions_run_id_agent_harness_runs_id_fk",
+          "tableFrom": "agent_harness_hitl_actions",
+          "tableTo": "agent_harness_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_harness_hitl_actions_step_id_agent_harness_steps_id_fk": {
+          "name": "agent_harness_hitl_actions_step_id_agent_harness_steps_id_fk",
+          "tableFrom": "agent_harness_hitl_actions",
+          "tableTo": "agent_harness_steps",
+          "columnsFrom": [
+            "step_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_harness_live_states": {
+      "name": "agent_harness_live_states",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_state": {
+          "name": "current_state",
+          "type": "agent_harness_live_state_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "active_step_id": {
+          "name": "active_step_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "working_memory": {
+          "name": "working_memory",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_harness_live_conv_id": {
+          "name": "idx_harness_live_conv_id",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_harness_live_states_run_id_agent_harness_runs_id_fk": {
+          "name": "agent_harness_live_states_run_id_agent_harness_runs_id_fk",
+          "tableFrom": "agent_harness_live_states",
+          "tableTo": "agent_harness_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_harness_live_states_conversation_id_agent_harness_conversations_id_fk": {
+          "name": "agent_harness_live_states_conversation_id_agent_harness_conversations_id_fk",
+          "tableFrom": "agent_harness_live_states",
+          "tableTo": "agent_harness_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_harness_runs": {
+      "name": "agent_harness_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_query": {
+          "name": "user_query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_response": {
+          "name": "ai_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_harness_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "usage": {
+          "name": "usage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interrupted_at": {
+          "name": "interrupted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_harness_runs_conv_id": {
+          "name": "idx_harness_runs_conv_id",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_harness_runs_status": {
+          "name": "idx_harness_runs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_harness_runs_integration_id": {
+          "name": "idx_harness_runs_integration_id",
+          "columns": [
+            {
+              "expression": "integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_harness_runs_conversation_id_agent_harness_conversations_id_fk": {
+          "name": "agent_harness_runs_conversation_id_agent_harness_conversations_id_fk",
+          "tableFrom": "agent_harness_runs",
+          "tableTo": "agent_harness_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_harness_runs_integration_id_integrations_id_fk": {
+          "name": "agent_harness_runs_integration_id_integrations_id_fk",
+          "tableFrom": "agent_harness_runs",
+          "tableTo": "integrations",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_harness_steps": {
+      "name": "agent_harness_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_type": {
+          "name": "step_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_order": {
+          "name": "step_order",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sub_agent_role": {
+          "name": "sub_agent_role",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sub_agent_id": {
+          "name": "sub_agent_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_harness_step_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_harness_steps_run_id": {
+          "name": "idx_harness_steps_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_harness_steps_sub_agent_id": {
+          "name": "idx_harness_steps_sub_agent_id",
+          "columns": [
+            {
+              "expression": "sub_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_harness_steps_run_sub_agent": {
+          "name": "uq_harness_steps_run_sub_agent",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sub_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_harness_steps_run_id_agent_harness_runs_id_fk": {
+          "name": "agent_harness_steps_run_id_agent_harness_runs_id_fk",
+          "tableFrom": "agent_harness_steps",
+          "tableTo": "agent_harness_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_harness_steps_conversation_id_agent_harness_conversations_id_fk": {
+          "name": "agent_harness_steps_conversation_id_agent_harness_conversations_id_fk",
+          "tableFrom": "agent_harness_steps",
+          "tableTo": "agent_harness_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_harness_sub_artifacts": {
+      "name": "agent_harness_sub_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sub_agent_id": {
+          "name": "sub_agent_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_harness_sub_artifacts_artifact_id": {
+          "name": "idx_harness_sub_artifacts_artifact_id",
+          "columns": [
+            {
+              "expression": "artifact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_harness_sub_artifacts_run_id": {
+          "name": "idx_harness_sub_artifacts_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_harness_sub_artifacts_artifact_id_agent_harness_artifacts_id_fk": {
+          "name": "agent_harness_sub_artifacts_artifact_id_agent_harness_artifacts_id_fk",
+          "tableFrom": "agent_harness_sub_artifacts",
+          "tableTo": "agent_harness_artifacts",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_harness_sub_artifacts_conversation_id_agent_harness_conversations_id_fk": {
+          "name": "agent_harness_sub_artifacts_conversation_id_agent_harness_conversations_id_fk",
+          "tableFrom": "agent_harness_sub_artifacts",
+          "tableTo": "agent_harness_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_harness_sub_artifacts_run_id_agent_harness_runs_id_fk": {
+          "name": "agent_harness_sub_artifacts_run_id_agent_harness_runs_id_fk",
+          "tableFrom": "agent_harness_sub_artifacts",
+          "tableTo": "agent_harness_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_users": {
+      "name": "system_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system_admin": {
+          "name": "is_system_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "system_users_email_unique": {
+          "name": "system_users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_id_system_users_id_fk": {
+          "name": "user_id_system_users_id_fk",
+          "tableFrom": "user",
+          "tableTo": "system_users",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.access_control_roles": {
+      "name": "access_control_roles",
+      "schema": "public",
+      "values": [
+        "viewer",
+        "creator",
+        "project_admin",
+        "system_admin"
+      ]
+    },
+    "public.app_config_data_types": {
+      "name": "app_config_data_types",
+      "schema": "public",
+      "values": [
+        "string",
+        "number",
+        "boolean"
+      ]
+    },
+    "public.custom_block_icon_type": {
+      "name": "custom_block_icon_type",
+      "schema": "public",
+      "values": [
+        "premade-list",
+        "custom"
+      ]
+    },
+    "public.custom_block_source_type": {
+      "name": "custom_block_source_type",
+      "schema": "public",
+      "values": [
+        "plugin",
+        "inhouse",
+        "user-defined"
+      ]
+    },
+    "public.encoding_types": {
+      "name": "encoding_types",
+      "schema": "public",
+      "values": [
+        "plaintext",
+        "base64",
+        "hex"
+      ]
+    },
+    "public.instance_setting_category": {
+      "name": "instance_setting_category",
+      "schema": "public",
+      "values": [
+        "auth"
+      ]
+    },
+    "public.agent_harness_conversation_status": {
+      "name": "agent_harness_conversation_status",
+      "schema": "public",
+      "values": [
+        "idle",
+        "running",
+        "paused_hitl",
+        "interrupted",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.agent_harness_hitl_action_type": {
+      "name": "agent_harness_hitl_action_type",
+      "schema": "public",
+      "values": [
+        "plan_approval",
+        "plan_rejection",
+        "user_input",
+        "confirmation",
+        "cancellation",
+        "custom"
+      ]
+    },
+    "public.agent_harness_live_state_status": {
+      "name": "agent_harness_live_state_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "paused_hitl",
+        "interrupted",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.agent_harness_run_status": {
+      "name": "agent_harness_run_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "routing",
+        "verifying",
+        "planning",
+        "orchestrating",
+        "executing",
+        "awaiting_hitl",
+        "completed",
+        "interrupted",
+        "failed"
+      ]
+    },
+    "public.agent_harness_step_status": {
+      "name": "agent_harness_step_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "interrupted"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/server/src/db/migrations/meta/_journal.json
+++ b/apps/server/src/db/migrations/meta/_journal.json
@@ -358,6 +358,13 @@
       "when": 1786009117656,
       "tag": "0050_mysterious_dakota_north",
       "breakpoints": true
+    },
+    {
+      "idx": 51,
+      "version": "7",
+      "when": 1786060047486,
+      "tag": "0051_curvy_storm",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/db/schema.ts
+++ b/apps/server/src/db/schema.ts
@@ -405,6 +405,34 @@ export const routesRelations = relations(routesEntity, ({ many }) => ({
 	testSuites: many(testSuitesEntity),
 }));
 
+/**
+ * Per-route knobs that are not worth a column each. One row per route, keyed by
+ * the route itself: `route_config` is an open bag so a new setting is a change
+ * to `lib/routeConfig.ts`, not a migration. A route with no row uses defaults.
+ */
+export const httpRouteConfigEntity = pgTable(
+	"http_route_config",
+	{
+		routeId: varchar("route_id", { length: 50 })
+			.primaryKey()
+			.references(() => routesEntity.id, { onDelete: "cascade" }),
+		projectId: varchar("project_id", { length: 50 }).references(
+			() => projectsEntity.id,
+			{ onDelete: "cascade" },
+		),
+		routeConfig: jsonb("route_config")
+			.$type<Record<string, unknown>>()
+			.default({})
+			.notNull(),
+		createdAt: timestamp("created_at").defaultNow().notNull(),
+		updatedAt: timestamp("updated_at")
+			.defaultNow()
+			.notNull()
+			.$onUpdate(() => new Date()),
+	},
+	(table) => [index("idx_http_route_config_project_id").on(table.projectId)],
+);
+
 /* ============================================================================
  * 7. CUSTOM BLOCKS EXTENSIONS
  * ============================================================================ */

--- a/apps/server/src/lib/env.ts
+++ b/apps/server/src/lib/env.ts
@@ -49,6 +49,17 @@ export const serverEnvSchema = baseEnvSchema.extend({
 			"Idle database integration timeout in seconds for compiled workers (default 450 / 7.5 minutes)",
 		),
 
+	WORKER_MAX_STREAM_SIZE: z
+		.string()
+		.optional()
+		.refine(
+			(val) => !val || (Number.isInteger(Number(val)) && Number(val) > 0),
+			{ message: "WORKER_MAX_STREAM_SIZE must be a positive integer" },
+		)
+		.describe(
+			"Hard cap on incoming request body size in kilobytes (default 8192 / 8 MB). Fluxify is an API server, not an upload gateway — raise it deliberately",
+		),
+
 	WORKER_PROJECT_ID: z
 		.string()
 		.optional()
@@ -160,3 +171,7 @@ export const NATS_TOKEN = getEnv("NATS_TOKEN")!;
 export const ENABLE_BUILTIN_WORKER = getEnv("ENABLE_BUILTIN_WORKER")!;
 // which project's compiled artifacts this worker pulls and serves
 export const WORKER_PROJECT_ID = getEnv("WORKER_PROJECT_ID")!;
+
+/** hard body-size ceiling for user-facing routes, in bytes (env is in KB) */
+export const MAX_REQUEST_BODY_BYTES =
+	(Number(getEnv("WORKER_MAX_STREAM_SIZE")) || 8192) * 1024;

--- a/apps/server/src/lib/routeConfig.ts
+++ b/apps/server/src/lib/routeConfig.ts
@@ -1,0 +1,44 @@
+import z from "zod";
+
+/**
+ * Per-route settings stored in `http_route_config.route_config`. One open jsonb
+ * bag so the next knob is a change here, not a migration. Everything in it must
+ * have a default: most routes have no row at all.
+ */
+
+/** Body formats a route may accept. Anything else is rejected with a 415. */
+export const CONTENT_TYPES = [
+	"application/json",
+	"application/x-www-form-urlencoded",
+	"multipart/form-data",
+	"application/octet-stream",
+	"text/plain",
+] as const;
+
+export type ContentType = (typeof CONTENT_TYPES)[number];
+
+export const DEFAULT_CONTENT_TYPES: ContentType[] = ["application/json"];
+
+export const routeConfigSchema = z.object({
+	acceptedContentTypes: z
+		.array(z.enum(CONTENT_TYPES))
+		.min(1)
+		.default(() => [...DEFAULT_CONTENT_TYPES]),
+});
+
+export type RouteConfig = z.infer<typeof routeConfigSchema>;
+
+/**
+ * Stored config is data, not input: a row written by an older build must not
+ * take the route down. Anything unparseable falls back to the defaults.
+ */
+export function parseRouteConfig(stored: unknown): RouteConfig {
+	const parsed = routeConfigSchema.safeParse(stored ?? {});
+	return parsed.success
+		? parsed.data
+		: { acceptedContentTypes: [...DEFAULT_CONTENT_TYPES] };
+}
+
+export function acceptedContentTypes(stored: unknown): ContentType[] {
+	return parseRouteConfig(stored).acceptedContentTypes;
+}

--- a/apps/server/src/lib/schemaParser.ts
+++ b/apps/server/src/lib/schemaParser.ts
@@ -107,7 +107,7 @@ function applyRules(schema: z.ZodTypeAny, dataType: string, rules: any[] = []): 
       if (rule.type === 'mimeTypes' && rule.value) {
         const allowed = toMimeList(rule.value);
         if (allowed.length > 0) {
-          s = s.refine((val: Blob) => allowed.includes(val.type.toLowerCase()), {
+          s = s.refine((val: Blob) => allowed.includes(baseMime(val.type)), {
             message: `Must be one of: ${allowed.join(', ')}`,
           });
         }
@@ -120,7 +120,15 @@ function applyRules(schema: z.ZodTypeAny, dataType: string, rules: any[] = []): 
 /** authored either as a list or as a comma-separated string — accept both */
 function toMimeList(value: unknown): string[] {
   const raw = Array.isArray(value) ? value : String(value).split(',');
-  return raw.map((entry) => String(entry).trim().toLowerCase()).filter(Boolean);
+  return raw.map((entry) => baseMime(String(entry))).filter(Boolean);
+}
+
+/**
+ * `text/plain;charset=utf-8` -> `text/plain`. A part's content type may carry
+ * parameters, and an exact string compare would reject a file that matches.
+ */
+function baseMime(value: string): string {
+  return value.split(';')[0]!.trim().toLowerCase();
 }
 
 export function buildZodSchema(schemaDef: any, coerce = false): z.ZodTypeAny {

--- a/apps/server/src/lib/schemaParser.ts
+++ b/apps/server/src/lib/schemaParser.ts
@@ -56,6 +56,9 @@ function getBaseZodType(dataType: string, coerce = false): z.ZodTypeAny {
     case 'bool': return coerce ? z.coerce.boolean() : z.boolean();
     case 'object': return z.object({});
     case 'arr': return z.array(z.any());
+    // multipart fields arrive as File, a raw octet-stream body as Blob
+    case 'file': return z.file();
+    case 'blob': return z.instanceof(Blob);
     default: return z.any();
   }
 }
@@ -85,8 +88,39 @@ function applyRules(schema: z.ZodTypeAny, dataType: string, rules: any[] = []): 
       if (rule.type === 'minItems' && rule.value != null) s = s.min(Number(rule.value));
       if (rule.type === 'maxItems' && rule.value != null) s = s.max(Number(rule.value));
     }
+
+    // Sizes are bytes. The per-request ceiling (WORKER_MAX_STREAM_SIZE) is a
+    // blunt instrument; this is where "avatar <= 2MB, image/* only" lives.
+    if (dataType === 'file' || dataType === 'blob') {
+      if (rule.type === 'maxSize' && rule.value != null) {
+        const max = Number(rule.value);
+        s = s.refine((val: Blob) => val.size <= max, {
+          message: `Must be at most ${max} bytes`,
+        });
+      }
+      if (rule.type === 'minSize' && rule.value != null) {
+        const min = Number(rule.value);
+        s = s.refine((val: Blob) => val.size >= min, {
+          message: `Must be at least ${min} bytes`,
+        });
+      }
+      if (rule.type === 'mimeTypes' && rule.value) {
+        const allowed = toMimeList(rule.value);
+        if (allowed.length > 0) {
+          s = s.refine((val: Blob) => allowed.includes(val.type.toLowerCase()), {
+            message: `Must be one of: ${allowed.join(', ')}`,
+          });
+        }
+      }
+    }
   }
   return s;
+}
+
+/** authored either as a list or as a comma-separated string — accept both */
+function toMimeList(value: unknown): string[] {
+  const raw = Array.isArray(value) ? value : String(value).split(',');
+  return raw.map((entry) => String(entry).trim().toLowerCase()).filter(Boolean);
 }
 
 export function buildZodSchema(schemaDef: any, coerce = false): z.ZodTypeAny {

--- a/apps/server/src/lib/tests/routeConfig.test.ts
+++ b/apps/server/src/lib/tests/routeConfig.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import {
+	acceptedContentTypes,
+	DEFAULT_CONTENT_TYPES,
+	parseRouteConfig,
+} from "../routeConfig";
+
+describe("routeConfig", () => {
+	test("a route with no stored config accepts JSON", () => {
+		expect(acceptedContentTypes(null)).toEqual(DEFAULT_CONTENT_TYPES);
+		expect(acceptedContentTypes({})).toEqual(DEFAULT_CONTENT_TYPES);
+	});
+
+	test("stored content types are returned as-is", () => {
+		expect(
+			acceptedContentTypes({
+				acceptedContentTypes: ["multipart/form-data", "application/json"],
+			}),
+		).toEqual(["multipart/form-data", "application/json"]);
+	});
+
+	test("a config written by another build never takes the route down", () => {
+		expect(acceptedContentTypes({ acceptedContentTypes: [] })).toEqual(
+			DEFAULT_CONTENT_TYPES,
+		);
+		expect(acceptedContentTypes({ acceptedContentTypes: "json" })).toEqual(
+			DEFAULT_CONTENT_TYPES,
+		);
+		expect(acceptedContentTypes("nonsense")).toEqual(DEFAULT_CONTENT_TYPES);
+	});
+
+	test("unknown keys survive a round trip through the parser", () => {
+		// route_config is an open bag; parsing must not be the thing that drops
+		// a key a newer build wrote.
+		expect(
+			parseRouteConfig({ acceptedContentTypes: ["text/plain"], future: 1 }),
+		).toMatchObject({ acceptedContentTypes: ["text/plain"] });
+	});
+});

--- a/apps/server/src/lib/tests/schemaParser.test.ts
+++ b/apps/server/src/lib/tests/schemaParser.test.ts
@@ -206,6 +206,67 @@ describe('schemaParser Exhaustive Test Suite', () => {
     });
   });
 
+  describe('Uploaded files and raw binary bodies', () => {
+    const png = (bytes: number, type = 'image/png') =>
+      new File(['x'.repeat(bytes)], 'avatar.png', { type });
+
+    test('File size and mime rules', async () => {
+      const schema = {
+        dataType: 'object',
+        properties: [
+          {
+            key: 'avatar',
+            dataType: 'file',
+            rules: [
+              { type: 'maxSize', value: 10 },
+              { type: 'minSize', value: 2 },
+              { type: 'mimeTypes', value: 'image/png, image/jpeg' },
+            ],
+          },
+        ],
+      };
+
+      expect((await parseRequestSchema(schema, { avatar: png(5) }, context)).success).toBe(true);
+      expect((await parseRequestSchema(schema, { avatar: png(50) }, context)).success).toBe(false); // too big
+      expect((await parseRequestSchema(schema, { avatar: png(1) }, context)).success).toBe(false); // too small
+      expect((await parseRequestSchema(schema, { avatar: png(5, 'application/pdf') }, context)).success).toBe(false);
+      expect((await parseRequestSchema(schema, { avatar: 'not-a-file' }, context)).success).toBe(false);
+    });
+
+    test('mimeTypes accepts an array as well as a comma-separated string', async () => {
+      const schema = {
+        dataType: 'file',
+        rules: [{ type: 'mimeTypes', value: ['image/png'] }],
+      };
+
+      expect((await parseRequestSchema(schema, png(3), context)).success).toBe(true);
+      expect((await parseRequestSchema(schema, png(3, 'image/gif'), context)).success).toBe(false);
+    });
+
+    test('Arrays of files reuse the item rules', async () => {
+      const schema = {
+        dataType: 'arr',
+        items: { key: 'docs', dataType: 'file', rules: [{ type: 'maxSize', value: 4 }] },
+        rules: [{ type: 'maxItems', value: 2 }],
+      };
+
+      expect((await parseRequestSchema(schema, [png(2), png(3)], context)).success).toBe(true);
+      expect((await parseRequestSchema(schema, [png(2), png(9)], context)).success).toBe(false); // one too big
+      expect((await parseRequestSchema(schema, [png(1), png(1), png(1)], context)).success).toBe(false); // too many
+    });
+
+    test('Blob accepts a raw octet-stream body, and its size rule holds', async () => {
+      const schema = {
+        dataType: 'blob',
+        rules: [{ type: 'maxSize', value: 4 }],
+      };
+
+      expect((await parseRequestSchema(schema, new Blob(['abc']), context)).success).toBe(true);
+      expect((await parseRequestSchema(schema, new Blob(['abcdefgh']), context)).success).toBe(false);
+      expect((await parseRequestSchema(schema, 'abc', context)).success).toBe(false);
+    });
+  });
+
   describe('DB Zod Schema Protection', () => {
     test('Rejects malformed JSON definitions entirely before execution', async () => {
       const malformedSchema = {

--- a/apps/server/src/lib/tests/schemaParser.test.ts
+++ b/apps/server/src/lib/tests/schemaParser.test.ts
@@ -243,6 +243,17 @@ describe('schemaParser Exhaustive Test Suite', () => {
       expect((await parseRequestSchema(schema, png(3, 'image/gif'), context)).success).toBe(false);
     });
 
+    test('A content type carrying parameters still matches its mime rule', async () => {
+      // a text part is commonly announced as `text/plain;charset=utf-8`
+      const schema = {
+        dataType: 'file',
+        rules: [{ type: 'mimeTypes', value: 'text/plain' }],
+      };
+      const upload = new File(['hi'], 'note.txt', { type: 'text/plain;charset=utf-8' });
+
+      expect((await parseRequestSchema(schema, upload, context)).success).toBe(true);
+    });
+
     test('Arrays of files reuse the item rules', async () => {
       const schema = {
         dataType: 'arr',

--- a/apps/server/src/lib/validationSchemaZod.ts
+++ b/apps/server/src/lib/validationSchemaZod.ts
@@ -1,7 +1,9 @@
 import { z } from 'zod';
 
 export const DataTypeZod = z.enum([
-  'str', 'int', 'float', 'bool', 'object', 'arr', 'js', 'enum'
+  'str', 'int', 'float', 'bool', 'object', 'arr', 'js', 'enum',
+  // uploaded parts: 'file' is a multipart field, 'blob' a raw binary body
+  'file', 'blob',
 ]);
 
 export const ChainTypeZod = z.enum(['or', 'and']);

--- a/apps/server/src/loaders/routesLoader.ts
+++ b/apps/server/src/loaders/routesLoader.ts
@@ -1,6 +1,11 @@
 import { HttpRouteParser } from "@fluxify/lib";
 import { db } from "../db";
-import { projectsEntity, routesEntity } from "../db/schema";
+import {
+	httpRouteConfigEntity,
+	projectsEntity,
+	routesEntity,
+} from "../db/schema";
+import { acceptedContentTypes } from "../lib/routeConfig";
 import {
 	CHAN_ON_ROUTE_CHANGE,
 	deleteCacheKey,
@@ -37,7 +42,7 @@ export async function loadRoutes() {
 }
 
 async function fetchRoutes() {
-	return await db
+	const routes = await db
 		.select({
 			method: routesEntity.method,
 			path: routesEntity.path,
@@ -48,8 +53,18 @@ async function fetchRoutes() {
 			querySchema: routesEntity.querySchema,
 			paramsSchema: routesEntity.paramsSchema,
 			timeoutSeconds: routesEntity.timeoutSeconds,
+			routeConfig: httpRouteConfigEntity.routeConfig,
 		})
 		.from(routesEntity)
 		.leftJoin(projectsEntity, eq(routesEntity.projectId, projectsEntity.id))
+		.leftJoin(
+			httpRouteConfigEntity,
+			eq(httpRouteConfigEntity.routeId, routesEntity.id),
+		)
 		.where(eq(routesEntity.active, true));
+
+	return routes.map(({ routeConfig, ...route }) => ({
+		...route,
+		acceptedContentTypes: acceptedContentTypes(routeConfig),
+	}));
 }

--- a/apps/server/src/modules/compiler/artifacts.ts
+++ b/apps/server/src/modules/compiler/artifacts.ts
@@ -14,6 +14,8 @@ export type RouteArtifact = {
 	querySchema?: unknown;
 	paramsSchema?: unknown;
 	timeoutSeconds: number;
+	/** body formats this route accepts; anything else is rejected with a 415 */
+	acceptedContentTypes: string[];
 	/** spans exported to the project's OTEL destination; nothing is stored by us */
 	tracingEnabled: boolean;
 	/** debug recording, persisted for the portal trace viewer; expensive */

--- a/apps/server/src/modules/compiler/service.ts
+++ b/apps/server/src/modules/compiler/service.ts
@@ -11,9 +11,11 @@ import {
 	blocksEntity,
 	customBlocksListEntity,
 	edgesEntity,
+	httpRouteConfigEntity,
 	projectsEntity,
 	routesEntity,
 } from "../../db/schema";
+import { acceptedContentTypes } from "../../lib/routeConfig";
 import { deleteArtifact, putArtifact } from "../../db/natsKv";
 import type { CanvasParent } from "../canvas/types";
 import { getProjectAppConfig } from "../../loaders/appconfigLoader";
@@ -102,9 +104,14 @@ export async function compileRoute(routeId: string) {
 			timeoutSeconds: routesEntity.timeoutSeconds,
 			tracingEnabled: routesEntity.tracingEnabled,
 			recordExecution: routesEntity.recordExecution,
+			routeConfig: httpRouteConfigEntity.routeConfig,
 		})
 		.from(routesEntity)
 		.leftJoin(projectsEntity, eq(routesEntity.projectId, projectsEntity.id))
+		.leftJoin(
+			httpRouteConfigEntity,
+			eq(httpRouteConfigEntity.routeId, routesEntity.id),
+		)
 		.where(eq(routesEntity.id, routeId));
 
 	if (!route || !route.active) {
@@ -127,6 +134,7 @@ export async function compileRoute(routeId: string) {
 		querySchema: route.querySchema,
 		paramsSchema: route.paramsSchema,
 		timeoutSeconds: route.timeoutSeconds,
+		acceptedContentTypes: acceptedContentTypes(route.routeConfig),
 		tracingEnabled: route.tracingEnabled,
 		recordExecution: route.recordExecution,
 		// no versioning yet — the compile timestamp is the version (see RouteArtifact)

--- a/apps/server/src/modules/requestRouter/compiledRuntime.ts
+++ b/apps/server/src/modules/requestRouter/compiledRuntime.ts
@@ -183,6 +183,7 @@ function routeDefinition(artifact: RouteArtifact): HttpRoute {
 		querySchema: artifact.querySchema,
 		paramsSchema: artifact.paramsSchema,
 		timeoutSeconds: artifact.timeoutSeconds,
+		acceptedContentTypes: artifact.acceptedContentTypes,
 		tracingEnabled: artifact.tracingEnabled,
 		recordExecution: artifact.recordExecution,
 		routeVersion: artifact.routeVersion,

--- a/apps/server/src/modules/requestRouter/executionProcess.ts
+++ b/apps/server/src/modules/requestRouter/executionProcess.ts
@@ -56,7 +56,13 @@ function bootstrap(nextBoot: ExecutionBootstrap) {
 	);
 	setMonitoring(boot.workerTimeoutsEnabled);
 
-	server = Bun.serve({ port: boot.port, reusePort: true, fetch: handle });
+	server = Bun.serve({
+		port: boot.port,
+		reusePort: true,
+		// hard ceiling: Bun rejects a larger body before user code ever sees it
+		maxRequestBodySize: boot.maxRequestBodyBytes,
+		fetch: handle,
+	});
 	send({ type: "ready" });
 	logger.info(`[execution] serving port ${server.port}`, "WORKER.execution");
 }

--- a/apps/server/src/modules/requestRouter/requestBody.ts
+++ b/apps/server/src/modules/requestRouter/requestBody.ts
@@ -1,0 +1,166 @@
+import {
+	CONTENT_TYPES,
+	type ContentType,
+} from "../../lib/routeConfig";
+
+/**
+ * Reads the body of an incoming HTTP request in the format the route declared.
+ *
+ * Nothing is read until the route has matched: the accepted content types are
+ * per-route, so the parse is deliberately deferred (see `BodyReader.parse`).
+ * Only the transport knows about content types — every consumer downstream
+ * (the get-request-body block, the JS runner global, body schema validation)
+ * sees the same plain value.
+ */
+
+export type BodyErrorStatus = 400 | 413 | 415;
+
+export class RequestBodyError extends Error {
+	constructor(
+		readonly status: BodyErrorStatus,
+		message: string,
+	) {
+		super(message);
+		this.name = "RequestBodyError";
+	}
+}
+
+/** Methods that carry a body. DELETE may per RFC 9110, but we don't invite it. */
+const METHODS_WITH_BODY = new Set(["POST", "PUT"]);
+
+/** `application/json; charset=utf-8` -> `application/json` */
+export function mediaType(header?: string | null): string {
+	return (header ?? "").split(";")[0]!.trim().toLowerCase();
+}
+
+function isSupported(type: string): type is ContentType {
+	return (CONTENT_TYPES as readonly string[]).includes(type);
+}
+
+/**
+ * Repeated keys become an array — dropping the second file of a two-file upload
+ * is worse than the shape being uneven. `defineProperty` so a `__proto__` field
+ * lands as an own property instead of reaching the prototype setter.
+ */
+function entriesToObject(entries: Iterable<[string, unknown]>) {
+	const out: Record<string, unknown> = {};
+	for (const [key, value] of entries) {
+		const existing = Object.hasOwn(out, key) ? out[key] : undefined;
+		const next =
+			existing === undefined
+				? value
+				: Array.isArray(existing)
+					? [...existing, value]
+					: [existing, value];
+		Object.defineProperty(out, key, {
+			value: next,
+			enumerable: true,
+			writable: true,
+			configurable: true,
+		});
+	}
+	return out;
+}
+
+async function decode(
+	contentType: ContentType,
+	bytes: ArrayBuffer,
+	rawHeader: string,
+): Promise<unknown> {
+	switch (contentType) {
+		case "application/json": {
+			const text = new TextDecoder().decode(bytes);
+			return text.trim() === "" ? null : JSON.parse(text);
+		}
+		case "text/plain":
+			return new TextDecoder().decode(bytes);
+		case "application/x-www-form-urlencoded":
+			return entriesToObject(
+				new URLSearchParams(new TextDecoder().decode(bytes)),
+			);
+		case "multipart/form-data":
+			// the raw header carries the boundary, so hand it back verbatim
+			return entriesToObject(
+				await new Response(bytes, {
+					headers: { "content-type": rawHeader },
+				}).formData(),
+			);
+		case "application/octet-stream":
+			return new Blob([bytes], { type: contentType });
+	}
+}
+
+/** the slice of a Hono (or Hono-like) context this module needs */
+type RequestLike = {
+	method: string;
+	header(name: string): string | undefined;
+	raw: Request;
+};
+
+export type BodyReader = {
+	/**
+	 * Buffer the bytes now. Async-reply requests answer 202 before the route
+	 * runs, and the request stream is not guaranteed to outlive that response.
+	 */
+	materialize(): Promise<void>;
+	/** Parse into a plain value, or throw `RequestBodyError`. */
+	parse(accepted: readonly string[]): Promise<unknown>;
+};
+
+/**
+ * Returns undefined when the request declares no body — a bodyless POST stays
+ * `null`, as it was before content types were enforced.
+ */
+export function bodyReader(
+	req: RequestLike,
+	maxBytes: number,
+): BodyReader | undefined {
+	if (!METHODS_WITH_BODY.has(req.method.toUpperCase())) return;
+	const rawHeader = req.header("content-type");
+	const contentType = mediaType(rawHeader);
+	if (!contentType) return;
+
+	const declared = Number(req.header("content-length"));
+	let bytes: Promise<ArrayBuffer> | undefined;
+	const read = () => (bytes ??= req.raw.arrayBuffer());
+
+	return {
+		async materialize() {
+			if (Number.isFinite(declared) && declared > maxBytes) return;
+			await read().catch(() => undefined);
+		},
+		async parse(accepted: readonly string[]) {
+			if (!isSupported(contentType) || !accepted.includes(contentType)) {
+				throw new RequestBodyError(
+					415,
+					`Unsupported content type "${contentType}". This route accepts: ${accepted.join(", ")}`,
+				);
+			}
+			if (Number.isFinite(declared) && declared > maxBytes) {
+				throw new RequestBodyError(413, tooLarge(maxBytes));
+			}
+			let buffer: ArrayBuffer;
+			try {
+				buffer = await read();
+			} catch {
+				// Bun rejects the read once its own body limit is exceeded
+				throw new RequestBodyError(413, tooLarge(maxBytes));
+			}
+			if (buffer.byteLength > maxBytes) {
+				throw new RequestBodyError(413, tooLarge(maxBytes));
+			}
+			try {
+				return await decode(contentType, buffer, rawHeader!);
+			} catch (error) {
+				throw new RequestBodyError(
+					400,
+					`Malformed ${contentType} body: ${error instanceof Error ? error.message : String(error)}`,
+				);
+			}
+		},
+	};
+}
+
+function tooLarge(maxBytes: number) {
+	return `Request body exceeds the ${Math.floor(maxBytes / 1024)}KB limit`;
+}

--- a/apps/server/src/modules/requestRouter/service.ts
+++ b/apps/server/src/modules/requestRouter/service.ts
@@ -39,6 +39,9 @@ import {
 import * as zodLib from "zod";
 import { projectSettingsCache } from "../../loaders/projectSettingsLoader";
 import type { RequestEnvelope, RequestPayload } from "./types";
+import { bodyReader, RequestBodyError } from "./requestBody";
+import { DEFAULT_CONTENT_TYPES } from "../../lib/routeConfig";
+import { MAX_REQUEST_BODY_BYTES } from "../../lib/env";
 
 dayjs.extend(dayjsUtc);
 
@@ -89,7 +92,8 @@ const DEFAULT_TRIGGER: TriggerContext = {
  * `reply` is opt-in async via header so schedulers/crons can fire-and-forget.
  */
 export async function envelopeFromHttp(ctx: Context): Promise<RequestEnvelope> {
-	return {
+	const reader = bodyReader(ctx.req, MAX_REQUEST_BODY_BYTES);
+	const envelope: RequestEnvelope = {
 		trigger: {
 			kind: "route",
 			source: "http",
@@ -101,9 +105,13 @@ export async function envelopeFromHttp(ctx: Context): Promise<RequestEnvelope> {
 			path: ctx.req.path,
 			headers: ctx.req.header(),
 			query: ctx.req.query(),
-			body: await getRequestBody(ctx),
+			body: null,
+			bodyReader: reader,
 		},
 	};
+	// an async reply is sent before the route runs; the stream may not survive it
+	if (reader && envelope.trigger.reply === "async") await reader.materialize();
+	return envelope;
 }
 
 /**
@@ -132,6 +140,18 @@ export async function dispatch(
 		};
 	}
 
+	let body = payload.body;
+	if (payload.bodyReader) {
+		try {
+			body = await payload.bodyReader.parse(
+				path.acceptedContentTypes ?? DEFAULT_CONTENT_TYPES,
+			);
+		} catch (error) {
+			if (!(error instanceof RequestBodyError)) throw error;
+			return { status: error.status, data: { message: error.message } };
+		}
+	}
+
 	const finish = observer?.onRouteStart({
 		routeId: path.id,
 		projectId: path.projectId!,
@@ -155,7 +175,7 @@ export async function dispatch(
 				path: payload.path,
 				headers: payload.headers,
 				query: payload.query,
-				body: payload.body,
+				body,
 				params: path.routeParams || payload.params || {},
 			},
 			httpCtx,
@@ -569,17 +589,3 @@ function createJsVM(vars: Record<string, any>) {
 	return vm;
 }
 
-async function getRequestBody(ctx: Context) {
-	const method = ctx.req.method;
-	if (method == "POST" || method == "PUT") {
-		const contentType = ctx.req.header("Content-Type");
-		if (contentType === "application/json") {
-			return await ctx.req.json();
-		}
-		if (contentType === "application/x-www-form-urlencoded") {
-			return await ctx.req.formData();
-		}
-		return await ctx.req.text();
-	}
-	return null;
-}

--- a/apps/server/src/modules/requestRouter/tests/dispatch.spec.ts
+++ b/apps/server/src/modules/requestRouter/tests/dispatch.spec.ts
@@ -42,6 +42,27 @@ function postCtx(body: string, contentType: string) {
 	} as any;
 }
 
+function multipartCtx(fields: Record<string, string | File>) {
+	const form = new FormData();
+	for (const [key, value] of Object.entries(fields)) form.set(key, value);
+	const raw = new Request("http://localhost/jobs", {
+		method: "POST",
+		body: form,
+	});
+	return {
+		req: {
+			method: "POST",
+			path: "/jobs",
+			header: (name?: string) =>
+				name === undefined
+					? Object.fromEntries(raw.headers.entries())
+					: (raw.headers.get(name) ?? undefined),
+			query: () => ({}),
+			raw,
+		},
+	} as any;
+}
+
 describe("envelopeFromHttp", () => {
 	it("maps an HTTP request to a sync route envelope by default", async () => {
 		const env = await envelopeFromHttp(
@@ -182,6 +203,115 @@ describe("dispatch", () => {
 		const res = await dispatch(env, parser);
 
 		expect(res.status).toBe(415);
+	});
+
+	it("validates an uploaded file against the route's body schema", async () => {
+		// the seam: what the multipart parser produces must be what the schema
+		// parser's `file` type accepts, size rules included
+		const bodySchema = {
+			dataType: "object",
+			properties: [
+				{
+					key: "avatar",
+					dataType: "file",
+					rules: [
+						{ type: "maxSize", value: 8 },
+						{ type: "mimeTypes", value: "image/png" },
+					],
+				},
+				{ key: "title", dataType: "str" },
+			],
+		};
+		const parser = {
+			getRouteId: () => ({
+				id: "route-1",
+				projectId: "project-1",
+				projectName: "Project",
+				acceptedContentTypes: ["multipart/form-data"],
+				bodySchema,
+			}),
+		} as unknown as HttpRouteParser;
+
+		let seen: any;
+		setBlocksExecutor(async (_target, context) => {
+			seen = context.requestBody;
+			return { successful: true, output: { body: "ok" } } as any;
+		});
+
+		const accepted = await dispatch(
+			await envelopeFromHttp(
+				multipartCtx({
+					title: "avatar",
+					avatar: new File(["12345"], "a.png", { type: "image/png" }),
+				}),
+			),
+			parser,
+		);
+		expect(accepted.status).toBe(200);
+		expect(seen.avatar).toBeInstanceOf(File);
+		expect(seen.title).toBe("avatar");
+
+		const tooBig = await dispatch(
+			await envelopeFromHttp(
+				multipartCtx({
+					title: "avatar",
+					avatar: new File(["x".repeat(64)], "a.png", { type: "image/png" }),
+				}),
+			),
+			parser,
+		);
+		expect(tooBig.status).toBe(400);
+		expect((tooBig.data as any).message).toBe("Body validation failed");
+		expect((tooBig.data as any).errors[0].property).toBe("avatar");
+
+		const wrongType = await dispatch(
+			await envelopeFromHttp(
+				multipartCtx({
+					title: "avatar",
+					avatar: new File(["12345"], "a.pdf", { type: "application/pdf" }),
+				}),
+			),
+			parser,
+		);
+		expect(wrongType.status).toBe(400);
+	});
+
+	it("validates a urlencoded body against the route's body schema", async () => {
+		// every value a form sends is text, so a numeric field must be coerced
+		// by the schema author, not silently accepted
+		const parser = {
+			getRouteId: () => ({
+				id: "route-1",
+				projectId: "project-1",
+				projectName: "Project",
+				acceptedContentTypes: ["application/x-www-form-urlencoded"],
+				bodySchema: {
+					dataType: "object",
+					properties: [
+						{ key: "name", dataType: "str", rules: [{ type: "minLength", value: 2 }] },
+					],
+				},
+			}),
+		} as unknown as HttpRouteParser;
+
+		setBlocksExecutor(async () => ({ successful: true, output: {} }) as any);
+
+		const ok = await dispatch(
+			await envelopeFromHttp(
+				postCtx("name=Alice", "application/x-www-form-urlencoded"),
+			),
+			parser,
+		);
+		expect(ok.status).toBe(200);
+
+		const rejected = await dispatch(
+			await envelopeFromHttp(
+				postCtx("name=A", "application/x-www-form-urlencoded"),
+			),
+			parser,
+		);
+		expect(rejected.status).toBe(400);
+		expect((rejected.data as any).errors[0].property).toBe("name");
 	});
 
 	it("reuses the HTTP client and normalizes headers once per execution", async () => {

--- a/apps/server/src/modules/requestRouter/tests/dispatch.spec.ts
+++ b/apps/server/src/modules/requestRouter/tests/dispatch.spec.ts
@@ -21,6 +21,27 @@ function fakeCtx(opts: {
 	} as any;
 }
 
+/** a real Request, so the body reader sees real headers and a real stream */
+function postCtx(body: string, contentType: string) {
+	const raw = new Request("http://localhost/jobs", {
+		method: "POST",
+		body,
+		headers: { "content-type": contentType },
+	});
+	return {
+		req: {
+			method: "POST",
+			path: "/jobs",
+			header: (name?: string) =>
+				name === undefined
+					? Object.fromEntries(raw.headers.entries())
+					: (raw.headers.get(name) ?? undefined),
+			query: () => ({}),
+			raw,
+		},
+	} as any;
+}
+
 describe("envelopeFromHttp", () => {
 	it("maps an HTTP request to a sync route envelope by default", async () => {
 		const env = await envelopeFromHttp(
@@ -102,6 +123,65 @@ describe("dispatch", () => {
 			message: "Body validation failed",
 			errors: [{ path: "", property: "", errors: ["expected failure"] }],
 		});
+	});
+
+	it("rejects a body the matched route does not accept", async () => {
+		const parser = {
+			getRouteId: () => ({
+				id: "route-1",
+				projectId: "project-1",
+				projectName: "Project",
+				acceptedContentTypes: ["multipart/form-data"],
+			}),
+		} as unknown as HttpRouteParser;
+		const env = await envelopeFromHttp(
+			postCtx('{"a":1}', "application/json"),
+		);
+
+		const res = await dispatch(env, parser);
+
+		expect(res.status).toBe(415);
+		expect((res.data as { message: string }).message).toContain(
+			"multipart/form-data",
+		);
+	});
+
+	it("parses the body only after the route matched, and hands it to the graph", async () => {
+		let seen: unknown;
+		setBlocksExecutor(async (_target, context) => {
+			seen = context.requestBody;
+			return { successful: true, output: { body: "ok" } } as any;
+		});
+		const parser = {
+			getRouteId: () => ({
+				id: "route-1",
+				projectId: "project-1",
+				projectName: "Project",
+				acceptedContentTypes: ["application/x-www-form-urlencoded"],
+			}),
+		} as unknown as HttpRouteParser;
+		const env = await envelopeFromHttp(
+			postCtx("name=Alice", "application/x-www-form-urlencoded"),
+		);
+
+		await dispatch(env, parser);
+
+		expect(seen).toEqual({ name: "Alice" });
+	});
+
+	it("falls back to JSON only when a route carries no content type config", async () => {
+		const parser = {
+			getRouteId: () => ({
+				id: "route-1",
+				projectId: "project-1",
+				projectName: "Project",
+			}),
+		} as unknown as HttpRouteParser;
+		const env = await envelopeFromHttp(postCtx("plain", "text/plain"));
+
+		const res = await dispatch(env, parser);
+
+		expect(res.status).toBe(415);
 	});
 
 	it("reuses the HTTP client and normalizes headers once per execution", async () => {

--- a/apps/server/src/modules/requestRouter/tests/requestBody.spec.ts
+++ b/apps/server/src/modules/requestRouter/tests/requestBody.spec.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from "bun:test";
+import {
+	bodyReader,
+	mediaType,
+	RequestBodyError,
+} from "../requestBody";
+import { CONTENT_TYPES } from "../../../lib/routeConfig";
+
+const MAX = 1024;
+
+function request(method: string, body?: BodyInit, contentType?: string) {
+	const headers = contentType ? { "content-type": contentType } : undefined;
+	const raw = new Request("http://localhost/x", { method, body, headers });
+	return {
+		method,
+		header: (name: string) => raw.headers.get(name) ?? undefined,
+		raw,
+	};
+}
+
+async function parse(
+	req: ReturnType<typeof request>,
+	accepted: readonly string[] = CONTENT_TYPES,
+	maxBytes = MAX,
+) {
+	return await bodyReader(req, maxBytes)!.parse(accepted);
+}
+
+async function statusOf(promise: Promise<unknown>) {
+	try {
+		await promise;
+		return 200;
+	} catch (error) {
+		if (error instanceof RequestBodyError) return error.status;
+		throw error;
+	}
+}
+
+describe("mediaType", () => {
+	it("drops parameters and normalizes case", () => {
+		expect(mediaType("Application/JSON; charset=utf-8")).toBe(
+			"application/json",
+		);
+		expect(mediaType("multipart/form-data; boundary=--x")).toBe(
+			"multipart/form-data",
+		);
+		expect(mediaType(undefined)).toBe("");
+	});
+});
+
+describe("bodyReader", () => {
+	it("is absent for methods that carry no body", () => {
+		expect(bodyReader(request("GET"), MAX)).toBeUndefined();
+		expect(bodyReader(request("DELETE"), MAX)).toBeUndefined();
+	});
+
+	it("is absent when the request declares no content type", () => {
+		expect(bodyReader(request("POST", "x"), MAX)).toBeUndefined();
+	});
+
+	it("parses JSON even when the header carries a charset", async () => {
+		const body = await parse(
+			request("POST", '{"name":"Alice"}', "application/json; charset=utf-8"),
+		);
+		expect(body).toEqual({ name: "Alice" });
+	});
+
+	it("treats an empty JSON body as null instead of failing", async () => {
+		expect(
+			await parse(request("POST", "", "application/json")),
+		).toBeNull();
+	});
+
+	it("rejects a content type the route does not accept", async () => {
+		const status = await statusOf(
+			parse(request("POST", "{}", "application/json"), [
+				"multipart/form-data",
+			]),
+		);
+		expect(status).toBe(415);
+	});
+
+	it("rejects a content type nothing supports", async () => {
+		const status = await statusOf(
+			parse(request("POST", "<a/>", "application/xml")),
+		);
+		expect(status).toBe(415);
+	});
+
+	it("turns urlencoded form data into a plain object", async () => {
+		const body = await parse(
+			request(
+				"POST",
+				"name=Alice&age=30",
+				"application/x-www-form-urlencoded",
+			),
+		);
+		expect(body).toEqual({ name: "Alice", age: "30" });
+	});
+
+	it("collects repeated form keys into an array", async () => {
+		const body = (await parse(
+			request("POST", "tag=a&tag=b&tag=c", "application/x-www-form-urlencoded"),
+		)) as Record<string, unknown>;
+		expect(body.tag).toEqual(["a", "b", "c"]);
+	});
+
+	it("keeps a __proto__ field as an own property", async () => {
+		const body = (await parse(
+			request(
+				"POST",
+				"__proto__=polluted&ok=1",
+				"application/x-www-form-urlencoded",
+			),
+		)) as Record<string, unknown>;
+		expect(Object.hasOwn(body, "__proto__")).toBe(true);
+		expect(({} as any).polluted).toBeUndefined();
+		expect(Object.getPrototypeOf(body)).toBe(Object.prototype);
+	});
+
+	it("returns multipart files as File instances beside plain fields", async () => {
+		const form = new FormData();
+		form.set("title", "avatar");
+		form.set("upload", new File(["hello"], "a.txt", { type: "text/plain" }));
+		const raw = new Request("http://localhost/x", { method: "POST", body: form });
+		const body = (await bodyReader(
+			{
+				method: "POST",
+				header: (name: string) => raw.headers.get(name) ?? undefined,
+				raw,
+			},
+			MAX,
+		)!.parse(CONTENT_TYPES)) as Record<string, unknown>;
+
+		expect(body.title).toBe("avatar");
+		expect(body.upload).toBeInstanceOf(File);
+		expect(await (body.upload as File).text()).toBe("hello");
+	});
+
+	it("collects repeated multipart files into an array", async () => {
+		const form = new FormData();
+		form.append("docs", new File(["1"], "one.txt"));
+		form.append("docs", new File(["2"], "two.txt"));
+		const raw = new Request("http://localhost/x", { method: "POST", body: form });
+		const body = (await bodyReader(
+			{
+				method: "POST",
+				header: (name: string) => raw.headers.get(name) ?? undefined,
+				raw,
+			},
+			MAX,
+		)!.parse(CONTENT_TYPES)) as Record<string, unknown>;
+
+		expect(Array.isArray(body.docs)).toBe(true);
+		expect((body.docs as File[]).map((f) => f.name)).toEqual([
+			"one.txt",
+			"two.txt",
+		]);
+	});
+
+	it("returns a raw binary body as a Blob", async () => {
+		const body = await parse(
+			request("POST", new Uint8Array([1, 2, 3]), "application/octet-stream"),
+		);
+		expect(body).toBeInstanceOf(Blob);
+		expect((body as Blob).size).toBe(3);
+	});
+
+	it("returns text/plain untouched", async () => {
+		expect(await parse(request("POST", "just words", "text/plain"))).toBe(
+			"just words",
+		);
+	});
+
+	it("reports malformed JSON as a 400, not a 500", async () => {
+		const status = await statusOf(
+			parse(request("POST", "{not json", "application/json")),
+		);
+		expect(status).toBe(400);
+	});
+
+	it("rejects a body whose declared length exceeds the cap", async () => {
+		const status = await statusOf(
+			parse(
+				request("POST", "x".repeat(2048), "text/plain"),
+				CONTENT_TYPES,
+				MAX,
+			),
+		);
+		expect(status).toBe(413);
+	});
+
+	it("rejects an oversized body that declared no length", async () => {
+		const stream = new ReadableStream({
+			start(controller) {
+				controller.enqueue(new TextEncoder().encode("x".repeat(2048)));
+				controller.close();
+			},
+		});
+		const raw = new Request("http://localhost/x", {
+			method: "POST",
+			body: stream,
+			headers: { "content-type": "text/plain" },
+			// @ts-expect-error node/bun require this for a streaming body
+			duplex: "half",
+		});
+		const status = await statusOf(
+			bodyReader(
+				{
+					method: "POST",
+					header: (name: string) => raw.headers.get(name) ?? undefined,
+					raw,
+				},
+				MAX,
+			)!.parse(CONTENT_TYPES),
+		);
+		expect(status).toBe(413);
+	});
+
+	it("parses only once, however often the body is read", async () => {
+		const req = request("POST", '{"a":1}', "application/json");
+		const reader = bodyReader(req, MAX)!;
+		await reader.materialize();
+		expect(await reader.parse(CONTENT_TYPES)).toEqual({ a: 1 });
+	});
+});

--- a/apps/server/src/modules/requestRouter/threadTypes.ts
+++ b/apps/server/src/modules/requestRouter/threadTypes.ts
@@ -13,6 +13,8 @@ export type ExecutionBootstrap = {
 	artifacts: ArtifactEntry[];
 	/** hot-reloadable supervisor policy; false means no heartbeat or tracking */
 	workerTimeoutsEnabled: boolean;
+	/** hard request body ceiling in bytes; the child cannot read the env itself */
+	maxRequestBodyBytes: number;
 	/** the execution process clears its env, so logging config travels with it */
 	logging: {
 		level: any;

--- a/apps/server/src/modules/requestRouter/types.ts
+++ b/apps/server/src/modules/requestRouter/types.ts
@@ -1,4 +1,5 @@
 import type { TriggerContext } from "@fluxify/blocks";
+import type { BodyReader } from "./requestBody";
 
 export type RequestOverrides = {
 	integrations?: Array<{ existingId: string; newId: string }>;
@@ -20,6 +21,12 @@ export type RequestPayload = {
 	body: any;
 	/** route params; usually filled by the router after matching */
 	params?: Record<string, string>;
+	/**
+	 * HTTP only. The accepted content types are a per-route setting, so the body
+	 * is parsed once the route is known; `body` above stays undefined until then.
+	 * Non-HTTP producers supply a plain `body` and leave this unset.
+	 */
+	bodyReader?: BodyReader;
 };
 
 export type RequestEnvelope = {

--- a/docker/kit/env.example
+++ b/docker/kit/env.example
@@ -42,6 +42,9 @@ WORKER_HEALTH_PORT=5601
 WORKER_PROJECT_ID=
 # Close an unused database integration after this many seconds (default 450 = 7.5 minutes).
 INTEGRATION_TIMEOUT_POLICY_IN_SEC=450
+# Hard cap on an incoming request body, in kilobytes (default 8192 = 8 MB).
+# Fluxify is an API server: for uploads, prefer a pre-signed object-storage URL.
+WORKER_MAX_STREAM_SIZE=8192
 # Per-worker bound for future async trigger/workflow execution.
 ASYNC_EXECUTOR_MAX_IN_FLIGHT=10
 ASYNC_EXECUTOR_MAX_QUEUE_DEPTH=100

--- a/docker/production/env.example
+++ b/docker/production/env.example
@@ -37,6 +37,9 @@ WORKER_PORT=5600
 WORKER_HEALTH_PORT=5601
 # Close an unused database integration after this many seconds (default 450 = 7.5 minutes).
 INTEGRATION_TIMEOUT_POLICY_IN_SEC=450
+# Hard cap on an incoming request body, in kilobytes (default 8192 = 8 MB).
+# Fluxify is an API server: for uploads, prefer a pre-signed object-storage URL.
+WORKER_MAX_STREAM_SIZE=8192
 # Per-worker bound for future async trigger/workflow execution.
 ASYNC_EXECUTOR_MAX_IN_FLIGHT=10
 ASYNC_EXECUTOR_MAX_QUEUE_DEPTH=100

--- a/docs/blocks/get-http-request-body.md
+++ b/docs/blocks/get-http-request-body.md
@@ -5,13 +5,74 @@ description: Access the data sent in the request body.
 
 # Get HTTP Request Body
 
-The **Get HTTP Request Body** block retrieves the entire body of the incoming request (e.g., JSON data sent to your API).
+The **Get HTTP Request Body** block returns the body of the incoming request,
+already turned into something you can work with. What you get depends on the
+content type the caller used.
 
 ## Inputs
 
-This block generally uses the request context and doesn't require specific user inputs.
+None. The block always reads the body of the request that started the workflow.
+
+## What the block returns
+
+| Caller sends | You get |
+| :--- | :--- |
+| `application/json` | The parsed JSON — an object, an array, a number, whatever was sent |
+| `application/x-www-form-urlencoded` | An object of field names and text values |
+| `multipart/form-data` | An object where text fields are strings and uploaded files are file objects |
+| `application/octet-stream` | The raw binary body as a single file-like value |
+| `text/plain` | The text, exactly as sent |
+| A `GET` or `DELETE` request | `null` — those methods carry no body |
+
+::: info Which types your route allows
+A route accepts **JSON only** unless you say otherwise. Pick the formats you
+want under **Accepted content types** when you create the route. A request that
+arrives in any other format is rejected with `415 Unsupported Media Type`
+before your workflow runs.
+:::
+
+### Repeated field names
+
+If a form sends the same field name twice (`tag=a&tag=b`, or two files under
+`docs`), you get a list for that field instead of a single value. A name that
+appears once stays a single value.
+
+```json
+{ "title": "Holiday photos", "tags": ["beach", "summer"] }
+```
+
+### Working with uploaded files
+
+A file field is a file object, not text. In a **JS Runner** block you can read
+its name, size, type, and contents:
+
+```javascript
+const body = getRequestBody();
+const upload = body.avatar;
+
+console.log(upload.name);  // "profile.png"
+console.log(upload.size);  // 20481  (bytes)
+console.log(upload.type);  // "image/png"
+
+const text = await upload.text();          // for text files
+const bytes = await upload.arrayBuffer();  // for anything else
+```
+
+::: warning Files are not JSON
+A file object cannot be returned directly from a **Response** block — JSON has
+no way to represent one. Read what you need from it (its text, its size, a
+value you extract from it) and return that instead.
+:::
+
+## Size limit
+
+Every request body is capped, 8 MB by default. A larger request is rejected
+with `413` and your workflow never starts. See
+[request body size](../deployments/production.md#request-body-size) for how to
+change the cap and why large uploads belong somewhere else.
 
 ## Logic
 
-1.  The block reads the body of the incoming HTTP request.
-2.  It returns this data as the output, often so you can process it with other blocks.
+1. The caller's content type is checked against the formats the route accepts.
+2. The body is read and turned into the value shown in the table above.
+3. That value becomes the block's output, ready for the blocks after it.

--- a/docs/deployments/production.md
+++ b/docs/deployments/production.md
@@ -104,6 +104,34 @@ the isolated execution process, so the container and its NATS watcher stay up.
 
 ---
 
+## Request body size {#request-body-size}
+
+Every request body a route receives is capped. The default is **8 MB**, and a
+request above it is rejected with `413` before any workflow runs.
+
+```env
+# Kilobytes. 8192 = 8 MB (the default).
+WORKER_MAX_STREAM_SIZE=8192
+```
+
+Set it in the same `.env` the workers read (see [Step 1](#env)), or per service
+in your compose file. Raise it deliberately: the whole body is held in memory
+while the route runs, so the cap multiplied by your concurrency is memory the
+worker has to have.
+
+::: warning Fluxify is an API server, not an upload service
+Routing large files through your API means the upload is paid for twice — once
+into the worker, once out of it — and every megabyte competes with the requests
+you actually want to serve.
+
+For file uploads, have your client upload **directly to object storage** with a
+pre-signed URL: your route issues a short-lived signed S3 (or compatible) URL,
+the client `PUT`s the file straight to storage, then calls your API again with
+the resulting object key. Only the key ever passes through Fluxify.
+:::
+
+---
+
 ## Local async executor
 
 Compiled workers include a bounded local executor for the future async-trigger

--- a/docs/getting-started/routing.md
+++ b/docs/getting-started/routing.md
@@ -50,13 +50,37 @@ tracking are created.
 Before Fluxify executes a single block in your workflow, it runs through a quick validation pipeline:
 
 1. **Match the route** — find the right workflow for this request.
-2. **Parse the request body** — read the JSON data sent by the caller.
-3. **Validate the body** — check it against your Body Schema (if set).
-4. **Validate query parameters** — check URL query strings against your Query Schema (if set).
-5. **Validate path parameters** — check URL path values against your Params Schema (if set).
-6. **Run your workflow** — only if everything above passed.
+2. **Check the content type** — make sure the caller sent a format this route accepts.
+3. **Parse the request body** — turn it into data your blocks can use.
+4. **Validate the body** — check it against your Body Schema (if set).
+5. **Validate query parameters** — check URL query strings against your Query Schema (if set).
+6. **Validate path parameters** — check URL path values against your Params Schema (if set).
+7. **Run your workflow** — only if everything above passed.
 
 If any validation step fails, the workflow never runs and the caller immediately gets a clear error response.
+## Accepted Content Types
+
+A route declares which body formats it accepts. New routes accept
+**`application/json`** only; choose more under **Accepted content types** when
+you create the route.
+
+| Content type | What your workflow receives |
+| :--- | :--- |
+| `application/json` | The parsed JSON value |
+| `application/x-www-form-urlencoded` | An object of field names and text values |
+| `multipart/form-data` | An object of text fields plus any uploaded files |
+| `application/octet-stream` | The raw binary body |
+| `text/plain` | The text as sent |
+
+A request in any other format — or in a format this particular route wasn't set
+up for — is rejected with `415` and the workflow never runs. `GET` and `DELETE`
+requests carry no body at all.
+
+::: tip Bodies have a size limit
+8 MB by default, and larger requests get a `413`. See
+[request body size](../deployments/production.md#request-body-size).
+:::
+
 ## Request Validation
 
 Each route optionally has three schemas you can configure in the Schema Editor:
@@ -80,6 +104,8 @@ You only need to configure the ones that matter for your route — unused schema
 | `Array` | A list of items, with optional min/max item count |
 | `Object` | A structured set of named fields (can be nested) |
 | `Enum` | One specific value from a predefined list |
+| `File` | An uploaded file from a `multipart/form-data` request, with optional size and file-type rules |
+| `Blob` | A raw binary body (`application/octet-stream`), with optional size rules |
 | `Use JavaScript` | Custom validation logic you write yourself |
 
 ### Marking Fields as Required
@@ -146,6 +172,9 @@ Here's every possible outcome and what the caller receives:
 | Situation | Status | Response |
 | :--- | :--- | :--- |
 | Route doesn't exist | `404` | `{ "message": "Route not found" }` |
+| Content type not accepted | `415` | `{ "message": "Unsupported content type ..." }` |
+| Body too large | `413` | `{ "message": "Request body exceeds the ...KB limit" }` |
+| Body couldn't be read | `400` | `{ "message": "Malformed ... body: ..." }` |
 | Validation failed | `400` | `{ "message": "...", "errors": [...] }` |
 | Workflow error | `500` | `{ "error": "description" }` |
 | Unexpected crash | `500` | `{ "message": "Internal server error" }` |

--- a/docs/scripting/context.md
+++ b/docs/scripting/context.md
@@ -56,7 +56,7 @@ Read data from the incoming HTTP request that triggered this workflow. All funct
 | `getRouteParam(key)` | `(key: string) => string` | Returns the value of a dynamic path segment defined in the route (e.g., `:id`). |
 | `getHeader(key)` | `(key: string) => string` | Returns a request header value. Header lookup is case-insensitive. |
 | `getCookie(key)` | `(key: string) => string` | Returns a cookie value sent with the request. |
-| `getRequestBody()` | `() => any` | Returns the parsed request body. Returns `null` for GET requests. Supports JSON, `application/x-www-form-urlencoded`, and plain text. |
+| `getRequestBody()` | `() => any` | Returns the parsed request body, or `null` when the request has none. JSON becomes a value, form data becomes an object (uploaded files included), a raw binary body a file-like value. See [accepted content types](../getting-started/routing.md#accepted-content-types). |
 | `httpRequestMethod` | `string` (constant) | The HTTP method of the request: `"GET"`, `"POST"`, `"PUT"`, `"DELETE"`, etc. |
 | `httpRequestRoute` | `string` (constant) | The full path of the incoming request, e.g., `"/api/orders/99"`. |
 

--- a/packages/blocks/baseBlock.ts
+++ b/packages/blocks/baseBlock.ts
@@ -176,7 +176,7 @@ const input: any;                // The output data from the previous connected 
 function getQueryParam(key: string): string;
 function getRouteParam(key: string): string;
 function getHeader(key: string): string;
-function getRequestBody(): any;  // Returns body object for POST/PUT, else undefined
+function getRequestBody(): any;  // POST/PUT body: JSON value, form object (files included), or null
 
 // 3. Response Helpers
 function setHeader(key: string, value: string): void;

--- a/packages/blocks/builtin/http/getHttpRequestBody.ts
+++ b/packages/blocks/builtin/http/getHttpRequestBody.ts
@@ -7,7 +7,7 @@ export const getHttpRequestBodyBlockSchema = z.any();
 export const getHttpRequestBodyAiDescription = {
   name: "get_http_request_body",
   description:
-    "Retrieves and returns the raw body of the incoming request.",
+    "Returns the body of the incoming request, parsed into the shape the route's content type implies: a JSON value, an object of form fields (multipart files arrive as File objects), a Blob for a raw binary body, or a string for plain text. Null when the request carries no body.",
   jsonSchema: JSON.stringify(z.toJSONSchema(getHttpRequestBodyBlockSchema)),
 };
 

--- a/packages/blocks/builtin/tests/compilerFormData.spec.ts
+++ b/packages/blocks/builtin/tests/compilerFormData.spec.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from "bun:test";
+import { compileGraph } from "../../compiler";
+import { BlockTypes } from "../../blockTypes";
+import type { EdgeDTOSchemaType } from "../../builderTypes";
+import { block, createContext, edge } from "./compilerTestHelpers";
+
+/**
+ * A compiled graph reading a parsed form body end to end. The unit tests prove
+ * the transport produces `File` objects and plain fields; this proves the
+ * compiled route can actually *use* them — the JS runner reads a file's bytes
+ * inside the sandbox, and the branch/response blocks act on the result.
+ */
+
+/** the shape the multipart parser hands to `ctx.requestBody` */
+function formBody(overrides: Record<string, unknown> = {}) {
+	return {
+		title: "Quarterly report",
+		tags: ["finance", "q3"],
+		report: new File(["net revenue up 4%"], "q3.txt", { type: "text/plain" }),
+		...overrides,
+	};
+}
+
+describe("compiled graph over a parsed form body", () => {
+	it("reads fields and a file's contents, then branches on them", async () => {
+		const blocks = [
+			block("entry", BlockTypes.entrypoint),
+			block("body", BlockTypes.httpGetRequestBody),
+			block("read", BlockTypes.jsrunner, {
+				value: `
+					const report = input.report;
+					return {
+						title: input.title,
+						tagCount: input.tags.length,
+						fileName: report.name,
+						// a part's type can carry parameters (text/plain;charset=utf-8)
+						fileType: report.type.split(";")[0],
+						fileSize: report.size,
+						excerpt: (await report.text()).slice(0, 11),
+					};
+				`,
+			}),
+			block("guard", BlockTypes.if, {
+				conditions: [
+					{ lhs: "js:return input.fileSize", rhs: 0, operator: "gt", chain: "and" },
+				],
+			}),
+			block("ok", BlockTypes.response, { httpCode: "200" }),
+			block("empty", BlockTypes.response, { httpCode: "400" }),
+		];
+		const edges: EdgeDTOSchemaType = [
+			edge("entry", "body"),
+			edge("body", "read"),
+			edge("read", "guard"),
+			edge("guard", "ok", "success"),
+			edge("guard", "empty", "failure"),
+		];
+
+		const { run, source } = compileGraph(blocks, edges);
+		expect(source).toContain("ctx.requestBody");
+
+		const ctx = createContext();
+		ctx.requestBody = formBody();
+
+		const result = await run(ctx, ctx.requestBody);
+
+		expect(result.successful).toBe(true);
+		expect(result.output).toEqual({
+			httpCode: "200",
+			body: {
+				title: "Quarterly report",
+				tagCount: 2,
+				fileName: "q3.txt",
+				fileType: "text/plain",
+				fileSize: 17,
+				excerpt: "net revenue",
+			},
+		});
+	});
+
+	it("takes the failure branch for an empty upload", async () => {
+		const blocks = [
+			block("entry", BlockTypes.entrypoint),
+			block("body", BlockTypes.httpGetRequestBody),
+			block("size", BlockTypes.jsrunner, { value: "return input.report.size;" }),
+			block("guard", BlockTypes.if, {
+				conditions: [{ lhs: "js:return input", rhs: 0, operator: "gt", chain: "and" }],
+			}),
+			block("ok", BlockTypes.response, { httpCode: "200" }),
+			block("empty", BlockTypes.response, { httpCode: "400" }),
+		];
+		const edges: EdgeDTOSchemaType = [
+			edge("entry", "body"),
+			edge("body", "size"),
+			edge("size", "guard"),
+			edge("guard", "ok", "success"),
+			edge("guard", "empty", "failure"),
+		];
+
+		const ctx = createContext();
+		ctx.requestBody = formBody({ report: new File([], "empty.txt") });
+
+		const { run } = compileGraph(blocks, edges);
+		const result = await run(ctx, ctx.requestBody);
+
+		expect(result.output).toEqual({ httpCode: "400", body: 0 });
+	});
+
+	it("stores an uploaded file in a var and a later block still reads its bytes", async () => {
+		// vars survive between blocks by reference — a File must not be flattened
+		// on the way through.
+		const blocks = [
+			block("entry", BlockTypes.entrypoint),
+			block("body", BlockTypes.httpGetRequestBody),
+			block("keep", BlockTypes.setvar, { key: "upload", value: "js:return input.report" }),
+			block("later", BlockTypes.jsrunner, {
+				value: "return (await upload.arrayBuffer()).byteLength;",
+			}),
+			block("out", BlockTypes.response, { httpCode: "200" }),
+		];
+		const edges: EdgeDTOSchemaType = [
+			edge("entry", "body"),
+			edge("body", "keep"),
+			edge("keep", "later"),
+			edge("later", "out"),
+		];
+
+		const ctx = createContext();
+		ctx.requestBody = formBody();
+
+		const { run } = compileGraph(blocks, edges);
+		const result = await run(ctx, ctx.requestBody);
+
+		expect(ctx.vars.upload).toBeInstanceOf(File);
+		expect(result.output).toEqual({ httpCode: "200", body: 17 });
+	});
+
+	it("iterates the repeated fields a form produced", async () => {
+		const blocks = [
+			block("entry", BlockTypes.entrypoint),
+			block("body", BlockTypes.httpGetRequestBody),
+			block("pick", BlockTypes.jsrunner, { value: "return input.tags;" }),
+			// the loop consumes the flowing value; results accumulate in a var
+			block("loop", BlockTypes.foreachloop, { values: [], useParam: true }),
+			block("upper", BlockTypes.jsrunner, {
+				value: "seen = (seen || []); seen.push(input.toUpperCase()); return input;",
+			}),
+			block("collect", BlockTypes.getvar, { key: "seen" }),
+			block("out", BlockTypes.response, { httpCode: "200" }),
+		];
+		const edges: EdgeDTOSchemaType = [
+			edge("entry", "body"),
+			edge("body", "pick"),
+			edge("pick", "loop"),
+			edge("loop", "upper", "executor"),
+			edge("loop", "collect"),
+			edge("collect", "out"),
+		];
+
+		const ctx = createContext();
+		ctx.requestBody = formBody();
+
+		const { run } = compileGraph(blocks, edges);
+		const result = await run(ctx, ctx.requestBody);
+
+		expect(result.output).toEqual({
+			httpCode: "200",
+			body: ["FINANCE", "Q3"],
+		});
+	});
+});

--- a/packages/components/index.ts
+++ b/packages/components/index.ts
@@ -13,6 +13,7 @@ export * from "./src/IntegrationSelector";
 export * from "./src/JsonEditor";
 export * from "./src/ArrayEditor";
 export * from "./src/JoinsEditor";
+export * from "./src/MultiSelect";
 export {
 	Checkbox,
 	CheckboxControl,

--- a/packages/components/src/MultiSelect/MultiSelect.tsx
+++ b/packages/components/src/MultiSelect/MultiSelect.tsx
@@ -1,0 +1,78 @@
+import {
+	Chip,
+	Description,
+	Label,
+	ListBox,
+	Select,
+} from "@heroui/react";
+import type { Key } from "react";
+import type { MultiSelectOption, MultiSelectProps } from "./types";
+
+/**
+ * Dropdown that keeps several options selected at once, shown as chips in the
+ * trigger. HeroUI's Select already does multiple selection — this only fixes
+ * the shape of the value (a plain `string[]`) and renders the chips.
+ */
+export function MultiSelect({
+	options,
+	value,
+	onChange,
+	label,
+	description,
+	placeholder = "Select…",
+	isDisabled,
+	fullWidth = true,
+	variant = "secondary",
+}: MultiSelectProps) {
+	const labelFor = (option: string) =>
+		options.find((entry: MultiSelectOption) => entry.value === option)?.label ??
+		option;
+
+	return (
+		<Select
+			selectionMode="multiple"
+			fullWidth={fullWidth}
+			variant={variant}
+			isDisabled={isDisabled}
+			placeholder={placeholder}
+			value={value}
+			onChange={(keys: Key[]) => onChange(keys.map(String))}
+		>
+			{label && <Label>{label}</Label>}
+			<Select.Trigger>
+				{/* chips come from `value`, not the collection: one source of truth */}
+				<Select.Value>
+					{({ isPlaceholder }) =>
+						isPlaceholder ? (
+							<span className="text-muted-foreground">{placeholder}</span>
+						) : (
+							<span className="flex flex-wrap items-center gap-1">
+								{value.map((entry) => (
+									<Chip key={entry} size="sm">
+										{labelFor(entry)}
+									</Chip>
+								))}
+							</span>
+						)
+					}
+				</Select.Value>
+				<Select.Indicator />
+			</Select.Trigger>
+			{description && <Description>{description}</Description>}
+			<Select.Popover>
+				<ListBox>
+					{options.map((option) => (
+						<ListBox.Item
+							key={option.value}
+							id={option.value}
+							textValue={option.label}
+						>
+							{option.label}
+							<ListBox.ItemIndicator />
+						</ListBox.Item>
+					))}
+				</ListBox>
+			</Select.Popover>
+		</Select>
+	);
+}

--- a/packages/components/src/MultiSelect/index.ts
+++ b/packages/components/src/MultiSelect/index.ts
@@ -1,0 +1,2 @@
+export { MultiSelect } from "./MultiSelect";
+export type { MultiSelectOption, MultiSelectProps } from "./types";

--- a/packages/components/src/MultiSelect/types.ts
+++ b/packages/components/src/MultiSelect/types.ts
@@ -1,0 +1,18 @@
+import type { ReactNode } from "react";
+
+export type MultiSelectOption = {
+	value: string;
+	label: string;
+};
+
+export type MultiSelectProps = {
+	options: MultiSelectOption[];
+	value: string[];
+	onChange: (value: string[]) => void;
+	label?: ReactNode;
+	description?: ReactNode;
+	placeholder?: string;
+	isDisabled?: boolean;
+	fullWidth?: boolean;
+	variant?: "primary" | "secondary";
+};

--- a/packages/lib/routing/parser.ts
+++ b/packages/lib/routing/parser.ts
@@ -8,6 +8,8 @@ export type HttpRoute = {
   querySchema?: any;
   paramsSchema?: any;
   timeoutSeconds?: number;
+  /** body formats this route accepts; anything else is rejected with a 415 */
+  acceptedContentTypes?: string[];
   /** spans exported to the project's OTEL destination; nothing is stored by us */
   tracingEnabled?: boolean;
   /** debug recording, persisted for the portal trace viewer; expensive */


### PR DESCRIPTION
Closes #161

## Why

**Get Request Body** only ever produced JSON, and not reliably:

- `contentType === "application/json"` was an exact match, so `application/json; charset=utf-8` fell through to `.text()` and the workflow got a string.
- `application/x-www-form-urlencoded` returned a raw `FormData` object — not JSON-serializable, not usable by body-schema validation, no `.field` access.
- `multipart/form-data` hit `.text()` and arrived as raw MIME.
- Nothing capped the body size.

The fix belongs in the transport, not the block: the same value feeds the block, the compiled emitter's `ctx.requestBody`, the JS-runner global `getRequestBody()`, and body validation. Fixing only the block would leave the other three broken.

## What

**Content types are now a per-route setting.** A route accepts `application/json` unless told otherwise; anything else is a `415` with a message naming what it does accept.

| Content type | Body becomes |
| :--- | :--- |
| `application/json` | the parsed value |
| `application/x-www-form-urlencoded` | plain object, string values |
| `multipart/form-data` | plain object; files stay native `File` |
| `application/octet-stream` | a `Blob` |
| `text/plain` | the string |

Repeated keys (`tag=a&tag=b`, two files under one name) collect into an array — silently dropping the second file of a two-file upload is worse than an uneven shape. `POST`/`PUT` only; `DELETE` may carry a body per RFC 9110, but we don't invite it.

**New `http_route_config` table** (`route_id` PK / `project_id` / `route_config` jsonb / timestamps). An open bag rather than a column per setting, so the next per-route knob is a change to `lib/routeConfig.ts` and not a migration. Patches merge with jsonb `||` so a key written by a newer build isn't clobbered. Missing or unparseable config falls back to the default — a bad row must never take a route down.

**Parsing happens after the route matches.** `envelopeFromHttp` now attaches a `bodyReader` and `dispatch` invokes it with the matched route's allowlist, so an unacceptable content type is rejected without reading the body at all. Non-HTTP producers (NATS/BullMQ, the test-suite runner) still supply a plain `body` and are untouched. Async-reply requests buffer before the 202, since the request stream isn't guaranteed to outlive the response.

**Size cap:** `WORKER_MAX_STREAM_SIZE` (kilobytes, default 8192 = 8 MB), applied at `Bun.serve` on both worker paths and re-checked per request → `413`. The execution child process clears its own env, so the value travels in `ExecutionBootstrap`.

**Schema types:** `file` and `blob` with `maxSize` / `minSize` / `mimeTypes` (an array or a comma-separated string). `File[]` already works via `arr` + `file` items. Mime comparison uses the media type only — `text/plain;charset=utf-8` matches a `text/plain` rule.

**Portal:** the create-route modal gained an **Accepted content types** picker (shown for POST/PUT), backed by a new `MultiSelect` in `packages/components` — HeroUI's Select in multiple mode with chips in the trigger. The generated OpenAPI spec now lists the route's real content types instead of assuming JSON.

## Tests

- `requestBody.spec.ts` — 18 cases: charset tolerance, each content type, repeated keys, `__proto__` staying an own property, malformed body → 400, oversize by `Content-Length` and by actual bytes → 413.
- `dispatch.spec.ts` — 415 for a disallowed type, the default-JSON fallback, the parsed body reaching the graph, and **parsed body → body-schema validation** (multipart against `file` size/mime rules, urlencoded against a string rule).
- `compilerFormData.spec.ts` — four **compiled graphs** run over a parsed form body: a JS runner reading a file's bytes then branching, the empty-upload failure path, a `File` surviving a setvar round trip by reference, and a foreach over a repeated field.
- `schemaParser.test.ts` / `routeConfig.test.ts` — file/blob rules, and config defaults and fallbacks.

The compiled-graph test caught a real bug before this shipped: Bun reports a text part as `text/plain;charset=utf-8`, which failed an exact-match `text/plain` mime rule. Hence the media-type normalization above.

Repo lint green; 658 unit + 78 integration tests pass.

## Notes for review

- **Behaviour change for existing deployments.** A live route called with `x-www-form-urlencoded` (previously an unusable `FormData`) or an arbitrary content type (previously `.text()`) now gets a `415` until its accepted types are set. Existing routes keep working for JSON, which is what nearly all of them use.
- **Editing is API-only for now.** `update-partial` accepts `acceptedContentTypes`; there is no route-settings screen yet, so the picker lives in the create modal until the portal settings page lands. `routes/update` (full PUT) is deliberately untouched.
- **Not covered by tests:** the DB round-trip (`patchRouteConfig` → loader/compiler), which needs a live Postgres, and the MultiSelect in a browser.
- Files are held in memory and cannot be returned from a Response block. The docs now point at pre-signed object-storage URLs for real uploads — Fluxify is an API server, not an upload gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
