### PR TITLE
feat(server): ephemeral child process for test suite execution

### DIFF
--- a/apps/server/src/modules/compiler/service.ts
+++ b/apps/server/src/modules/compiler/service.ts
@@ -227,7 +227,12 @@ export async function publishProjectConfig(projectId: string) {
 	await putArtifact(projectConfigKey(projectId), artifact);
 }
 
-async function loadGraph(parent: CanvasParent) {
+/**
+ * Exported for the test runner: a suite runs the canvas as it is saved right
+ * now, not the last published artifact, so it compiles the graph itself rather
+ * than reading the artifact store.
+ */
+export async function loadGraph(parent: CanvasParent) {
 	const blockRows = await db
 		.select()
 		.from(blocksEntity)

--- a/apps/server/src/modules/testRunner/compile.ts
+++ b/apps/server/src/modules/testRunner/compile.ts
@@ -1,0 +1,82 @@
+import { compileGraph } from "@fluxify/blocks";
+import { logger } from "@fluxify/common";
+import { eq } from "drizzle-orm";
+import { db } from "../../db";
+import {
+	customBlocksListEntity,
+	projectsEntity,
+	routesEntity,
+} from "../../db/schema";
+import { loadGraph } from "../compiler/service";
+
+/**
+ * The compiled graph a suite runs, built from the database on every run.
+ *
+ * Deliberately not read from the artifact store: that holds the last published
+ * compile, so editing a route and pressing Run would test the previously
+ * deployed version. A suite tests what is saved.
+ */
+export async function compileSuiteRoute(routeId: string) {
+	const [route] = await db
+		.select({
+			id: routesEntity.id,
+			method: routesEntity.method,
+			path: routesEntity.path,
+			projectId: routesEntity.projectId,
+			projectName: projectsEntity.name,
+			bodySchema: routesEntity.bodySchema,
+			querySchema: routesEntity.querySchema,
+			paramsSchema: routesEntity.paramsSchema,
+			timeoutSeconds: routesEntity.timeoutSeconds,
+		})
+		.from(routesEntity)
+		.leftJoin(projectsEntity, eq(routesEntity.projectId, projectsEntity.id))
+		.where(eq(routesEntity.id, routeId));
+
+	if (!route) throw new Error(`Route ${routeId} not found`);
+
+	const { blocks, edges } = await loadGraph({ type: "route", id: routeId });
+	const { source } = compileGraph(blocks, edges);
+	return {
+		route,
+		source,
+		customBlocks: await compileProjectCustomBlocks(route.projectId!),
+	};
+}
+
+/**
+ * Every custom block in the project, compiled and ready to register.
+ *
+ * A route that calls one only runs if the library holds it, and the child has no
+ * database to fetch a missing one from.
+ *
+ * ponytail: compiles the whole project rather than just the blocks this route
+ * reaches. Walk the graph for invocations if a large project makes a run slow.
+ */
+async function compileProjectCustomBlocks(projectId: string) {
+	const rows = await db
+		.select({ id: customBlocksListEntity.id, name: customBlocksListEntity.name })
+		.from(customBlocksListEntity)
+		.where(eq(customBlocksListEntity.projectId, projectId));
+
+	const compiled: Array<{ name: string; source: string }> = [];
+	for (const row of rows) {
+		try {
+			const { blocks, edges } = await loadGraph({
+				type: "custom_block",
+				id: row.id,
+			});
+			// `param:` placeholders resolve from the invocation, same as the compiler
+			const { source } = compileGraph(blocks, edges, { asCustomBlock: true });
+			compiled.push({ name: row.name, source });
+		} catch (error) {
+			// one unfinished block must not stop the suite; the route only fails if
+			// it actually calls this one, and then it fails with a clear message
+			logger.error(
+				`[test-runner] skipping custom block ${row.name}: ${String(error)}`,
+				"TEST_RUNNER",
+			);
+		}
+	}
+	return compiled;
+}

--- a/apps/server/src/modules/testRunner/spawn.ts
+++ b/apps/server/src/modules/testRunner/spawn.ts
@@ -1,0 +1,107 @@
+import { fileURLToPath } from "node:url";
+import { executionRuntimeEnvironment } from "../requestRouter/executionEnvironment";
+import type { TestBootstrap, TestChildMessage, TestResult } from "./types";
+
+/** fileURLToPath, not .pathname — the latter yields "/D:/..." on Windows */
+const ENTRY = fileURLToPath(
+	new URL("./testExecutionProcess.ts", import.meta.url),
+);
+
+/** how long past the route's own timeout the child gets to report before it is killed */
+const WATCHDOG_GRACE_MS = 2_000;
+
+/** an env override is only usable as an rlimit if it is a positive integer */
+function positiveInt(value: string | undefined, fallback: number) {
+	const parsed = Number(value);
+	return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+/**
+ * The argv that starts one suite child.
+ *
+ * The route is user-authored code, so the descriptor and address-space caps are
+ * applied by the shell that becomes the process rather than trusted to it.
+ * `ulimit` is POSIX-only, so Windows spawns bun directly — dev has to work there
+ * too, it just runs without the caps.
+ *
+ * The interpreter and entry path are passed as shell *arguments* ("$0"/"$1"),
+ * never interpolated into the script: a path with a space or a quote would
+ * otherwise change what the shell runs.
+ */
+export function spawnCommand(
+	entry: string,
+	platform: string = process.platform,
+	env: NodeJS.ProcessEnv = process.env,
+) {
+	if (platform === "win32") return [process.execPath, "--smol", entry];
+	const fds = positiveInt(env.TEST_RUNNER_MAX_FDS, 256);
+	const vmemKb = positiveInt(env.TEST_RUNNER_MAX_VMEM_KB, 1_048_576);
+	return [
+		"/bin/sh",
+		"-c",
+		`ulimit -n ${fds}; ulimit -v ${vmemKb}; exec "$0" --smol "$1"`,
+		process.execPath,
+		entry,
+	];
+}
+
+/**
+ * Runs one suite in a fresh process and resolves with its raw response.
+ *
+ * The timeout is unconditional — `experimental.workerTimeouts` governs live
+ * traffic, not tests. A killed child reports `timedOut` with a duration and
+ * nothing else: partial results are not streamed out of a process that is about
+ * to die, they would describe a run that never finished.
+ */
+export async function runSuiteInChild(
+	bootstrap: TestBootstrap,
+	entry = ENTRY,
+): Promise<TestResult> {
+	const { promise, resolve } = Promise.withResolvers<TestResult>();
+	const startedAt = Date.now();
+	let settled = false;
+	const finish = (result: TestResult) => {
+		if (settled) return;
+		settled = true;
+		resolve(result);
+	};
+
+	const child = Bun.spawn(spawnCommand(entry), {
+		env: executionRuntimeEnvironment(),
+		stdout: "inherit",
+		stderr: "inherit",
+		ipc(message: TestChildMessage) {
+			if (message?.type === "ready") {
+				child.send({ type: "bootstrap", bootstrap });
+			} else if (message?.type === "result") {
+				finish(message.result);
+			}
+		},
+		onExit(_child, code, signal) {
+			// a crash, an OOM kill, or a hit rlimit — the happy path already settled
+			finish({
+				ok: false,
+				error: `test process exited before reporting (code=${code}, signal=${signal})`,
+				durationMs: Date.now() - startedAt,
+			});
+		},
+	});
+
+	const watchdog = setTimeout(() => {
+		finish({
+			ok: false,
+			timedOut: true,
+			error: `suite timed out after ${bootstrap.timeoutMs}ms`,
+			durationMs: Date.now() - startedAt,
+		});
+		child.kill();
+	}, bootstrap.timeoutMs + WATCHDOG_GRACE_MS);
+
+	try {
+		return await promise;
+	} finally {
+		// an uncleared timer keeps the admin process alive for the whole timeout
+		clearTimeout(watchdog);
+		child.kill();
+	}
+}

--- a/apps/server/src/modules/testRunner/spawn.ts
+++ b/apps/server/src/modules/testRunner/spawn.ts
@@ -19,10 +19,19 @@ function positiveInt(value: string | undefined, fallback: number) {
 /**
  * The argv that starts one suite child.
  *
- * The route is user-authored code, so the descriptor and address-space caps are
- * applied by the shell that becomes the process rather than trusted to it.
- * `ulimit` is POSIX-only, so Windows spawns bun directly — dev has to work there
- * too, it just runs without the caps.
+ * The route is user-authored code, so the descriptor cap is applied by the shell
+ * that becomes the process rather than trusted to it. `ulimit` is POSIX-only, so
+ * Windows spawns bun directly — dev has to work there too, it just runs without
+ * the cap.
+ *
+ * There is deliberately no `ulimit -v`. It caps *address space*, which JSC uses
+ * as a reservation, not as memory: a plain `bun` process peaks at ~129 GB of
+ * virtual address space. Any value low enough to be a real cap aborts the
+ * runtime with SIGABRT before user code runs (`MemoryExhaustion` — every child
+ * died this way), and any value above the reservation caps nothing.
+ * `BUN_JSC_forceRAMSize` is only a GC heuristic and does not bound the heap
+ * either. The memory ceiling is the container's `mem_limit`, which is a real
+ * cgroup limit — see the `admin` service in docker/production/docker-compose.yml.
  *
  * The interpreter and entry path are passed as shell *arguments* ("$0"/"$1"),
  * never interpolated into the script: a path with a space or a quote would
@@ -35,11 +44,10 @@ export function spawnCommand(
 ) {
 	if (platform === "win32") return [process.execPath, "--smol", entry];
 	const fds = positiveInt(env.TEST_RUNNER_MAX_FDS, 256);
-	const vmemKb = positiveInt(env.TEST_RUNNER_MAX_VMEM_KB, 1_048_576);
 	return [
 		"/bin/sh",
 		"-c",
-		`ulimit -n ${fds}; ulimit -v ${vmemKb}; exec "$0" --smol "$1"`,
+		`ulimit -n ${fds}; exec "$0" --smol "$1"`,
 		process.execPath,
 		entry,
 	];

--- a/apps/server/src/modules/testRunner/testExecutionProcess.ts
+++ b/apps/server/src/modules/testRunner/testExecutionProcess.ts
@@ -1,0 +1,106 @@
+import { instantiateCompiled, registerCompiledCustomBlock } from "@fluxify/blocks";
+import { hydrateAppConfig } from "../../loaders/appconfigLoader";
+import { hydrateIntegrations } from "../../loaders/integrationsLoader";
+import { hydrateProjectSettings } from "../../loaders/projectSettingsLoader";
+import { executionRuntimeEnvironment } from "../requestRouter/executionEnvironment";
+import { setBlocksExecutor } from "../requestRouter/executor";
+import { createHttpContext } from "../requestRouter/httpContext";
+import { executeRouteInternal } from "../requestRouter/service";
+import type {
+	TestBootstrap,
+	TestBootstrapMessage,
+	TestChildMessage,
+	TestResult,
+} from "./types";
+
+/**
+ * Ephemeral child that runs exactly one test suite and exits.
+ *
+ * Never reused. A second suite in the same process would inherit module state,
+ * open database clients and timers from the first — the precise thing that makes
+ * a test pass for the wrong reason.
+ *
+ * It holds no system credentials: no master encryption key, no NATS, no admin
+ * database url. The route's own integration connection details do arrive in the
+ * bootstrap, because the route cannot run without them.
+ */
+process.env = executionRuntimeEnvironment();
+process.argv = [];
+process.execArgv = [];
+
+process.on("message", (message: TestBootstrapMessage) => {
+	if (message?.type !== "bootstrap") return;
+	void runSuite(message.bootstrap);
+});
+
+async function runSuite(boot: TestBootstrap) {
+	const startedAt = Date.now();
+	try {
+		// the caches are the runtime's only config source — executeRouteInternal
+		// queries nothing, and the suite's overrides are already baked in here
+		hydrateAppConfig(boot.projectId, boot.config.appConfig);
+		hydrateIntegrations(boot.projectId, {
+			db: boot.config.dbIntegrations,
+			kv: boot.config.kvIntegrations,
+			observability: boot.config.observabilityIntegrations,
+			ai: boot.config.aiIntegrations,
+		});
+		hydrateProjectSettings(boot.projectId, boot.config.projectSettings);
+
+		// custom blocks first: a route that invokes one needs it in the library
+		for (const block of boot.customBlocks) {
+			registerCompiledCustomBlock(block.name, block.source);
+		}
+
+		const run = instantiateCompiled(boot.source);
+		setBlocksExecutor((_target, context) => run(context, context.requestBody));
+
+		// a real Hono-shaped context, so header and cookie writes made by the route
+		// are captured instead of dropped — header assertions read them back
+		const ctx = createHttpContext(
+			new Request(`http://test.local${boot.request.path}`, {
+				method: boot.request.method,
+				headers: boot.request.headers,
+			}),
+		);
+
+		const response = await executeRouteInternal(
+			{
+				id: boot.route.id,
+				projectId: boot.projectId,
+				projectName: boot.route.projectName,
+				bodySchema: boot.route.bodySchema,
+				querySchema: boot.route.querySchema,
+				paramsSchema: boot.route.paramsSchema,
+				// the engine's in-band stall budget, from the same number the
+				// watchdog uses, so neither can silently outlive the other
+				timeoutSeconds: boot.timeoutMs / 1000,
+			},
+			boot.request,
+			ctx as any,
+		);
+
+		report({
+			ok: true,
+			status: response.status,
+			data: response.data,
+			headers: Object.fromEntries(ctx.responseHeaders),
+			durationMs: Date.now() - startedAt,
+		});
+	} catch (error) {
+		report({
+			ok: false,
+			error: error instanceof Error ? error.message : String(error),
+			durationMs: Date.now() - startedAt,
+		});
+	}
+}
+
+function report(result: TestResult) {
+	process.send?.({ type: "result", result } satisfies TestChildMessage);
+	// let the ipc write flush before tearing the process down; the parent kills
+	// the child regardless, so this is only about exiting cleanly
+	setTimeout(() => process.exit(0), 0);
+}
+
+process.send?.({ type: "ready" } satisfies TestChildMessage);

--- a/apps/server/src/modules/testRunner/tests/spawn.spec.ts
+++ b/apps/server/src/modules/testRunner/tests/spawn.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "bun:test";
+import { spawnCommand } from "../spawn";
+
+describe("spawnCommand", () => {
+	it("applies fd and address-space caps through the shell on posix", () => {
+		const argv = spawnCommand("/app/entry.ts", "linux", {});
+		expect(argv[0]).toBe("/bin/sh");
+		expect(argv[2]).toBe(
+			`ulimit -n 256; ulimit -v 1048576; exec "$0" --smol "$1"`,
+		);
+		// interpreter and entry are arguments, never interpolated into the script
+		expect(argv[3]).toBe(process.execPath);
+		expect(argv[4]).toBe("/app/entry.ts");
+	});
+
+	it("takes the env overrides for both caps", () => {
+		const argv = spawnCommand("/app/entry.ts", "linux", {
+			TEST_RUNNER_MAX_FDS: "64",
+			TEST_RUNNER_MAX_VMEM_KB: "524288",
+		});
+		expect(argv[2]).toContain("ulimit -n 64;");
+		expect(argv[2]).toContain("ulimit -v 524288;");
+	});
+
+	it("ignores an override that is not a positive integer", () => {
+		// the value lands in a shell script, so anything but a number is refused
+		const argv = spawnCommand("/app/entry.ts", "linux", {
+			TEST_RUNNER_MAX_FDS: "0; rm -rf /",
+			TEST_RUNNER_MAX_VMEM_KB: "-1",
+		});
+		expect(argv[2]).toContain("ulimit -n 256;");
+		expect(argv[2]).toContain("ulimit -v 1048576;");
+		expect(argv[2]).not.toContain("rm -rf");
+	});
+
+	it("skips the shell on windows — ulimit does not exist there", () => {
+		const argv = spawnCommand("C:\\app\\entry.ts", "win32", {});
+		expect(argv).toEqual([process.execPath, "--smol", "C:\\app\\entry.ts"]);
+	});
+});

--- a/apps/server/src/modules/testRunner/tests/spawn.spec.ts
+++ b/apps/server/src/modules/testRunner/tests/spawn.spec.ts
@@ -2,34 +2,36 @@ import { describe, expect, it } from "bun:test";
 import { spawnCommand } from "../spawn";
 
 describe("spawnCommand", () => {
-	it("applies fd and address-space caps through the shell on posix", () => {
+	it("applies the descriptor cap through the shell on posix", () => {
 		const argv = spawnCommand("/app/entry.ts", "linux", {});
 		expect(argv[0]).toBe("/bin/sh");
-		expect(argv[2]).toBe(
-			`ulimit -n 256; ulimit -v 1048576; exec "$0" --smol "$1"`,
-		);
+		expect(argv[2]).toBe(`ulimit -n 256; exec "$0" --smol "$1"`);
 		// interpreter and entry are arguments, never interpolated into the script
 		expect(argv[3]).toBe(process.execPath);
 		expect(argv[4]).toBe("/app/entry.ts");
 	});
 
-	it("takes the env overrides for both caps", () => {
+	it("never sets an address-space limit", () => {
+		// `ulimit -v` aborts JSC before user code runs — a plain bun process
+		// reserves ~129 GB of address space. The container's mem_limit is the cap.
+		expect(spawnCommand("/app/entry.ts", "linux", {})[2]).not.toContain(
+			"ulimit -v",
+		);
+	});
+
+	it("takes the env override for the descriptor cap", () => {
 		const argv = spawnCommand("/app/entry.ts", "linux", {
 			TEST_RUNNER_MAX_FDS: "64",
-			TEST_RUNNER_MAX_VMEM_KB: "524288",
 		});
 		expect(argv[2]).toContain("ulimit -n 64;");
-		expect(argv[2]).toContain("ulimit -v 524288;");
 	});
 
 	it("ignores an override that is not a positive integer", () => {
 		// the value lands in a shell script, so anything but a number is refused
 		const argv = spawnCommand("/app/entry.ts", "linux", {
 			TEST_RUNNER_MAX_FDS: "0; rm -rf /",
-			TEST_RUNNER_MAX_VMEM_KB: "-1",
 		});
 		expect(argv[2]).toContain("ulimit -n 256;");
-		expect(argv[2]).toContain("ulimit -v 1048576;");
 		expect(argv[2]).not.toContain("rm -rf");
 	});
 

--- a/apps/server/src/modules/testRunner/tests/suiteExecution.integration.spec.ts
+++ b/apps/server/src/modules/testRunner/tests/suiteExecution.integration.spec.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "bun:test";
+import { BlockTypes, compileGraph } from "@fluxify/blocks";
+import { runSuiteInChild } from "../spawn";
+import type { TestBootstrap } from "../types";
+
+/**
+ * The real thing: a graph compiled the way the compiler compiles it, run in a
+ * spawned child that has no database, no NATS and no artifact store — only the
+ * bootstrap. An in-process assertion cannot catch a payload that will not cross
+ * the process boundary, or a loader that only works when the cache was warm.
+ */
+const block = (id: string, type: string, data: any = {}) => ({
+	id,
+	type,
+	position: { x: 0, y: 0 },
+	data,
+});
+const edge = (from: string, to: string) => ({
+	id: `${from}-${to}`,
+	from,
+	to,
+	// "source" is the default handle the compiler follows; anything else is a
+	// conditional branch and the graph reads as unconnected
+	fromHandle: "source",
+	toHandle: "source",
+});
+
+function bootstrap(source: string, overrides: Partial<TestBootstrap> = {}) {
+	return {
+		suiteRunId: "run-1",
+		projectId: "p1",
+		route: { id: "r1", projectName: "demo" },
+		source,
+		customBlocks: [],
+		config: {
+			appConfig: { GREETING: "hello" },
+			dbIntegrations: {},
+			kvIntegrations: {},
+			observabilityIntegrations: {},
+			aiIntegrations: {},
+			projectSettings: {},
+		},
+		request: {
+			method: "GET",
+			path: "/demo",
+			headers: { "x-caller": "suite" },
+			query: { who: "world" },
+			params: {},
+			body: null,
+		},
+		timeoutMs: 10_000,
+		...overrides,
+	} satisfies TestBootstrap;
+}
+
+describe("runSuiteInChild", () => {
+	it("runs a compiled route and returns its response, config and headers", async () => {
+		const { source } = compileGraph(
+			[
+				block("1", BlockTypes.entrypoint),
+				block("2", BlockTypes.jsrunner, {
+					value: `setHeader("x-suite", "ok");
+						return { greeting: getConfig("GREETING"), who: getQueryParam("who"), caller: getHeader("x-caller") };`,
+				}),
+				block("3", BlockTypes.response, { httpCode: "200" }),
+			],
+			[edge("1", "2"), edge("2", "3")] as any,
+		);
+
+		const result = await runSuiteInChild(bootstrap(source));
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(Number(result.status)).toBe(200);
+		expect(result.data).toEqual({
+			// proves the bootstrap config hydrated the loader cache in a cold process
+			greeting: "hello",
+			who: "world",
+			caller: "suite",
+		});
+		// the route's header writes are captured, not dropped — header assertions
+		// in the parent read these back
+		expect(result.headers["x-suite"]).toBe("ok");
+	}, 30_000);
+
+	it("kills a route that never returns and reports it as a timeout", async () => {
+		// hand-written compiled source: a graph cannot express "never return", and
+		// this is the shape instantiateCompiled runs either way
+		const result = await runSuiteInChild(
+			bootstrap("await new Promise(() => {});", { timeoutMs: 1_000 }),
+		);
+
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.timedOut).toBe(true);
+		expect(result.durationMs).toBeGreaterThanOrEqual(1_000);
+	}, 30_000);
+
+	it("reports a route that throws without taking the parent down", async () => {
+		const result = await runSuiteInChild(
+			bootstrap(`throw new Error("boom");`),
+		);
+
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error).toContain("boom");
+		expect(result.timedOut).toBeUndefined();
+	}, 30_000);
+});

--- a/apps/server/src/modules/testRunner/types.ts
+++ b/apps/server/src/modules/testRunner/types.ts
@@ -1,0 +1,54 @@
+import type { ProjectConfigPayload } from "../compiler/artifacts";
+
+/**
+ * Everything the ephemeral suite process is given, in one message.
+ *
+ * The child starts cold: no database, no NATS, no artifact store, no
+ * credentials. Anything missing here is not reachable from inside it — which is
+ * the point. `config` is the payload `resolveSuiteConfig` produced, so the
+ * suite's overrides are already applied and no override travels separately.
+ */
+export type TestBootstrap = {
+	suiteRunId: string;
+	projectId: string;
+	route: {
+		id: string;
+		projectName: string;
+		bodySchema?: unknown;
+		querySchema?: unknown;
+		paramsSchema?: unknown;
+	};
+	/** compiled graph source — the child never sees blocks or edges */
+	source: string;
+	customBlocks: Array<{ name: string; source: string }>;
+	config: ProjectConfigPayload;
+	request: {
+		method: string;
+		path: string;
+		headers: Record<string, string>;
+		query: Record<string, string | string[]>;
+		params: Record<string, string>;
+		body: unknown;
+	};
+	/** route.timeoutSeconds * 1000 — drives both the in-band stopper and the watchdog */
+	timeoutMs: number;
+};
+
+/**
+ * The raw response, never a verdict. Assertions are evaluated in the parent so
+ * there is one implementation of them, not two.
+ */
+export type TestResult =
+	| {
+			ok: true;
+			status: number;
+			data: unknown;
+			headers: Record<string, string>;
+			durationMs: number;
+	  }
+	| { ok: false; error: string; timedOut?: boolean; durationMs: number };
+
+export type TestBootstrapMessage = { type: "bootstrap"; bootstrap: TestBootstrap };
+export type TestChildMessage =
+	| { type: "ready" }
+	| { type: "result"; result: TestResult };

--- a/docker/production/docker-compose.yml
+++ b/docker/production/docker-compose.yml
@@ -60,9 +60,11 @@ services:
       ENABLE_ADMIN: "true"
       ENABLE_BUILTIN_WORKER: "false"
     # Test suites run user-authored code in child processes of THIS container,
-    # so it needs a ceiling. Per-child rlimits are set at spawn time; these are
-    # the backstop for a fleet of them. A Dockerfile cannot set either — ulimits
-    # and memory are runtime settings.
+    # so it needs a ceiling. Descriptors are also capped per child at spawn time
+    # and this is the backstop for a fleet of them; memory is capped ONLY here.
+    # A per-child `ulimit -v` is not an option — it bounds address space, which
+    # JSC reserves ~129 GB of, so any usable value aborts Bun at startup.
+    # A Dockerfile cannot set either — ulimits and memory are runtime settings.
     ulimits:
       nofile:
         soft: 4096


### PR DESCRIPTION
Part 3 of 6 — sandboxed test suite runner. Refs #217.

## Why

Test suites execute in the admin API's own process today. A route with an infinite loop, a leaked global or a crash takes the admin server down with it, and module state bleeds from one suite into the next. This adds the machinery to run one suite in a process that is spawned, used once, and killed.

## What

| file | role |
|---|---|
| `testRunner/types.ts` | `TestBootstrap` / `TestResult` messages |
| `testRunner/compile.ts` | route + project custom blocks → compiled source |
| `testRunner/testExecutionProcess.ts` | the child entry point |
| `testRunner/spawn.ts` | `runSuiteInChild` + `spawnCommand` (fd cap, watchdog) |
| `compiler/service.ts` | `loadGraph` exported |

### The child reuses `executeRouteInternal`

The issue sketched the child rebuilding the execution context the way `initCompiledRuntime` and `setupContextVars` do. It doesn't — it hydrates the loader caches from the bootstrap and then calls the existing `executeRouteInternal`. Schema validation, context vars, the db factory and `ctx.stopper.duration` all come along, and there is no second copy of any of it to drift.

Two consequences worth calling out:

- **Overrides never cross the wire.** `resolveSuiteConfig` (#216) already applied them to the payload, so no `RequestOverrides` is passed and `assertOverridesOwned` stays a parent-side concern.
- **Response headers now exist.** The child builds a real `createHttpContext`, so `setHeader`/`setCookie` writes made by the route are captured and returned as `result.headers`. `runner.ts:91` hardcoded `resHeaders = {}`, which meant every `header` assertion has been silently evaluating against `undefined`.

### Custom blocks

The issue's bootstrap carried only `source`. A route that invokes a custom block would have thrown in the child — the interpreted path supports them today, so shipping without would have been a regression. `compile.ts` compiles the project's custom blocks alongside the route and the child calls `registerCompiledCustomBlock` before instantiating. A block that fails to compile is logged and skipped rather than failing the run, matching `compiledRuntime.addCustomBlock`.

### Source comes from the database, not the artifact store

`compileSuiteRoute` calls `loadGraph` + `compileGraph` per run. Reading the published artifact would have been cheaper but would test the last *deployed* graph — edit a route, press Run, and you'd be testing the old version.

### Resource limits — `ulimit -v` had to be dropped

The issue prescribed `ulimit -n` **and** `ulimit -v 1048576`. The descriptor cap ships as specified. The address-space cap does not, and the first CI run is why: **every** child aborted on Linux with `MemoryExhaustion … SIGABRT` before user code ran. It passed locally only because Windows skips the shell wrapper entirely.

Measured in `oven/bun:1`:

| observation | value |
|---|---|
| `VmPeak` of a plain `bun` process | **135,363,680 kB ≈ 129 GB** |
| `ulimit -v 1048576` + trivial script | survives |
| `ulimit -v 1048576` + real import graph | SIGABRT |
| `BUN_JSC_forceRAMSize=256MB` + 8M allocations | 519 MB RSS — not a cap |

`ulimit -v` bounds *address space*, which JSC uses as a reservation rather than as memory. Any value low enough to be a real cap kills the runtime at startup; any value above the reservation caps nothing. `BUN_JSC_forceRAMSize` steers GC and does not bound the heap, so there is no drop-in replacement knob — shipping one would have been theatre.

Memory is therefore capped by the container's `mem_limit: 2g` on the `admin` service, which is a real cgroup limit and already landed in #221. The comment there now says so explicitly instead of implying a per-child memory limit exists.

`spawnCommand` wraps the child in `/bin/sh -c "ulimit -n 256; exec \"$0\" --smol \"$1\""`, env-overridable, and an override that isn't a positive integer is refused — the value lands in a shell script. The interpreter and entry path are passed as `$0`/`$1` rather than interpolated, so a path with a space or a quote can't change what runs. Windows skips the wrapper and still spawns.

### Watchdog

`setTimeout(timeoutMs + 2s)` → `child.kill()`, reported as `timedOut` with a duration and nothing else. No partial assertion detail is streamed out of a process about to die. The timer is cleared in a `finally`, so it can't hold the admin process open for the whole timeout. Unconditional — `experimental.workerTimeouts` governs live traffic, not tests.

## Tests

`tests/spawn.spec.ts` — argv shape: fd cap applied, env override honoured, a non-integer override (`"0; rm -rf /"`) refused, no `ulimit -v` ever emitted, win32 bypasses the shell.

`tests/suiteExecution.integration.spec.ts` — real spawns, no mocks:
- a graph compiled with `compileGraph` runs in the cold child; `getConfig`/`getQueryParam`/`getHeader` all resolve from the bootstrap and `setHeader` comes back in `result.headers`
- `await new Promise(() => {})` → killed, `timedOut: true`, parent unaffected
- a throwing route → `ok: false` carrying the message

## Out of scope

Nothing is wired to `/test-suites/run` — `runSuiteAssertions` still runs in-process. Orchestration and persistence are #219, concurrency limiting #218, endpoints #220.

## Notes for #219

Edge handles are `"source"`, not `"input"/"output"`. A wrong handle compiles to an unconnected graph that returns `"NO RESULT"` with no error.

`compile.ts` compiles every custom block in the project rather than just the ones the route reaches (marked `ponytail:`) — narrow it by walking the graph for invocations if a large project makes runs slow.

## Verification

`bun test apps/server/src/modules/testRunner` — 14 pass / 0 fail. Pre-commit chain green: lint 9/9, 670 pass / 0 fail across 123 files. `test-apps-server-unit` passes on Linux CI, which is the run that matters here — the spawn path only executes the shell wrapper there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pjR2Xuyxu5UTUDFo9smSd
