### PR TITLE
feat(server): concurrency pool for test suite workers

### DIFF
--- a/apps/server/src/modules/testRunner/pool.ts
+++ b/apps/server/src/modules/testRunner/pool.ts
@@ -1,0 +1,124 @@
+import { readFileSync } from "node:fs";
+import os from "node:os";
+import { join } from "node:path";
+
+/** an env override is only usable as a limit if it is a positive integer */
+function positiveInt(value: string | undefined, fallback: number) {
+	const parsed = Number(value);
+	return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+/**
+ * Memory headroom in MB — the container's cgroup cap when there is one, the host
+ * otherwise.
+ *
+ * `os.freemem()` on its own is useless here: it reads the HOST, not the cgroup.
+ * Measured in `docker run --rm -m 2g oven/bun:1` — cap 2048 MB, `os.freemem()`
+ * 10049 MB of 11804 MB "total". A 512 MB threshold against that never trips, so
+ * the back-off tier would be dead code in the one place it matters. Suite
+ * children are children of the admin process, so they count against the same
+ * cgroup: this is the number that decides whether the container gets OOM-killed.
+ *
+ * cgroup v1 (`memory.limit_in_bytes`) is not read. v2 has been the Docker
+ * default since 20.10, and v1 lands on the same host fallback as a Windows dev
+ * box. `root` is a parameter only so the parsing can be tested off Linux.
+ */
+export function headroomMb(root = "/sys/fs/cgroup") {
+	try {
+		const max = readFileSync(join(root, "memory.max"), "utf8").trim();
+		// "max" means uncapped — the host figure is the honest one then
+		if (max !== "max") {
+			const used = readFileSync(join(root, "memory.current"), "utf8");
+			return (Number(max) - Number(used)) / 1048576;
+		}
+	} catch {
+		// no cgroupfs: not Linux, cgroup v1, or running outside a container
+	}
+	return os.freemem() / 1048576;
+}
+
+export type PoolOptions = {
+	max?: number;
+	min?: number;
+	thresholdMb?: number;
+	/** injectable for tests; production reads the cgroup */
+	freeMb?: () => number;
+};
+
+export type Pool = {
+	/** runs `task` once a slot is free and always gives the slot back */
+	run<T>(task: () => Promise<T>): Promise<T>;
+	/** tasks running right now */
+	readonly active: number;
+	/** tasks waiting for a slot */
+	readonly queued: number;
+	/** the ceiling as of this moment — it moves with available memory */
+	readonly limit: number;
+};
+
+/**
+ * A counting semaphore. It takes an async task and resolves with its result; it
+ * knows nothing about test suites, child processes or the database, which is
+ * what keeps it testable without any of them.
+ */
+export function createPool(overrides: PoolOptions = {}): Pool {
+	const max =
+		overrides.max ?? positiveInt(process.env.TEST_RUNNER_MAX_WORKERS, 4);
+	const configuredMin =
+		overrides.min ?? positiveInt(process.env.TEST_RUNNER_MIN_WORKERS, 2);
+	// a min above max would raise concurrency exactly when memory is short
+	const min = Math.min(configuredMin, max);
+	const thresholdMb =
+		overrides.thresholdMb ??
+		positiveInt(process.env.TEST_RUNNER_FREEMEM_THRESHOLD_MB, 512);
+	const freeMb = overrides.freeMb ?? headroomMb;
+
+	let active = 0;
+	const waiting: Array<() => void> = [];
+	const limit = () => (freeMb() < thresholdMb ? min : max);
+
+	function release() {
+		active--;
+		// re-read the limit on every release rather than once at startup: the
+		// point of the tier is to back off while the box is already under load
+		while (active < limit() && waiting.length > 0) {
+			active++;
+			waiting.shift()?.();
+		}
+	}
+
+	return {
+		get active() {
+			return active;
+		},
+		get queued() {
+			return waiting.length;
+		},
+		get limit() {
+			return limit();
+		},
+		async run<T>(task: () => Promise<T>): Promise<T> {
+			if (active < limit()) {
+				active++;
+			} else {
+				const { promise, resolve } = Promise.withResolvers<void>();
+				waiting.push(resolve);
+				// release() takes the slot on our behalf before waking us, so the
+				// count cannot be raced by another caller in between
+				await promise;
+			}
+			try {
+				return await task();
+			} finally {
+				// every exit path, or a leaked slot shrinks the pool permanently
+				release();
+			}
+		},
+	};
+}
+
+/**
+ * One pool for the whole admin process, deliberately not one per run: two people
+ * each launching a fleet have to share the slots, or the cap is not a cap.
+ */
+export const testWorkerPool = createPool();

--- a/apps/server/src/modules/testRunner/tests/pool.spec.ts
+++ b/apps/server/src/modules/testRunner/tests/pool.spec.ts
@@ -1,0 +1,192 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createPool, headroomMb } from "../pool";
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 5));
+
+/** plenty of memory, so the pool always picks `max` */
+const roomy = () => 4096;
+
+const ENV_KEYS = [
+	"TEST_RUNNER_MAX_WORKERS",
+	"TEST_RUNNER_MIN_WORKERS",
+	"TEST_RUNNER_FREEMEM_THRESHOLD_MB",
+] as const;
+
+afterEach(() => {
+	for (const key of ENV_KEYS) delete process.env[key];
+});
+
+/** a task that records how many were running at its busiest moment */
+function tracker() {
+	let active = 0;
+	let peak = 0;
+	return {
+		get peak() {
+			return peak;
+		},
+		task: async () => {
+			active++;
+			peak = Math.max(peak, active);
+			await tick();
+			active--;
+		},
+	};
+}
+
+describe("createPool", () => {
+	it("never runs more than the limit at once", async () => {
+		const pool = createPool({ max: 2, min: 2, freeMb: roomy });
+		const seen = tracker();
+
+		await Promise.all(Array.from({ length: 5 }, () => pool.run(seen.task)));
+
+		// exactly 2: it caps at the limit and it actually uses every slot
+		expect(seen.peak).toBe(2);
+		expect(pool.active).toBe(0);
+		expect(pool.queued).toBe(0);
+	});
+
+	it("queues the overflow instead of dropping it", async () => {
+		const pool = createPool({ max: 1, min: 1, freeMb: roomy });
+		let ran = 0;
+		const runs = Array.from({ length: 4 }, () =>
+			pool.run(async () => {
+				await tick();
+				ran++;
+			}),
+		);
+
+		expect(pool.active).toBe(1);
+		expect(pool.queued).toBe(3);
+
+		await Promise.all(runs);
+		expect(ran).toBe(4);
+	});
+
+	it("releases the slot of a task that throws", async () => {
+		const pool = createPool({ max: 1, min: 1, freeMb: roomy });
+		const order: string[] = [];
+
+		const failing = pool.run(async () => {
+			order.push("boom");
+			throw new Error("boom");
+		});
+		const after = pool.run(async () => {
+			order.push("after");
+		});
+
+		await expect(failing).rejects.toThrow("boom");
+		await after;
+
+		// the rejection must not eat the slot — the queue still drains
+		expect(order).toEqual(["boom", "after"]);
+		expect(pool.active).toBe(0);
+	});
+
+	it("resolves with the task's value", async () => {
+		const pool = createPool({ max: 1, min: 1, freeMb: roomy });
+		expect(await pool.run(async () => 42)).toBe(42);
+	});
+
+	it("backs off to the minimum when headroom drops mid-run", async () => {
+		let free = 4096;
+		const pool = createPool({
+			max: 4,
+			min: 1,
+			thresholdMb: 512,
+			freeMb: () => free,
+		});
+		const seen = tracker();
+
+		// runs synchronously, so the queued tasks below are admitted under the
+		// lowered limit — this is the re-read-on-release behaviour
+		const first = pool.run(async () => {
+			free = 100;
+			await tick();
+		});
+		const rest = Array.from({ length: 4 }, () => pool.run(seen.task));
+
+		await Promise.all([first, ...rest]);
+		expect(seen.peak).toBe(1);
+	});
+
+	it("uses the maximum again once headroom recovers", async () => {
+		let free = 100;
+		const pool = createPool({
+			max: 3,
+			min: 1,
+			thresholdMb: 512,
+			freeMb: () => free,
+		});
+		expect(pool.limit).toBe(1);
+
+		free = 4096;
+		expect(pool.limit).toBe(3);
+	});
+
+	it("defaults to 4 / 2 / 512MB", () => {
+		expect(createPool({ freeMb: roomy }).limit).toBe(4);
+		expect(createPool({ freeMb: () => 511 }).limit).toBe(2);
+		expect(createPool({ freeMb: () => 512 }).limit).toBe(4);
+	});
+
+	it("takes the limits from the environment", () => {
+		process.env.TEST_RUNNER_MAX_WORKERS = "7";
+		process.env.TEST_RUNNER_MIN_WORKERS = "3";
+		process.env.TEST_RUNNER_FREEMEM_THRESHOLD_MB = "2048";
+
+		expect(createPool({ freeMb: roomy }).limit).toBe(7);
+		expect(createPool({ freeMb: () => 1024 }).limit).toBe(3);
+	});
+
+	it("ignores env values that are not positive integers", () => {
+		process.env.TEST_RUNNER_MAX_WORKERS = "0";
+		process.env.TEST_RUNNER_MIN_WORKERS = "lots";
+
+		expect(createPool({ freeMb: roomy }).limit).toBe(4);
+		expect(createPool({ freeMb: () => 0 }).limit).toBe(2);
+	});
+
+	it("never lets the minimum exceed the maximum", () => {
+		// otherwise a misconfigured pair raises concurrency exactly when memory
+		// is short
+		expect(createPool({ max: 2, min: 8, freeMb: () => 0 }).limit).toBe(2);
+	});
+});
+
+describe("headroomMb", () => {
+	function cgroup(files: Record<string, string>) {
+		const dir = mkdtempSync(join(tmpdir(), "fluxify-cgroup-"));
+		for (const [name, body] of Object.entries(files)) {
+			writeFileSync(join(dir, name), body);
+		}
+		return dir;
+	}
+
+	it("reports the cgroup's headroom, not the host's", () => {
+		const dir = cgroup({
+			// the shape docker writes for `-m 2g`, trailing newline included
+			"memory.max": "2147483648\n",
+			"memory.current": "1073741824\n",
+		});
+		expect(headroomMb(dir)).toBe(1024);
+	});
+
+	it("falls back to the host when the cgroup is uncapped", () => {
+		const dir = cgroup({ "memory.max": "max\n", "memory.current": "1024\n" });
+		// parsing "max" as a number would give NaN, which fails this assertion
+		expect(headroomMb(dir)).toBeGreaterThan(0);
+	});
+
+	it("falls back to the host when there is no cgroupfs", () => {
+		expect(headroomMb(join(tmpdir(), "fluxify-no-cgroup"))).toBeGreaterThan(0);
+	});
+
+	it("falls back when the cgroup files are only half there", () => {
+		const dir = cgroup({ "memory.max": "2147483648\n" });
+		expect(headroomMb(dir)).toBeGreaterThan(0);
+	});
+});


### PR DESCRIPTION
Closes #218. Part 4 of 6 — sandboxed test suite runner.

## Why

Every suite gets its own child process (#217). Without a cap, a route with 40 suites spawns 40 of them and the admin server falls over. There was no pool, semaphore or queue anywhere in the repo.

## What

New file: `apps/server/src/modules/testRunner/pool.ts`.

A counting semaphore, **global to the admin process** rather than per run — two people each launching a fleet share the slots, or the cap is not a cap. It takes an async task and resolves with its result; it knows nothing about suites, child processes or the database, which is what keeps it testable without any of them. Nothing calls it yet: wiring is #219.

- In-memory queue, no DB-backed jobs. (`sweep.ts` from #215 is what covers a restart losing it.)
- The ceiling is re-read **on every slot release**, not once at startup — the point of the tier is to back off while the box is already under load.
- The slot is released in a `finally`, so success, throw and timeout kill all give it back. A leaked slot shrinks the pool permanently.
- `TEST_RUNNER_MAX_WORKERS` / `TEST_RUNNER_MIN_WORKERS` / `TEST_RUNNER_FREEMEM_THRESHOLD_MB`, defaulting to 4 / 2 / 512. Non-positive-integer values are ignored rather than trusted, and `min` is clamped to `max` so a misconfigured pair cannot raise concurrency exactly when memory is short.

## Deviation from the issue: cgroup headroom, not `os.freemem()`

The issue specified `os.freemem()` with a `ponytail:` note that it reads the host rather than the cgroup. That turned out to be worse than a rough approximation — it makes the whole back-off tier dead code in the one environment it was written for. Measured in `docker run --rm -m 2g oven/bun:1`:

| | |
|---|---|
| `/sys/fs/cgroup/memory.max` | 2147483648 (2 GiB — the real cap) |
| `/sys/fs/cgroup/memory.current` | 2097152 |
| `os.freemem()` | **10049 MB** |
| `os.totalmem()` | 11804 MB |

10 GB "free" against a 512 MB threshold never trips, so the pool would always pick `MAX`. Suite children are children of the admin process and count against the *same* cgroup, so the cgroup figure is the one that decides whether the container gets OOM-killed.

`headroomMb()` reads `memory.max - memory.current` and falls back to `os.freemem()` when there is no cgroupfs — Windows dev boxes, cgroup v1, or running outside a container. cgroup v1 (`memory.limit_in_bytes`) is deliberately not read: v2 has been Docker's default since 20.10 and v1 lands on the same fallback.

Verified end to end against the real file, not a fixture:

```
docker run --rm -m 2g   ... -> headroomMb = 2037 MB | limit = 4
docker run --rm -m 400m ... -> headroomMb =  390 MB | limit = 2
```

The second line is the tier actually firing. With `os.freemem()` both would have read ~10 GB and picked 4.

This also lines up with #217's finding that a per-child `ulimit -v` is unusable with JSC: `mem_limit` is the only real memory cap in this stack, so it is the thing worth measuring against.

## Tests

`tests/pool.spec.ts` — 14 tests, no mocks of the pool itself:

- **limit forced to 2, 5 tasks queued -> a live counter peaks at exactly 2** (asserted on the counter, not on timing), and both slots are actually used
- overflow is queued, not dropped (`active` 1 / `queued` 3), and all 4 tasks run
- a task that throws releases its slot and the queue still drains, in order
- the limit is re-read on release: headroom dropped mid-run pins the rest of the fleet to `min: 1`
- defaults are 4 / 2 / 512, with the threshold boundary checked at 511 and 512
- env overrides apply; `"0"` and `"lots"` fall back to the defaults
- `min` above `max` clamps
- `headroomMb` parses a real docker-shaped cgroup fixture (2 GiB cap, 1 GiB used -> 1024), and falls back on `max`, on a missing directory, and on a half-present pair

`bun test apps/server/src/modules/testRunner` -> 28 pass / 0 fail. `bun run --cwd apps/server lint` clean. Pre-commit: 684 pass / 0 fail across 124 files.

## Out of scope

Spawning (#217, merged), orchestration and persistence (#219). No CPU sampling or event-loop instrumentation — the memory tier is the whole adaptive story.
