### PR TITLE
fix(adapters): unhang KV container tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,7 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.adapters == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2

--- a/packages/adapters/containerTestHelpers.ts
+++ b/packages/adapters/containerTestHelpers.ts
@@ -47,13 +47,3 @@ export function pullImage(image: string): Promise<void> {
 		});
 	});
 }
-
-/** Pull an image only when the local Docker daemon does not already have it. */
-export async function ensureImage(image: string): Promise<void> {
-	try {
-		await docker.getImage(image).inspect();
-	} catch (error: any) {
-		if (error.statusCode !== 404) throw error;
-		await pullImage(image);
-	}
-}

--- a/packages/adapters/kv/memcached.test.ts
+++ b/packages/adapters/kv/memcached.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll } from "bun:test";
 import { faker } from "@faker-js/faker";
 import { MemcachedIntegration } from "./memcached";
 import type Docker from "dockerode";
-import { docker, ensureImage, startContainerWithRandomPort } from "../containerTestHelpers";
+import { docker, pullImage, startContainerWithRandomPort } from "../containerTestHelpers";
 
 const MEMCACHED_IMAGE = "memcached:1.6-alpine";
 
@@ -14,7 +14,7 @@ describe("MemcachedIntegration", () => {
 
 	beforeAll(async () => {
 		await docker.getContainer(containerName).remove({ force: true }).catch(() => {});
-		await ensureImage(MEMCACHED_IMAGE);
+		await pullImage(MEMCACHED_IMAGE);
 		const started = await startContainerWithRandomPort((hostPort) =>
 			docker.createContainer({
 				Image: MEMCACHED_IMAGE,

--- a/packages/adapters/kv/redis.test.ts
+++ b/packages/adapters/kv/redis.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect, beforeAll, afterAll } from "bun:test";
 import { faker } from "@faker-js/faker";
 import { RedisIntegration } from "./redis";
 import type Docker from "dockerode";
-import { docker, ensureImage, startContainerWithRandomPort } from "../containerTestHelpers";
+import { docker, pullImage, startContainerWithRandomPort } from "../containerTestHelpers";
 
-const REDIS_IMAGE = "redis:7.4-alpine";
+const REDIS_IMAGE = "valkey/valkey:8-alpine";
 
 describe("RedisIntegration", () => {
 	const containerName = "fluxify-redis-test";
@@ -14,7 +14,7 @@ describe("RedisIntegration", () => {
 
 	beforeAll(async () => {
 		await docker.getContainer(containerName).remove({ force: true }).catch(() => {});
-		await ensureImage(REDIS_IMAGE);
+		await pullImage(REDIS_IMAGE);
 		const started = await startContainerWithRandomPort((hostPort) =>
 			docker.createContainer({
 				Image: REDIS_IMAGE,


### PR DESCRIPTION
## Why

`test-packages-adapters` has been hanging indefinitely on `main` — the last run sat in progress for over an hour with no redis or memcached test output at all, blocking every downstream job.

The cause is `ensureImage()`, added in d151956. It probes the daemon with `docker.getImage(x).inspect()` before deciding whether to pull. That call never settles on the CI runner, so the redis/memcached `beforeAll` hung forever — which is why those tests never printed rather than failing.

The db container tests (`mongo`, `mysql`, `postgres`) were untouched by that commit, still call `pullImage()` directly, and have never hung. That's the tell.

## What

- Drop `ensureImage()`; KV tests call `pullImage()` directly, same as the db container tests. A pull against an image the daemon already has is a cheap no-op, so the probe bought nothing.
- Swap `redis:7.4-alpine` for `valkey/valkey:8-alpine`.
- Cap `test-packages-adapters` at `timeout-minutes: 15` so a stalled docker call fails fast instead of burning a runner for hours.

## Testing

Cold local run (images removed first): 6 pass, 0 fail across both KV files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)