### PR TITLE
fix(docker): copy testing/e2e/package.json for frozen lockfile install

### DIFF
--- a/docker/admin/Dockerfile
+++ b/docker/admin/Dockerfile
@@ -71,6 +71,7 @@ COPY packages/blocks/package.json packages/blocks/package.json
 COPY packages/common/package.json packages/common/package.json
 COPY packages/components/package.json packages/components/package.json
 COPY packages/lib/package.json packages/lib/package.json
+COPY testing/e2e/package.json testing/e2e/package.json
 COPY scripts/setup-hooks.ts scripts/setup-hooks.ts
 
 RUN bun install --frozen-lockfile

--- a/docker/kit/Dockerfile
+++ b/docker/kit/Dockerfile
@@ -73,6 +73,7 @@ COPY packages/blocks/package.json packages/blocks/package.json
 COPY packages/common/package.json packages/common/package.json
 COPY packages/components/package.json packages/components/package.json
 COPY packages/lib/package.json packages/lib/package.json
+COPY testing/e2e/package.json testing/e2e/package.json
 COPY scripts/setup-hooks.ts scripts/setup-hooks.ts
 
 RUN bun install --frozen-lockfile

--- a/docker/worker-compiled/Dockerfile
+++ b/docker/worker-compiled/Dockerfile
@@ -69,6 +69,7 @@ COPY packages/blocks/package.json packages/blocks/package.json
 COPY packages/common/package.json packages/common/package.json
 COPY packages/components/package.json packages/components/package.json
 COPY packages/lib/package.json packages/lib/package.json
+COPY testing/e2e/package.json testing/e2e/package.json
 COPY scripts/setup-hooks.ts scripts/setup-hooks.ts
 
 RUN bun install --frozen-lockfile


### PR DESCRIPTION
## Summary
- `testing/e2e` is declared as a workspace in root `package.json`, but no Dockerfile's `deps` stage copied `testing/e2e/package.json`, so `bun install --frozen-lockfile` failed with `Workspace not found "testing/e2e"` in every image build (kit, admin, worker-compiled).
- Adds `COPY testing/e2e/package.json testing/e2e/package.json` to all three Dockerfiles' deps stages, alongside the other workspace manifests.
- Second, independent bug found while verifying the fix with a real `docker build`: `bun run build` (invoked by every Dockerfile after `bun install`) also failed, in `apps/web`, on a genuine `next build` type-check error unrelated to the lockfile. `whereConditionSchema`'s `attribute`/`value` had become a tagged `{ kind, value }` union (column vs literal), but the db block settings panels (`delete.tsx`, `getAll.tsx`, `getSingle.tsx`, `update.tsx`) still passed those tagged objects straight through to `ConditionsEditor`, which expects flat `string | number | boolean`. Fixed by unwrapping `.value` on read and re-tagging (`column` for lhs, `literal` for rhs) on write — the same approach `apps/portal`'s `serializeDbConditions`/`parseDbConditions` already use for the current db block settings panels.

## Test plan
- [x] Reproduced the lockfile failure by simulating the `deps` stage COPY list in an isolated dir and running `bun install --frozen-lockfile` — failed with `Workspace not found "testing/e2e"`; fix resolved it.
- [x] `bun run --cwd apps/web build` and full `bun run build` (all 4 workspace build tasks) pass after the `apps/web` fix.
- [x] Built `docker/worker-compiled/Dockerfile` end-to-end locally (`docker build`) — succeeded.
- [x] Built `docker/kit/Dockerfile` end-to-end locally (`docker build`, all 3 stages: deps → build → production) — succeeded. Test images removed afterward (`docker rmi`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)