### PR TITLE
fix(web): match ConditionsEditor's flat lhs/rhs to the tagged where-condition shape

### DIFF
--- a/apps/web/src/components/editor/blocks/builtin/database/delete.tsx
+++ b/apps/web/src/components/editor/blocks/builtin/database/delete.tsx
@@ -59,8 +59,8 @@ export function DeleteBlockDataSettingsPanel(props: {
   ) {
     updateBlockData(props.blockId, {
       conditions: value.map((x) => ({
-        attribute: x.lhs,
-        value: x.rhs,
+        attribute: { kind: "column" as const, value: x.lhs },
+        value: { kind: "literal" as const, value: x.rhs },
         operator: x.operator,
         chain: x.chain,
       })),
@@ -92,8 +92,8 @@ export function DeleteBlockDataSettingsPanel(props: {
           conditions={
             props.blockData.conditions.map((condition) => ({
               ...condition,
-              lhs: condition.attribute,
-              rhs: condition.value,
+              lhs: condition.attribute.value,
+              rhs: condition.value.value,
             })) ?? []
           }
           onChange={onConditionsChange}

--- a/apps/web/src/components/editor/blocks/builtin/database/getAll.tsx
+++ b/apps/web/src/components/editor/blocks/builtin/database/getAll.tsx
@@ -86,8 +86,8 @@ export function GetAllBlockDataSettingsPanel(props: {
   ) {
     updateBlockData(props.blockId, {
       conditions: value.map((x) => ({
-        attribute: x.lhs,
-        value: x.rhs,
+        attribute: { kind: "column" as const, value: x.lhs },
+        value: { kind: "literal" as const, value: x.rhs },
         operator: x.operator,
         chain: x.chain,
       })),
@@ -258,8 +258,8 @@ export function GetAllBlockDataSettingsPanel(props: {
           conditions={
             props.blockData.conditions.map((condition) => ({
               ...condition,
-              lhs: condition.attribute,
-              rhs: condition.value,
+              lhs: condition.attribute.value,
+              rhs: condition.value.value,
             })) ?? []
           }
           ignoreOperators={["is_empty", "is_not_empty"]}

--- a/apps/web/src/components/editor/blocks/builtin/database/getSingle.tsx
+++ b/apps/web/src/components/editor/blocks/builtin/database/getSingle.tsx
@@ -77,8 +77,8 @@ export function GetSingleFromDBSettingsPanel(props: {
   ) {
     updateBlockData(props.blockId, {
       conditions: value.map((x) => ({
-        attribute: x.lhs,
-        value: x.rhs,
+        attribute: { kind: "column" as const, value: x.lhs },
+        value: { kind: "literal" as const, value: x.rhs },
         operator: x.operator,
         chain: x.chain,
       })),
@@ -172,8 +172,8 @@ export function GetSingleFromDBSettingsPanel(props: {
           conditions={
             props.blockData.conditions.map((condition) => ({
               ...condition,
-              lhs: condition.attribute,
-              rhs: condition.value,
+              lhs: condition.attribute.value,
+              rhs: condition.value.value,
             })) ?? []
           }
           ignoreOperators={["is_empty", "is_not_empty"]}

--- a/apps/web/src/components/editor/blocks/builtin/database/update.tsx
+++ b/apps/web/src/components/editor/blocks/builtin/database/update.tsx
@@ -75,8 +75,8 @@ export function UpdateBlockDataSettingsPanel(props: {
 	) {
 		updateBlockData(props.blockId, {
 			conditions: value.map((x) => ({
-				attribute: x.lhs,
-				value: x.rhs,
+				attribute: { kind: "column" as const, value: x.lhs },
+				value: { kind: "literal" as const, value: x.rhs },
 				operator: x.operator,
 				chain: x.chain,
 			})),
@@ -154,8 +154,8 @@ export function UpdateBlockDataSettingsPanel(props: {
 					conditions={
 						props.blockData.conditions.map((condition) => ({
 							...condition,
-							lhs: condition.attribute,
-							rhs: condition.value,
+							lhs: condition.attribute.value,
+							rhs: condition.value.value,
 						})) ?? []
 					}
 					ignoreOperators={["is_empty", "is_not_empty"]}


### PR DESCRIPTION
## Summary
Found while verifying #222 (the `bun.lock`/Docker fix) with a real `docker build`: even after fixing the frozen-lockfile install, every Dockerfile still failed later at `bun run build`, on a genuine `next build` type-check error in `apps/web` unrelated to the lockfile.

`whereConditionSchema`'s `attribute`/`value` became a tagged `{ kind, value }` union (column vs literal) in `packages/blocks/builtin/db/schema.ts`, but 4 db block settings panels still passed those tagged objects straight through to the legacy `ConditionsEditor`, which expects flat `string | number | boolean`:
- `apps/web/src/components/editor/blocks/builtin/database/delete.tsx`
- `apps/web/src/components/editor/blocks/builtin/database/getAll.tsx`
- `apps/web/src/components/editor/blocks/builtin/database/getSingle.tsx`
- `apps/web/src/components/editor/blocks/builtin/database/update.tsx`

Fixed by unwrapping `.value` on read and re-tagging (`column` for lhs, `literal` for rhs) on write — the same approach `apps/portal`'s `serializeDbConditions`/`parseDbConditions` (`apps/portal/src/components/canvas/panel/blocks/db/conditions.ts`) already use for the current db block settings panels.

## Test plan
- [x] `bun run --cwd apps/web build` passes (was failing with a type error in `delete.tsx` before the fix).
- [x] Full `bun run build` (all 4 workspace build tasks: web, portal, server, ai-gateway) passes.
- [x] Built `docker/kit/Dockerfile` end-to-end locally (`docker build`, all 3 stages) — succeeded. Test image removed afterward.
- [x] Pre-commit hook (lint, secret scan, fta analysis, unit tests) passed clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)