### PR TITLE
feat(server): per-suite config resolution with overrides

### DIFF
--- a/apps/server/src/loaders/integrationsLoader.ts
+++ b/apps/server/src/loaders/integrationsLoader.ts
@@ -5,7 +5,7 @@ import {
 	CHAN_ON_INTEGRATION_CHANGE,
 	subscribeToChannel,
 } from "../db/redis";
-import { getAppConfig, getProjectAppConfig } from "./appconfigLoader";
+import { getProjectAppConfig } from "./appconfigLoader";
 import { parsePostgresUrl } from "../lib/parsers/postgres";
 import { parseMysqlUrl } from "../lib/parsers/mysql";
 import { parseMongoUrl } from "../lib/parsers/mongodb";
@@ -118,125 +118,125 @@ export async function loadIntegrations() {
 	});
 }
 
-async function loadFromDB() {
-	const integrations = await db.select().from(integrationsEntity);
-	for (let integration of integrations) {
-		const group = integration.group!;
-		const variant = integration.variant!;
-		let config: any = null!;
-		if (integration.group === integrationsGroupSchema.enum.database) {
-			if (integration.variant === databaseVariantSchema.enum.PostgreSQL) {
-				config = mapIntegrationToPgConnectionData(
-					integration.projectId!,
-					integration.config as any,
-				);
-			} else if (variant === databaseVariantSchema.enum.MySQL) {
-				config = mapIntegrationToMysqlConnectionData(
-					integration.projectId!,
-					integration.config as any,
-				);
-			} else if (variant === databaseVariantSchema.enum.MongoDB) {
-				config = mapIntegrationToMongoConnectionData(
-					integration.projectId!,
-					integration.config as any,
-				);
-			}
-			dbIntegrationsCache[integration.id] = config;
-		} else if (
-			integration.group === integrationsGroupSchema.enum.observability
-		) {
-			// normalized so rows still carrying the old "Open Telemetry Logs" name
-			// resolve to the same adapter
-			const observabilityVariant = normalizeObservabilityVariant(variant);
-			if (
-				observabilityVariant === observabilityVariantSchema.enum["Open Telemetry"]
-			) {
-				config = OpenTelemetryLogs.ExtractConnectionInfo(
-					integration.config as any,
-					getProjectAppConfig(integration.projectId!),
-				);
-			} else if (
-				observabilityVariant === observabilityVariantSchema.enum["Loki"]
-			) {
-				config = LokiLogger.extractConnectionInfo(
-					integration.config as any,
-					getProjectAppConfig(integration.projectId!),
-				);
-			}
-			observabilityIntegrationsCache[integration.id] = config;
-		} else if (integration.group === integrationsGroupSchema.enum.kv) {
-			const appConfigMap = convertObjectToMap(
-				getProjectAppConfig(integration.projectId!),
-			);
-			if (integration.variant === kvVariantSchema.enum.Redis) {
-				config = RedisIntegration.ExtractConnectionInfo(
-					integration.config as any,
-					appConfigMap,
-				);
-			} else if (integration.variant === kvVariantSchema.enum.Memcached) {
-				config = MemcachedIntegration.ExtractConnectionInfo(
-					integration.config as any,
-					appConfigMap,
-				);
-			}
-			kvIntegrationsCache[integration.id] = config;
-		} else if (integration.group === integrationsGroupSchema.enum.ai) {
-			const appConfigMap = convertObjectToMap(
-				getProjectAppConfig(integration.projectId!),
-			);
-			if (integration.variant === aiVariantSchema.enum.Anthropic) {
-				config = AnthropicIntegration.ExtractConnectionInfo(
-					integration.config as any,
-					appConfigMap,
-				);
-			} else if (integration.variant === aiVariantSchema.enum.Gemini) {
-				config = GeminiIntegration.ExtractConnectionInfo(
-					integration.config as any,
-					appConfigMap,
-				);
-			} else if (integration.variant === aiVariantSchema.enum.OpenAI) {
-				config = OpenAIIntegration.ExtractConnectionInfo(
-					integration.config as any,
-					appConfigMap,
-				);
-			} else if (integration.variant === aiVariantSchema.enum.Mistral) {
-				config = MistralIntegration.ExtractConnectionInfo(
-					integration.config as any,
-					appConfigMap,
-				);
-			} else if (
-				integration.variant === aiVariantSchema.enum["OpenAI Compatible"]
-			) {
-				config = OpenAICompatibleIntegration.ExtractConnectionInfo(
-					integration.config as any,
-					appConfigMap,
-				);
-			}
-			aiIntegrationsCache[integration.id] = config;
-		}
-		if (config) {
-			// the cached variant is what IntegrationFactory switches on, so it has to
-			// be the current name even when the row still stores the old one
-			config["variant"] =
-				group === integrationsGroupSchema.enum.observability
-					? normalizeObservabilityVariant(variant)
-					: variant;
-			config["group"] = group;
-			config[OWNER_KEY] = integration.projectId ?? null;
-			if (group === integrationsGroupSchema.enum.database) {
-				if (variant === databaseVariantSchema.enum.PostgreSQL) {
-					config["dbType"] = "pg";
-				} else if (variant === databaseVariantSchema.enum.MySQL) {
-					config["dbType"] = "mysql";
-				} else if (variant === databaseVariantSchema.enum.MongoDB) {
-					config["dbType"] = "mongo";
-				}
-			}
-		}
+export type IntegrationRow = {
+	id: string;
+	group: string | null;
+	variant: string | null;
+	config: unknown;
+	projectId: string | null;
+};
+
+/** the cache a group's resolved config belongs in, or undefined for an unknown group */
+export function cacheForGroup(group: string | null) {
+	switch (group) {
+		case integrationsGroupSchema.enum.database:
+			return dbIntegrationsCache;
+		case integrationsGroupSchema.enum.observability:
+			return observabilityIntegrationsCache;
+		case integrationsGroupSchema.enum.kv:
+			return kvIntegrationsCache;
+		case integrationsGroupSchema.enum.ai:
+			return aiIntegrationsCache;
+		default:
+			return undefined;
 	}
 }
 
-function convertObjectToMap(config: Record<string, any>) {
+/**
+ * One row -> the connection config the runtime caches, with `cfg:` references
+ * expanded from `appConfig`.
+ *
+ * `appConfig` is a parameter, not a cache read, so a caller holding overridden
+ * values (the test runner) resolves against those instead of the live ones.
+ */
+export function resolveIntegrationConfig(
+	integration: IntegrationRow,
+	appConfig: Record<string, any> | undefined,
+): any {
+	const group = integration.group!;
+	const variant = integration.variant!;
+	const raw = integration.config as any;
+	let config: any = null!;
+
+	if (group === integrationsGroupSchema.enum.database) {
+		if (variant === databaseVariantSchema.enum.PostgreSQL) {
+			config = mapIntegrationToConnectionData(appConfig, raw, parsePostgresUrl);
+		} else if (variant === databaseVariantSchema.enum.MySQL) {
+			config = mapIntegrationToConnectionData(appConfig, raw, parseMysqlUrl);
+		} else if (variant === databaseVariantSchema.enum.MongoDB) {
+			config = mapIntegrationToConnectionData(appConfig, raw, parseMongoUrl);
+		}
+	} else if (group === integrationsGroupSchema.enum.observability) {
+		// normalized so rows still carrying the old "Open Telemetry Logs" name
+		// resolve to the same adapter
+		const observabilityVariant = normalizeObservabilityVariant(variant);
+		if (
+			observabilityVariant === observabilityVariantSchema.enum["Open Telemetry"]
+		) {
+			config = OpenTelemetryLogs.ExtractConnectionInfo(raw, appConfig!);
+		} else if (observabilityVariant === observabilityVariantSchema.enum["Loki"]) {
+			config = LokiLogger.extractConnectionInfo(raw, appConfig!);
+		}
+	} else if (group === integrationsGroupSchema.enum.kv) {
+		const appConfigMap = convertObjectToMap(appConfig);
+		if (variant === kvVariantSchema.enum.Redis) {
+			config = RedisIntegration.ExtractConnectionInfo(raw, appConfigMap);
+		} else if (variant === kvVariantSchema.enum.Memcached) {
+			config = MemcachedIntegration.ExtractConnectionInfo(raw, appConfigMap);
+		}
+	} else if (group === integrationsGroupSchema.enum.ai) {
+		const appConfigMap = convertObjectToMap(appConfig);
+		if (variant === aiVariantSchema.enum.Anthropic) {
+			config = AnthropicIntegration.ExtractConnectionInfo(raw, appConfigMap);
+		} else if (variant === aiVariantSchema.enum.Gemini) {
+			config = GeminiIntegration.ExtractConnectionInfo(raw, appConfigMap);
+		} else if (variant === aiVariantSchema.enum.OpenAI) {
+			config = OpenAIIntegration.ExtractConnectionInfo(raw, appConfigMap);
+		} else if (variant === aiVariantSchema.enum.Mistral) {
+			config = MistralIntegration.ExtractConnectionInfo(raw, appConfigMap);
+		} else if (variant === aiVariantSchema.enum["OpenAI Compatible"]) {
+			config = OpenAICompatibleIntegration.ExtractConnectionInfo(
+				raw,
+				appConfigMap,
+			);
+		}
+	}
+
+	if (config) {
+		// the cached variant is what IntegrationFactory switches on, so it has to
+		// be the current name even when the row still stores the old one
+		config["variant"] =
+			group === integrationsGroupSchema.enum.observability
+				? normalizeObservabilityVariant(variant)
+				: variant;
+		config["group"] = group;
+		config[OWNER_KEY] = integration.projectId ?? null;
+		if (group === integrationsGroupSchema.enum.database) {
+			if (variant === databaseVariantSchema.enum.PostgreSQL) {
+				config["dbType"] = "pg";
+			} else if (variant === databaseVariantSchema.enum.MySQL) {
+				config["dbType"] = "mysql";
+			} else if (variant === databaseVariantSchema.enum.MongoDB) {
+				config["dbType"] = "mongo";
+			}
+		}
+	}
+	return config;
+}
+
+async function loadFromDB() {
+	const integrations = await db.select().from(integrationsEntity);
+	for (const integration of integrations) {
+		const cache = cacheForGroup(integration.group);
+		if (!cache) continue;
+		cache[integration.id] = resolveIntegrationConfig(
+			integration,
+			getProjectAppConfig(integration.projectId!),
+		);
+	}
+}
+
+function convertObjectToMap(config: Record<string, any> | undefined) {
 	let map = new Map<string, string>();
 	for (let key in config) {
 		map.set(key, config[key]);
@@ -244,80 +244,35 @@ function convertObjectToMap(config: Record<string, any>) {
 	return map;
 }
 
-function mapIntegrationToPgConnectionData(
-	projectId: string,
-	config: Record<string, string>,
-) {
-	let connectionDetails = {} as any;
-	if (config.source === "url") {
-		config.url = config.url.toString().startsWith("cfg:")
-			? (getAppConfig(projectId, config.url.slice(4)) as string)
-			: config.url;
-		const parsed = parsePostgresUrl(config.url);
-		if (parsed) {
-			connectionDetails = parsed;
-		} else {
-			logger.info("Failed to load integration");
-		}
-	} else {
-		for (let key in config) {
-			const value = config[key];
-			connectionDetails[key] = value.toString().startsWith("cfg:")
-				? getAppConfig(projectId, value.slice(4))
-				: value;
-		}
-	}
-	return connectionDetails;
+/** `cfg:KEY` -> the app config value, anything else unchanged */
+function expand(appConfig: Record<string, any> | undefined, value: unknown) {
+	const text = value?.toString() ?? "";
+	return text.startsWith("cfg:") ? appConfig?.[text.slice(4)] : value;
 }
 
-function mapIntegrationToMysqlConnectionData(
-	projectId: string,
+/**
+ * A database row -> connection details, `cfg:` references expanded.
+ *
+ * The expansion goes into a NEW object and is never written back onto `config`.
+ * The test runner resolves the same row twice — once against the live app
+ * config, once against the overridden one — and a row whose `cfg:` reference had
+ * been overwritten by the first pass would silently keep the first pass's value.
+ */
+function mapIntegrationToConnectionData(
+	appConfig: Record<string, any> | undefined,
 	config: Record<string, string>,
+	parseUrl: (url: string) => any,
 ) {
-	let connectionDetails = {} as any;
+	const connectionDetails = {} as any;
 	if (config.source === "url") {
-		config.url = config.url.toString().startsWith("cfg:")
-			? (getAppConfig(projectId, config.url.slice(4)) as string)
-			: config.url;
-		const parsed = parseMysqlUrl(config.url);
-		if (parsed) {
-			connectionDetails = parsed;
-		} else {
-			logger.info("Failed to load integration");
-		}
-	} else {
-		for (let key in config) {
-			const value = config[key];
-			connectionDetails[key] = value.toString().startsWith("cfg:")
-				? getAppConfig(projectId, value.slice(4))
-				: value;
-		}
+		// missing cfg key -> "" -> no match -> logged, rather than a TypeError
+		const parsed = parseUrl(String(expand(appConfig, config.url) ?? ""));
+		if (parsed) return parsed;
+		logger.info("Failed to load integration");
+		return connectionDetails;
 	}
-	return connectionDetails;
-}
-
-function mapIntegrationToMongoConnectionData(
-	projectId: string,
-	config: Record<string, string>,
-) {
-	let connectionDetails = {} as any;
-	if (config.source === "url") {
-		config.url = config.url.toString().startsWith("cfg:")
-			? (getAppConfig(projectId, config.url.slice(4)) as string)
-			: config.url;
-		const parsed = parseMongoUrl(config.url);
-		if (parsed) {
-			connectionDetails = parsed;
-		} else {
-			logger.info("Failed to load integration");
-		}
-	} else {
-		for (let key in config) {
-			const value = config[key];
-			connectionDetails[key] = value.toString().startsWith("cfg:")
-				? getAppConfig(projectId, value.slice(4))
-				: value;
-		}
+	for (const key in config) {
+		connectionDetails[key] = expand(appConfig, config[key]);
 	}
 	return connectionDetails;
 }

--- a/apps/server/src/modules/testRunner/resolve.ts
+++ b/apps/server/src/modules/testRunner/resolve.ts
@@ -1,0 +1,92 @@
+import { eq, isNull, or } from "drizzle-orm";
+import { db } from "../../db";
+import { integrationsEntity } from "../../db/schema";
+import { integrationsGroupSchema } from "../../api/v1/integrations/schemas";
+import { getProjectAppConfig } from "../../loaders/appconfigLoader";
+import { resolveIntegrationConfig } from "../../loaders/integrationsLoader";
+import { projectSettingsCache } from "../../loaders/projectSettingsLoader";
+import type { ProjectConfigPayload } from "../compiler/artifacts";
+
+export type SuiteOverrides = {
+	appConfigOverrides?: Array<{ key: string; value: string }> | null;
+	integrationOverrides?: Array<{ existingId: string; newId: string }> | null;
+};
+
+/**
+ * Everything a test suite's child process needs, resolved in the parent — the
+ * child starts cold and `setupContextVars` runs no queries, it reads caches.
+ * The shape is `ProjectConfigPayload` so the child hydrates through the same
+ * loaders the compiled worker uses.
+ *
+ * ORDER IS LOAD-BEARING: app config overrides are applied FIRST, then
+ * integrations are resolved against the overridden map. Integration configs
+ * hold `cfg:` references, so resolving them first expands the pre-swap values
+ * and the override silently does nothing — a test quietly pointed at the real
+ * database instead of the sandbox one.
+ *
+ * Integrations are re-resolved from their rows rather than copied out of the
+ * live cache for exactly that reason: the cached ones were already expanded
+ * against the un-overridden config.
+ *
+ * No ownership check here — the orchestrator calls `assertOverridesOwned`
+ * before dispatch (#219). Only this project's rows (and unowned ones) are
+ * loaded, so an override naming a foreign integration throws below.
+ */
+export async function resolveSuiteConfig(
+	projectId: string,
+	overrides: SuiteOverrides,
+): Promise<ProjectConfigPayload> {
+	// 1. app config first.
+	const appConfig = { ...(getProjectAppConfig(projectId) ?? {}) };
+	for (const { key, value } of overrides.appConfigOverrides ?? []) {
+		appConfig[key] = value;
+	}
+
+	// 2. integrations second, against the overridden map.
+	const rows = await db
+		.select()
+		.from(integrationsEntity)
+		.where(
+			or(
+				eq(integrationsEntity.projectId, projectId),
+				// unowned rows are usable by every project (see ownsIntegration)
+				isNull(integrationsEntity.projectId),
+			),
+		);
+
+	const payload: ProjectConfigPayload = {
+		appConfig,
+		dbIntegrations: {},
+		kvIntegrations: {},
+		observabilityIntegrations: {},
+		aiIntegrations: {},
+		projectSettings: projectSettingsCache[projectId] ?? {},
+	};
+	const byGroup: Record<string, Record<string, any>> = {
+		[integrationsGroupSchema.enum.database]: payload.dbIntegrations,
+		[integrationsGroupSchema.enum.kv]: payload.kvIntegrations,
+		[integrationsGroupSchema.enum.observability]:
+			payload.observabilityIntegrations,
+		[integrationsGroupSchema.enum.ai]: payload.aiIntegrations,
+	};
+
+	for (const row of rows) {
+		const bucket = byGroup[row.group ?? ""];
+		if (!bucket) continue;
+		const config = resolveIntegrationConfig(row, appConfig);
+		if (config) bucket[row.id] = config;
+	}
+
+	// 3. integration swaps, on the freshly resolved configs.
+	for (const { existingId, newId } of overrides.integrationOverrides ?? []) {
+		const bucket = Object.values(byGroup).find((b) => b[newId]);
+		if (!bucket) {
+			throw new Error(
+				`Integration override target "${newId}" was not found for this project`,
+			);
+		}
+		bucket[existingId] = bucket[newId];
+	}
+
+	return payload;
+}

--- a/apps/server/src/modules/testRunner/tests/fixtures/hydrateChild.ts
+++ b/apps/server/src/modules/testRunner/tests/fixtures/hydrateChild.ts
@@ -1,0 +1,41 @@
+/**
+ * Child half of resolve.integration.spec.ts.
+ *
+ * Starts cold — no database, no NATS, no artifacts — so everything it knows
+ * comes from the IPC payload. That is the whole claim `resolveSuiteConfig` has
+ * to make good on: the payload survives the process boundary and hydrates the
+ * same loaders the compiled worker uses.
+ */
+import {
+	getAppConfig,
+	hydrateAppConfig,
+} from "../../../../loaders/appconfigLoader";
+import {
+	dbIntegrationsCache,
+	hydrateIntegrations,
+} from "../../../../loaders/integrationsLoader";
+
+process.on("message", (message: any) => {
+	if (message?.type !== "bootstrap") return;
+	const { projectId, payload } = message;
+
+	hydrateAppConfig(projectId, payload.appConfig);
+	hydrateIntegrations(projectId, {
+		db: payload.dbIntegrations,
+		kv: payload.kvIntegrations,
+		observability: payload.observabilityIntegrations,
+		ai: payload.aiIntegrations,
+	});
+
+	const integration = dbIntegrationsCache["pg-1"];
+	process.send?.({
+		type: "hydrated",
+		// read back through the same accessors the runtime uses, not the payload
+		pgUrl: getAppConfig(projectId, "PG_URL"),
+		host: integration?.host,
+		database: integration?.database,
+		dbType: integration?.dbType,
+	});
+});
+
+process.send?.({ type: "ready" });

--- a/apps/server/src/modules/testRunner/tests/resolve.integration.spec.ts
+++ b/apps/server/src/modules/testRunner/tests/resolve.integration.spec.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, mock } from "bun:test";
+import { fileURLToPath } from "node:url";
+
+/**
+ * The unit spec proves the resolution rules. This one proves the result is
+ * actually usable by a child process: spawn one, ship the payload over IPC,
+ * and have it hydrate and read the values back through the runtime accessors.
+ *
+ * Catches what an in-process assertion cannot — a payload that is not
+ * structured-cloneable, or a loader that only works when the module cache was
+ * already warm.
+ */
+const PROJECT = "p1";
+// fileURLToPath, not .pathname — the latter yields "/D:/..." on Windows
+const CHILD = fileURLToPath(
+	new URL("./fixtures/hydrateChild.ts", import.meta.url),
+);
+
+const rows = [
+	{
+		id: "pg-1",
+		group: "database",
+		variant: "PostgreSQL",
+		config: { source: "url", url: "cfg:PG_URL" },
+		projectId: PROJECT,
+	},
+];
+
+mock.module("../../../db", () => ({
+	db: {
+		select: () => ({ from: () => ({ where: async () => rows }) }),
+	},
+}));
+
+const { resolveSuiteConfig } = await import("../resolve");
+const { hydrateAppConfig } = await import("../../../loaders/appconfigLoader");
+
+hydrateAppConfig(PROJECT, {
+	PG_URL: "postgres://real:real@prod-host:5432/proddb",
+});
+
+/** spawn, bootstrap, wait for the child's answer, always reap it */
+async function hydrateInChild(payload: unknown) {
+	const { promise, resolve, reject } = Promise.withResolvers<any>();
+	const child = Bun.spawn([process.execPath, CHILD], {
+		stdout: "inherit",
+		stderr: "inherit",
+		ipc(message: any) {
+			if (message?.type === "ready") {
+				child.send({ type: "bootstrap", projectId: PROJECT, payload });
+			} else if (message?.type === "hydrated") {
+				resolve(message);
+			}
+		},
+		onExit(_p, code) {
+			// resolve() already settled it on the happy path
+			reject(new Error(`child exited early (code=${code})`));
+		},
+	});
+
+	const timer = setTimeout(
+		() => reject(new Error("child never reported back")),
+		15_000,
+	);
+	try {
+		return await promise;
+	} finally {
+		clearTimeout(timer);
+		child.kill();
+	}
+}
+
+describe("resolveSuiteConfig over IPC", () => {
+	it("hydrates a cold child with the overridden config", async () => {
+		const payload = await resolveSuiteConfig(PROJECT, {
+			appConfigOverrides: [
+				{ key: "PG_URL", value: "postgres://test:test@test-host:5432/testdb" },
+			],
+		});
+
+		// plain data only — a class instance or a function would throw here, and
+		// would throw on child.send() too
+		expect(() => structuredClone(payload)).not.toThrow();
+
+		const result = await hydrateInChild(payload);
+		expect(result.host).toBe("test-host");
+		expect(result.database).toBe("testdb");
+		expect(result.dbType).toBe("pg");
+		expect(result.pgUrl).toBe("postgres://test:test@test-host:5432/testdb");
+	}, 20_000);
+});

--- a/apps/server/src/modules/testRunner/tests/resolve.spec.ts
+++ b/apps/server/src/modules/testRunner/tests/resolve.spec.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, mock } from "bun:test";
+
+const PROJECT = "p1";
+
+// One postgres integration whose url is a `cfg:` reference — the whole point of
+// the ordering rule is that this reference sees the overridden value.
+const rows = [
+	{
+		id: "pg-1",
+		group: "database",
+		variant: "PostgreSQL",
+		config: { source: "url", url: "cfg:PG_URL" },
+		projectId: PROJECT,
+	},
+	{
+		id: "pg-2",
+		group: "database",
+		variant: "PostgreSQL",
+		config: {
+			source: "url",
+			url: "postgres://sand:sand@sandbox:5432/sanddb",
+		},
+		projectId: PROJECT,
+	},
+];
+
+mock.module("../../../db", () => ({
+	db: {
+		select: () => ({ from: () => ({ where: async () => rows }) }),
+	},
+}));
+
+const { resolveSuiteConfig } = await import("../resolve");
+const { hydrateAppConfig } = await import("../../../loaders/appconfigLoader");
+
+hydrateAppConfig(PROJECT, {
+	PG_URL: "postgres://real:real@prod-host:5432/proddb",
+});
+
+describe("resolveSuiteConfig", () => {
+	it("resolves integrations against the OVERRIDDEN app config", async () => {
+		const payload = await resolveSuiteConfig(PROJECT, {
+			appConfigOverrides: [
+				{ key: "PG_URL", value: "postgres://test:test@test-host:5432/testdb" },
+			],
+		});
+
+		// Flip the order (integrations before app configs) and this is "prod-host".
+		expect(payload.dbIntegrations["pg-1"].host).toBe("test-host");
+		expect(payload.dbIntegrations["pg-1"].database).toBe("testdb");
+		expect(payload.appConfig.PG_URL).toBe(
+			"postgres://test:test@test-host:5432/testdb",
+		);
+	});
+
+	it("resolves to the live config when there are no overrides", async () => {
+		const payload = await resolveSuiteConfig(PROJECT, {});
+		expect(payload.dbIntegrations["pg-1"].host).toBe("prod-host");
+		expect(payload.dbIntegrations["pg-1"].dbType).toBe("pg");
+	});
+
+	it("swaps an integration id for the override target", async () => {
+		const payload = await resolveSuiteConfig(PROJECT, {
+			integrationOverrides: [{ existingId: "pg-1", newId: "pg-2" }],
+		});
+		expect(payload.dbIntegrations["pg-1"].host).toBe("sandbox");
+	});
+
+	it("throws when the override target does not exist", async () => {
+		expect(
+			resolveSuiteConfig(PROJECT, {
+				integrationOverrides: [{ existingId: "pg-1", newId: "nope" }],
+			}),
+		).rejects.toThrow(/"nope" was not found/);
+	});
+});


### PR DESCRIPTION
Closes #216. Part 2 of 6 of the sandboxed test suite runner.

## Why

Test suites will run in an ephemeral child process (#217). That child starts cold — `setupContextVars` runs no queries, it reads module caches that are empty in a fresh process. So the parent has to resolve app config and integrations up front and ship them over IPC.

## What

**`apps/server/src/modules/testRunner/resolve.ts`** — `resolveSuiteConfig(projectId, overrides)`.

Returns a `ProjectConfigPayload` rather than the `ResolvedIntegration[]` the issue sketched. That is the shape the compiled worker already hydrates from (`hydrateAppConfig` + `hydrateIntegrations`), so the child needs no new loader and no second hydration path.

### Order is load-bearing

1. app config overrides applied **first**
2. integrations resolved **second**, against the overridden map

Integration configs hold `cfg:` references. Resolving them first expands pre-swap values and the override silently does nothing — a test quietly pointed at the real database instead of the sandbox one. The ordering test fails if the two steps are swapped.

For the same reason integrations are **re-resolved from their rows** instead of copied out of `dbIntegrationsCache`: the cached ones were already expanded against the un-overridden config, so copying would make the rule unenforceable.

### Loader refactor

Per-row resolution extracted into the exported `resolveIntegrationConfig(row, appConfig)` in `integrationsLoader.ts`. The app config map is a parameter now instead of a `getAppConfig` cache read; `loadFromDB` passes the live one, the test runner passes the overridden one. No new decryption — `loadFromDB` behaviour is unchanged.

### Bug fixed on the way

The three near-identical `mapIntegrationTo{Pg,Mysql,Mongo}ConnectionData` helpers wrote the expanded url back onto the row (`config.url = ...`), destroying the `cfg:` reference. Harmless when a row is resolved once; fatal here, where the same row is resolved twice (live config, then overridden). Collapsed into one `mapIntegrationToConnectionData(appConfig, config, parseUrl)` that expands into a new object. A missing cfg key now logs "Failed to load integration" instead of throwing a TypeError on `undefined.match`.

## Tests

`tests/resolve.spec.ts` — ordering (fails if flipped), no-override identity, id swap, unknown override target throws.

`tests/resolve.integration.spec.ts` + `tests/fixtures/hydrateChild.ts` — **spawns a real child process**, ships the payload over IPC, child hydrates through the production loaders and reads values back through `getAppConfig` / `dbIntegrationsCache`. Proves three things the in-process spec cannot:

- the payload is structured-cloneable — no class instances, no functions, so `child.send()` cannot fail on it
- the loaders work with a **cold** module cache
- a child with **no Postgres and no NATS** builds its entire view from the message

Pre-commit green on both commits: lint 9/9, 662 pass / 0 fail across 121 files.

## Notes for #217

The spawn mechanism is now verified end to end, but the child here is a test stub — it only hydrates. The real `testExecutionProcess.ts` (instantiate, run, watchdog, rlimits) is still #217. One gotcha worth carrying over: `new URL(...).pathname` yields `/D:/...` on Windows and the child dies with `Module not found` — use `fileURLToPath`.

## Out of scope

No ownership check here — `assertOverridesOwned` is called by the orchestrator in #219, in the parent, before dispatch. Only this project's rows (and unowned ones) are loaded, so an override naming a foreign integration throws.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pjR2Xuyxu5UTUDFo9smSd
