### PR TITLE
feat(server): test run orchestration and assertion extraction

### DIFF
--- a/apps/server/src/api/v1/test-suites/runner.ts
+++ b/apps/server/src/api/v1/test-suites/runner.ts
@@ -1,47 +1,27 @@
-import { testSuitesEntity, routesEntity } from "../../../db/schema";
-import { InferSelectModel } from "drizzle-orm";
-import { JsVM } from "@fluxify/lib";
-import { z } from "zod";
-import { assertionSchema } from "./schema";
-import * as requestRouterService from "../../../modules/requestRouter/service";
 import { logger } from "@fluxify/common";
+import type { InferSelectModel } from "drizzle-orm";
+import type { routesEntity, testSuitesEntity } from "../../../db/schema";
+import {
+	buildSuiteRequest,
+	evaluateAssertions,
+	type AssertionType,
+} from "../../../modules/testRunner/assertions";
+import * as requestRouterService from "../../../modules/requestRouter/service";
 
-export type AssertionType = z.infer<typeof assertionSchema>;
+export type { AssertionType };
 
+/**
+ * The legacy in-process runner: the suite executes inside the admin process,
+ * with its credentials and its memory. #220 deletes this and its two endpoints
+ * in favour of `modules/testRunner/runner.ts`, which runs the same suite in a
+ * cold child process.
+ */
 export async function runSuiteAssertions(
 	suite: InferSelectModel<typeof testSuitesEntity>,
 	route: InferSelectModel<typeof routesEntity>,
 	_executeRouteInternal = requestRouterService.executeRouteInternal,
 ) {
-	let finalPath = route.path || "";
-	const pathParams = (suite.routeParams as Record<string, string>) || {};
-
-	Object.entries(pathParams).forEach(([key, value]) => {
-		finalPath = finalPath.replace(
-			`:${key}`,
-			encodeURIComponent(value || `:${key}`),
-		);
-	});
-
-	const queryParams = (suite.queryParams as Record<string, string>) || {};
-	const headers = (suite.headers as Record<string, string>) || {};
-	const method = route.method || "GET";
-
-	// default json
-	const lowerHeaders = Object.keys(headers).reduce(
-		(acc, k) => {
-			acc[k.toLowerCase()] = headers[k];
-			return acc;
-		},
-		{} as Record<string, string>,
-	);
-
-	if (
-		!lowerHeaders["content-type"] &&
-		["POST", "PUT"].includes(method.toUpperCase())
-	) {
-		headers["Content-Type"] = "application/json";
-	}
+	const request = buildSuiteRequest(suite, route);
 
 	const overrides: requestRouterService.RequestOverrides = {
 		integrations: Array.isArray(suite.integrationOverrides)
@@ -52,7 +32,7 @@ export async function runSuiteAssertions(
 			: [],
 	};
 
-	let resStatus: number = 500;
+	let resStatus = 500;
 	let resBody: unknown = null;
 	const startTime = Date.now();
 
@@ -62,18 +42,18 @@ export async function runSuiteAssertions(
 				id: route.id,
 				projectId: route.projectId!,
 				projectName: "", // We might not have this here, but it's okay for testing
-				routeParams: pathParams,
+				routeParams: request.params,
 				bodySchema: route.bodySchema,
 				querySchema: route.querySchema,
 				paramsSchema: route.paramsSchema,
 			},
 			{
-				method: method.toUpperCase(),
-				path: finalPath,
-				headers,
-				query: queryParams,
-				body: suite.body,
-				params: pathParams,
+				method: request.method,
+				path: request.path,
+				headers: request.headers,
+				query: request.query,
+				body: request.body,
+				params: request.params,
 			},
 			undefined,
 			overrides,
@@ -87,133 +67,13 @@ export async function runSuiteAssertions(
 		resBody = { error: e.message };
 	}
 
-	const time = Date.now() - startTime;
-	const resHeaders: Record<string, string> = {}; // executeRouteInternal doesn't currently return headers
-
-	const assertions = (suite.assertions as AssertionType[]) || [];
-	const result = await Promise.all(assertions.map(async (a: AssertionType) => {
-		let actualValue: unknown;
-		let targetDesc = "";
-
-		try {
-			if (a.target === "status") {
-				actualValue = resStatus;
-				targetDesc = "Status";
-			} else if (a.target === "time") {
-				actualValue = time;
-				targetDesc = "Time";
-			} else if (a.target === "header") {
-				actualValue = resHeaders[(a.propertyPath || "").toLowerCase()];
-				targetDesc = `Header(${a.propertyPath})`;
-			} else if (a.target === "body") {
-				// Evaluate dot-notation path
-				if (a.propertyPath) {
-					const parts = a.propertyPath
-						.replace(/\[(\d+)\]/g, ".$1")
-						.split(".")
-						.filter(Boolean);
-					let curr: any = resBody;
-					for (const p of parts) {
-						if (curr === undefined || curr === null) break;
-						curr = curr[p];
-					}
-					actualValue = curr;
-				} else {
-					actualValue = resBody;
-				}
-				targetDesc = `Body(${a.propertyPath || ""})`;
-			} else if (a.target === "customJs") {
-				const vm = new JsVM({
-					fluxify: {
-						request: {
-							path: finalPath,
-							query: queryParams,
-							body: suite.body,
-							headers,
-							params: pathParams,
-						},
-					},
-					body: resBody,
-					headers: resHeaders,
-					status: resStatus,
-				});
-				actualValue = await vm.run(a.customJs || "return true;");
-				targetDesc = "Custom JS";
-			}
-
-			let passed = false;
-			if (a.target === "customJs") {
-				passed = new JsVM({}).truthy(actualValue);
-			}
-
-			const expected = a.expectedValue == null ? "" : String(a.expectedValue);
-			const actualStr = actualValue == null ? "" : String(actualValue);
-
-			if (a.target !== "customJs") {
-				switch (a.operator) {
-					case "eq":
-						passed = actualStr === expected || String(actualValue) === expected;
-						if (a.target === "status" || a.target === "time") {
-							passed = Number(actualValue) === Number(expected);
-						}
-						break;
-					case "neq":
-						passed = actualStr !== expected;
-						if (a.target === "status" || a.target === "time") {
-							passed = Number(actualValue) !== Number(expected);
-						}
-						break;
-					case "lt":
-						passed = Number(actualValue) < Number(expected);
-						break;
-					case "gt":
-						passed = Number(actualValue) > Number(expected);
-						break;
-					case "contains":
-						passed =
-							typeof actualValue === "string"
-								? actualValue.includes(expected)
-								: JSON.stringify(actualValue).includes(expected);
-						break;
-					case "true":
-						passed = actualValue === true || actualStr === "true";
-						break;
-					case "false":
-						passed = actualValue === false || actualStr === "false";
-						break;
-					case "exists":
-						passed = actualValue !== undefined && actualValue !== null;
-						break;
-					case "not_exists":
-						passed = actualValue === undefined || actualValue === null;
-						break;
-					default:
-						passed = false;
-				}
-			}
-
-			const opStr = a.operator ? a.operator.replace("_", " ") : "";
-			return {
-				success: passed,
-				message: passed
-					? `${targetDesc} ${a.target !== "customJs" ? opStr + " " + (a.expectedValue || "") : ""} ✓`
-					: a.target === "customJs"
-						? `Custom JS evaluated to falsy (${actualStr})`
-						: `Expected ${targetDesc} to ${opStr} ${a.expectedValue || ""}, got: ${actualStr}`,
-			};
-		} catch (err: unknown) {
-			return {
-				success: false,
-				message: `Evaluation error: ${err instanceof Error ? err.message : String(err)}`,
-			};
-		}
-	}));
-
-	const allPassed = result.length === 0 || result.every((r) => r.success);
-
-	return {
-		success: allPassed,
-		result,
-		actualData: resBody,
-	};
+	return evaluateAssertions((suite.assertions as AssertionType[]) || [], {
+		status: resStatus,
+		body: resBody,
+		// executeRouteInternal doesn't return headers; the sandboxed runner does,
+		// so header assertions only actually evaluate there
+		headers: {},
+		durationMs: Date.now() - startTime,
+		request,
+	});
 }

--- a/apps/server/src/loaders/integrationsLoader.ts
+++ b/apps/server/src/loaders/integrationsLoader.ts
@@ -50,6 +50,21 @@ export function ownsIntegration(config: any, projectId: string) {
 	return !!config && (owner == null || owner === projectId);
 }
 
+/**
+ * The cached config for an integration id, whichever group it belongs to.
+ *
+ * An id alone does not say which cache holds it, so any ownership check written
+ * against one or two of the four silently passes every id in the others.
+ */
+export function findIntegrationConfig(id: string) {
+	return (
+		dbIntegrationsCache[id] ??
+		kvIntegrationsCache[id] ??
+		observabilityIntegrationsCache[id] ??
+		aiIntegrationsCache[id]
+	);
+}
+
 /** only the entries `projectId` is allowed to see */
 export function scopeToProject<T>(
 	cache: Record<string, T>,

--- a/apps/server/src/modules/requestRouter/service.ts
+++ b/apps/server/src/modules/requestRouter/service.ts
@@ -33,6 +33,7 @@ import {
 } from "@fluxify/adapters";
 import {
 	dbIntegrationsCache,
+	findIntegrationConfig,
 	observabilityIntegrationsCache,
 	ownsIntegration,
 } from "../../loaders/integrationsLoader";
@@ -416,15 +417,16 @@ function createContext(
  * belongs to. Rejected outright rather than ignored: a request aimed at another
  * tenant's integration should fail loudly, not silently run against the real one.
  */
-function assertOverridesOwned(
+export function assertOverridesOwned(
 	projectId: string,
 	overrides?: RequestOverrides,
 ): HandleRequestType | null {
 	const foreign = (overrides?.integrations ?? [])
 		.map((o) => o.newId)
 		.filter((id) => {
-			const config =
-				dbIntegrationsCache[id] ?? observabilityIntegrationsCache[id];
+			// every group, not just db and observability: a kv or ai override
+			// naming another tenant's integration used to pass unchecked
+			const config = findIntegrationConfig(id);
 			return config && !ownsIntegration(config, projectId);
 		});
 

--- a/apps/server/src/modules/testRunner/assertions.ts
+++ b/apps/server/src/modules/testRunner/assertions.ts
@@ -1,0 +1,209 @@
+import { JsVM } from "@fluxify/lib";
+import type { InferSelectModel } from "drizzle-orm";
+import type { z } from "zod";
+import type { assertionSchema } from "../../api/v1/test-suites/schema";
+import type { routesEntity, testSuitesEntity } from "../../db/schema";
+
+export type AssertionType = z.infer<typeof assertionSchema>;
+
+type Suite = InferSelectModel<typeof testSuitesEntity>;
+type Route = InferSelectModel<typeof routesEntity>;
+
+export type SuiteRequest = {
+	method: string;
+	path: string;
+	headers: Record<string, string>;
+	query: Record<string, string>;
+	params: Record<string, string>;
+	body: unknown;
+};
+
+/**
+ * The HTTP request one suite sends, built from the suite's mock data and the
+ * route's own path.
+ *
+ * Shared by both runners so the in-process path and the sandboxed one send the
+ * same request — a suite that passes in one and fails in the other because a
+ * path param was substituted differently is the worst kind of bug to chase.
+ */
+export function buildSuiteRequest(
+	suite: Suite,
+	route: Pick<Route, "path" | "method">,
+): SuiteRequest {
+	const params = (suite.routeParams as Record<string, string>) || {};
+	// an unfilled param stays as ":id" rather than becoming "undefined", so the
+	// route simply does not match and the failure names the missing param
+	const path = Object.entries(params).reduce(
+		(acc, [key, value]) =>
+			acc.replace(`:${key}`, encodeURIComponent(value || `:${key}`)),
+		route.path || "",
+	);
+
+	const headers = { ...((suite.headers as Record<string, string>) || {}) };
+	const method = (route.method || "GET").toUpperCase();
+	const hasContentType = Object.keys(headers).some(
+		(k) => k.toLowerCase() === "content-type",
+	);
+	if (!hasContentType && ["POST", "PUT"].includes(method)) {
+		headers["Content-Type"] = "application/json";
+	}
+
+	return {
+		method,
+		path,
+		headers,
+		query: (suite.queryParams as Record<string, string>) || {},
+		params,
+		body: suite.body,
+	};
+}
+
+/** the response an assertion set is evaluated against */
+export type AssertionContext = {
+	status: number;
+	body: unknown;
+	headers: Record<string, string>;
+	durationMs: number;
+	request: SuiteRequest;
+};
+
+/** an empty path is the whole body; `a.b[0].c` walks into it */
+function readPath(body: unknown, propertyPath?: string | null) {
+	if (!propertyPath) return body;
+	const parts = propertyPath
+		.replace(/\[(\d+)\]/g, ".$1")
+		.split(".")
+		.filter(Boolean);
+	let curr: any = body;
+	for (const p of parts) {
+		if (curr === undefined || curr === null) break;
+		curr = curr[p];
+	}
+	return curr;
+}
+
+async function actualFor(a: AssertionType, ctx: AssertionContext) {
+	switch (a.target) {
+		case "status":
+			return { value: ctx.status as unknown, desc: "Status" };
+		case "time":
+			return { value: ctx.durationMs as unknown, desc: "Time" };
+		case "header":
+			return {
+				value: ctx.headers[(a.propertyPath || "").toLowerCase()] as unknown,
+				desc: `Header(${a.propertyPath})`,
+			};
+		case "body":
+			return {
+				value: readPath(ctx.body, a.propertyPath),
+				desc: `Body(${a.propertyPath || ""})`,
+			};
+		case "customJs": {
+			const vm = new JsVM({
+				fluxify: {
+					request: {
+						path: ctx.request.path,
+						query: ctx.request.query,
+						body: ctx.request.body,
+						headers: ctx.request.headers,
+						params: ctx.request.params,
+					},
+				},
+				body: ctx.body,
+				headers: ctx.headers,
+				status: ctx.status,
+			});
+			return {
+				value: await vm.run(a.customJs || "return true;"),
+				desc: "Custom JS",
+			};
+		}
+		default:
+			return { value: undefined as unknown, desc: "" };
+	}
+}
+
+function compare(a: AssertionType, actualValue: unknown) {
+	const expected = a.expectedValue == null ? "" : String(a.expectedValue);
+	const actualStr = actualValue == null ? "" : String(actualValue);
+	const numeric = a.target === "status" || a.target === "time";
+
+	switch (a.operator) {
+		case "eq":
+			return numeric
+				? Number(actualValue) === Number(expected)
+				: actualStr === expected;
+		case "neq":
+			return numeric
+				? Number(actualValue) !== Number(expected)
+				: actualStr !== expected;
+		case "lt":
+			return Number(actualValue) < Number(expected);
+		case "gt":
+			return Number(actualValue) > Number(expected);
+		case "contains":
+			return typeof actualValue === "string"
+				? actualValue.includes(expected)
+				: JSON.stringify(actualValue).includes(expected);
+		case "true":
+			return actualValue === true || actualStr === "true";
+		case "false":
+			return actualValue === false || actualStr === "false";
+		case "exists":
+			return actualValue !== undefined && actualValue !== null;
+		case "not_exists":
+			return actualValue === undefined || actualValue === null;
+		default:
+			return false;
+	}
+}
+
+/**
+ * Every assertion's verdict for one response.
+ *
+ * Evaluated in the PARENT, never in the suite's child process: assertions are
+ * the thing the sandbox is not trusted to report honestly, and a killed child
+ * has no results to send anyway.
+ *
+ * The return shape is the one the frontend already renders — do not change it
+ * without changing `SuiteRunResult` and the UI together.
+ */
+export async function evaluateAssertions(
+	assertions: AssertionType[],
+	ctx: AssertionContext,
+) {
+	const result = await Promise.all(
+		assertions.map(async (a) => {
+			try {
+				const { value: actualValue, desc: targetDesc } = await actualFor(a, ctx);
+				const passed =
+					a.target === "customJs"
+						? new JsVM({}).truthy(actualValue)
+						: compare(a, actualValue);
+
+				const actualStr = actualValue == null ? "" : String(actualValue);
+				const opStr = a.operator ? a.operator.replace("_", " ") : "";
+				return {
+					success: passed,
+					message: passed
+						? `${targetDesc} ${a.target !== "customJs" ? `${opStr} ${a.expectedValue || ""}` : ""} ✓`
+						: a.target === "customJs"
+							? `Custom JS evaluated to falsy (${actualStr})`
+							: `Expected ${targetDesc} to ${opStr} ${a.expectedValue || ""}, got: ${actualStr}`,
+				};
+			} catch (err: unknown) {
+				return {
+					success: false,
+					message: `Evaluation error: ${err instanceof Error ? err.message : String(err)}`,
+				};
+			}
+		}),
+	);
+
+	return {
+		// a suite with no assertions passes: it asserted nothing and nothing broke
+		success: result.length === 0 || result.every((r) => r.success),
+		result,
+		actualData: ctx.body,
+	};
+}

--- a/apps/server/src/modules/testRunner/runner.ts
+++ b/apps/server/src/modules/testRunner/runner.ts
@@ -1,0 +1,328 @@
+import { logger } from "@fluxify/common";
+import { and, eq, inArray, type InferSelectModel } from "drizzle-orm";
+import { db } from "../../db";
+import {
+	routesEntity,
+	testRunsEntity,
+	testSuiteRunsEntity,
+	testSuitesEntity,
+	type SuiteRunResult,
+	type TestRunStatus,
+	type TestRunSummary,
+} from "../../db/schema";
+import { assertOverridesOwned } from "../requestRouter/service";
+import {
+	buildSuiteRequest,
+	evaluateAssertions,
+	type AssertionType,
+} from "./assertions";
+import { compileSuiteRoute } from "./compile";
+import { testWorkerPool, type Pool } from "./pool";
+import { resolveSuiteConfig } from "./resolve";
+import { runSuiteInChild } from "./spawn";
+import type { TestBootstrap, TestResult } from "./types";
+
+type Suite = InferSelectModel<typeof testSuitesEntity>;
+
+/** carries the HTTP status #220's endpoint should answer with */
+export class TestRunError extends Error {
+	constructor(
+		readonly status: number,
+		message: string,
+		readonly data?: unknown,
+	) {
+		super(message);
+		this.name = "TestRunError";
+	}
+}
+
+/** injectable so the orchestration can be tested without a child process */
+export type RunnerDeps = {
+	compile: typeof compileSuiteRoute;
+	resolve: typeof resolveSuiteConfig;
+	spawn: typeof runSuiteInChild;
+	pool: Pool;
+};
+
+const defaultDeps: RunnerDeps = {
+	compile: compileSuiteRoute,
+	resolve: resolveSuiteConfig,
+	spawn: runSuiteInChild,
+	pool: testWorkerPool,
+};
+
+/**
+ * Start a run and hand back its id immediately.
+ *
+ * Everything that can reject the request outright happens here, synchronously:
+ * once the caller has a `runId` the only way to report a problem is a row
+ * update it has to poll for. In particular the ownership check runs in the
+ * PARENT, before any child exists — a check performed inside the sandbox is
+ * worthless, since the sandbox is the thing being contained.
+ *
+ * `done` resolves when the background phase settles. Production ignores it; it
+ * exists so a test can await a run instead of polling the database.
+ */
+export async function startTestRun(
+	input: { projectId: string; routeId: string; suiteIds?: string[] },
+	deps: Partial<RunnerDeps> = {},
+): Promise<{ runId: string; done: Promise<void> }> {
+	const { projectId, routeId, suiteIds } = input;
+
+	const [route] = await db
+		.select({ id: routesEntity.id, projectId: routesEntity.projectId })
+		.from(routesEntity)
+		.where(eq(routesEntity.id, routeId));
+	if (!route) throw new TestRunError(404, "Route not found");
+	if (route.projectId !== projectId) {
+		throw new TestRunError(403, "Route belongs to another project");
+	}
+
+	const suites = await db
+		.select()
+		.from(testSuitesEntity)
+		.where(
+			suiteIds?.length
+				? and(
+						eq(testSuitesEntity.routeId, routeId),
+						inArray(testSuitesEntity.id, suiteIds),
+					)
+				: eq(testSuitesEntity.routeId, routeId),
+		);
+	if (suites.length === 0) {
+		throw new TestRunError(404, "No test suites found for this route");
+	}
+
+	for (const suite of suites) {
+		const denied = assertOverridesOwned(projectId, {
+			integrations: suite.integrationOverrides ?? [],
+			appConfigs: suite.appConfigOverrides ?? [],
+		});
+		// one foreign integration fails the whole run: a partially-run fleet whose
+		// remaining suites were rejected is harder to read than a clean refusal
+		if (denied) {
+			throw new TestRunError(
+				403,
+				`Test suite "${suite.name}" names an integration from another project`,
+				denied.data,
+			);
+		}
+	}
+
+	const [run] = await db
+		.insert(testRunsEntity)
+		.values({ projectId, routeId, totalSuites: suites.length })
+		.returning({ id: testRunsEntity.id });
+
+	const suiteRuns = await db
+		.insert(testSuiteRunsEntity)
+		.values(
+			suites.map((suite) => ({
+				testRunId: run!.id,
+				projectId,
+				routeId,
+				testSuiteId: suite.id,
+			})),
+		)
+		.returning({ id: testSuiteRunsEntity.id, testSuiteId: testSuiteRunsEntity.testSuiteId });
+
+	const byId = new Map(suiteRuns.map((r) => [r.testSuiteId, r.id]));
+	const work = suites.map((suite) => ({
+		suite,
+		suiteRunId: byId.get(suite.id)!,
+	}));
+
+	return {
+		runId: run!.id,
+		done: executeRun(run!.id, routeId, projectId, work, {
+			...defaultDeps,
+			...deps,
+		}),
+	};
+}
+
+/**
+ * The background half: compile once, then run every suite through the pool,
+ * writing each row as it settles so a polling UI sees progress.
+ *
+ * Nothing throws out of here. An unhandled rejection in a fire-and-forget task
+ * leaves the parent row on `running` and the UI polling until the next restart.
+ */
+async function executeRun(
+	runId: string,
+	routeId: string,
+	projectId: string,
+	work: Array<{ suite: Suite; suiteRunId: string }>,
+	deps: RunnerDeps,
+): Promise<void> {
+	try {
+		// ONE compile for the whole fleet: it reads the live blocks/edges tables,
+		// so compiling per suite would be the same work N times — and could hand
+		// two suites of one run different code if the route were edited mid-run.
+		const compiled = await deps.compile(routeId);
+
+		await db
+			.update(testRunsEntity)
+			.set({ status: "running", startedAt: new Date() })
+			.where(eq(testRunsEntity.id, runId));
+
+		const startedAt = Date.now();
+		const statuses = await Promise.all(
+			work.map(({ suite, suiteRunId }) =>
+				deps.pool.run(async () => {
+					const status = await runOneSuite(
+						suiteRunId,
+						suite,
+						projectId,
+						compiled,
+						deps,
+					);
+					return [suite.id, status] as const;
+				}),
+			),
+		);
+
+		const passed = statuses.filter(([, s]) => s === "passed").length;
+		const summary: TestRunSummary = {
+			total: statuses.length,
+			passed,
+			failed: statuses.length - passed,
+			suites: Object.fromEntries(statuses),
+		};
+
+		await db
+			.update(testRunsEntity)
+			.set({
+				status: passed === statuses.length ? "passed" : "failed",
+				passedCount: passed,
+				failedCount: summary.failed,
+				result: summary,
+				durationMs: Date.now() - startedAt,
+				finishedAt: new Date(),
+			})
+			.where(eq(testRunsEntity.id, runId));
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		logger.error(`[test-runner] run ${runId} failed: ${message}`, "TEST_RUNNER");
+		await failRun(runId, message).catch(() => {
+			// the database is the only place a failure can be reported; if that is
+			// gone too, the boot sweep picks the row up on the next restart
+		});
+	}
+}
+
+/** mark the run and every suite that never settled as `error` */
+async function failRun(runId: string, message: string) {
+	const finishedAt = new Date();
+	await db
+		.update(testSuiteRunsEntity)
+		.set({
+			status: "error",
+			finishedAt,
+			result: { success: false, result: [], error: message },
+		})
+		.where(
+			and(
+				eq(testSuiteRunsEntity.testRunId, runId),
+				inArray(testSuiteRunsEntity.status, ["queued", "running"]),
+			),
+		);
+
+	await db
+		.update(testRunsEntity)
+		.set({
+			status: "error",
+			finishedAt,
+			result: { total: 0, passed: 0, failed: 0, suites: {}, error: message },
+		})
+		.where(eq(testRunsEntity.id, runId));
+}
+
+/**
+ * One suite: resolve its own config, run it in a fresh process, judge the
+ * response here in the parent, and write the row.
+ *
+ * Config resolution is per suite even though the compile is shared — overrides
+ * live on the suite, so two suites of one fleet legitimately talk to different
+ * databases.
+ */
+async function runOneSuite(
+	suiteRunId: string,
+	suite: Suite,
+	projectId: string,
+	compiled: Awaited<ReturnType<typeof compileSuiteRoute>>,
+	deps: RunnerDeps,
+): Promise<TestRunStatus> {
+	const startedAt = Date.now();
+	await db
+		.update(testSuiteRunsEntity)
+		.set({ status: "running", startedAt: new Date(startedAt) })
+		.where(eq(testSuiteRunsEntity.id, suiteRunId));
+
+	let status: TestRunStatus = "error";
+	let result: SuiteRunResult;
+	let durationMs = 0;
+
+	try {
+		const config = await deps.resolve(projectId, {
+			appConfigOverrides: suite.appConfigOverrides,
+			integrationOverrides: suite.integrationOverrides,
+		});
+		const request = buildSuiteRequest(suite, compiled.route);
+		const bootstrap: TestBootstrap = {
+			suiteRunId,
+			projectId,
+			route: {
+				id: compiled.route.id,
+				projectName: compiled.route.projectName ?? "",
+				bodySchema: compiled.route.bodySchema,
+				querySchema: compiled.route.querySchema,
+				paramsSchema: compiled.route.paramsSchema,
+			},
+			source: compiled.source,
+			customBlocks: compiled.customBlocks,
+			config,
+			request,
+			timeoutMs: compiled.route.timeoutSeconds * 1_000,
+		};
+
+		const response: TestResult = await deps.spawn(bootstrap);
+		durationMs = response.durationMs;
+
+		if (response.ok) {
+			const verdict = await evaluateAssertions(
+				(suite.assertions as AssertionType[]) || [],
+				{
+					status: response.status,
+					body: response.data,
+					headers: response.headers,
+					durationMs,
+					request,
+				},
+			);
+			status = verdict.success ? "passed" : "failed";
+			result = {
+				...verdict,
+				statusCode: response.status,
+				headers: response.headers,
+			};
+		} else {
+			// a killed process has no partial verdicts to report — the duration and
+			// the reason are all that honestly exist
+			status = response.timedOut ? "timeout" : "error";
+			result = { success: false, result: [], error: response.error };
+		}
+	} catch (error) {
+		durationMs = Date.now() - startedAt;
+		const message = error instanceof Error ? error.message : String(error);
+		status = "error";
+		result = { success: false, result: [], error: message };
+	}
+
+	await db
+		.update(testSuiteRunsEntity)
+		.set({ status, result, durationMs, finishedAt: new Date() })
+		.where(eq(testSuiteRunsEntity.id, suiteRunId));
+
+	return status;
+}

--- a/apps/server/src/modules/testRunner/tests/assertions.spec.ts
+++ b/apps/server/src/modules/testRunner/tests/assertions.spec.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "bun:test";
+import {
+	buildSuiteRequest,
+	evaluateAssertions,
+	type AssertionContext,
+	type AssertionType,
+} from "../assertions";
+
+const suite = (overrides: Record<string, unknown> = {}) =>
+	({
+		id: "s1",
+		headers: {},
+		queryParams: {},
+		routeParams: {},
+		body: null,
+		...overrides,
+	}) as any;
+
+const context = (overrides: Partial<AssertionContext> = {}): AssertionContext => ({
+	status: 200,
+	body: { user: { name: "ada" }, tags: ["a", "b"] },
+	headers: { "content-type": "application/json" },
+	durationMs: 12,
+	request: {
+		method: "GET",
+		path: "/demo",
+		headers: {},
+		query: {},
+		params: {},
+		body: null,
+	},
+	...overrides,
+});
+
+const run = (assertions: AssertionType[], ctx = context()) =>
+	evaluateAssertions(assertions, ctx);
+
+describe("buildSuiteRequest", () => {
+	it("substitutes path params and encodes them", () => {
+		const request = buildSuiteRequest(
+			suite({ routeParams: { id: "a b/c" } }),
+			{ path: "/items/:id", method: "GET" } as any,
+		);
+		expect(request.path).toBe("/items/a%20b%2Fc");
+	});
+
+	it("leaves an unfilled param in place rather than writing undefined", () => {
+		const request = buildSuiteRequest(suite({ routeParams: { id: "" } }), {
+			path: "/items/:id",
+			method: "GET",
+		} as any);
+		expect(request.path).toBe("/items/%3Aid");
+	});
+
+	it("defaults the content type for bodied methods only", () => {
+		const post = buildSuiteRequest(suite(), { path: "/x", method: "post" } as any);
+		expect(post.method).toBe("POST");
+		expect(post.headers["Content-Type"]).toBe("application/json");
+
+		const get = buildSuiteRequest(suite(), { path: "/x", method: "GET" } as any);
+		expect(get.headers["Content-Type"]).toBeUndefined();
+	});
+
+	it("does not override a content type the suite already set", () => {
+		const request = buildSuiteRequest(
+			suite({ headers: { "content-type": "text/plain" } }),
+			{ path: "/x", method: "PUT" } as any,
+		);
+		expect(request.headers).toEqual({ "content-type": "text/plain" });
+	});
+});
+
+describe("evaluateAssertions", () => {
+	it("keeps the shape the frontend renders", async () => {
+		const verdict = await run([
+			{ target: "status", operator: "eq", expectedValue: "200" } as AssertionType,
+		]);
+		expect(verdict).toEqual({
+			success: true,
+			result: [{ success: true, message: expect.stringContaining("Status") }],
+			actualData: context().body,
+		});
+	});
+
+	it("passes a suite that asserts nothing", async () => {
+		expect((await run([])).success).toBe(true);
+	});
+
+	it("compares status and time numerically", async () => {
+		const verdict = await run([
+			{ target: "status", operator: "lt", expectedValue: "300" },
+			{ target: "time", operator: "gt", expectedValue: "5" },
+		] as AssertionType[]);
+		expect(verdict.success).toBe(true);
+	});
+
+	it("walks a dotted body path, including array indexes", async () => {
+		const verdict = await run([
+			{ target: "body", propertyPath: "user.name", operator: "eq", expectedValue: "ada" },
+			{ target: "body", propertyPath: "tags[1]", operator: "eq", expectedValue: "b" },
+			{ target: "body", propertyPath: "user.email", operator: "not_exists" },
+		] as AssertionType[]);
+		expect(verdict.result.map((r) => r.success)).toEqual([true, true, true]);
+	});
+
+	it("evaluates header assertions against the real response headers", async () => {
+		// dead until now: the in-process runner had no headers to read, so every
+		// header assertion silently saw undefined
+		const verdict = await run(
+			[
+				{ target: "header", propertyPath: "Content-Type", operator: "contains", expectedValue: "json" },
+				{ target: "header", propertyPath: "x-missing", operator: "not_exists" },
+			] as AssertionType[],
+			context({ headers: { "content-type": "application/json" } }),
+		);
+		expect(verdict.result.map((r) => r.success)).toEqual([true, true]);
+	});
+
+	it("reports a failure with the actual value", async () => {
+		const verdict = await run([
+			{ target: "status", operator: "eq", expectedValue: "404" },
+		] as AssertionType[]);
+		expect(verdict.success).toBe(false);
+		expect(verdict.result[0]!.message).toContain("got: 200");
+	});
+
+	it("runs customJs against the response and the request that produced it", async () => {
+		const verdict = await run(
+			[
+				{
+					target: "customJs",
+					customJs: `return status === 201 && body.user.name === "ada" && fluxify.request.path === "/made-up";`,
+				},
+			] as AssertionType[],
+			context({
+				status: 201,
+				request: { ...context().request, path: "/made-up" },
+			}),
+		);
+		expect(verdict.success).toBe(true);
+	});
+
+	it("turns a throwing assertion into a failure, not a crashed run", async () => {
+		const verdict = await run([
+			{ target: "customJs", customJs: "throw new Error('boom')" },
+		] as AssertionType[]);
+		expect(verdict.success).toBe(false);
+		expect(verdict.result[0]!.message).toContain("boom");
+	});
+});

--- a/apps/server/src/modules/testRunner/tests/runner.spec.ts
+++ b/apps/server/src/modules/testRunner/tests/runner.spec.ts
@@ -1,0 +1,292 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import {
+	routesEntity,
+	testRunsEntity,
+	testSuiteRunsEntity,
+	testSuitesEntity,
+} from "../../../db/schema";
+import {
+	dbIntegrationsCache,
+	OWNER_KEY,
+} from "../../../loaders/integrationsLoader";
+import type { Pool } from "../pool";
+import type { TestResult } from "../types";
+
+const PROJECT = "p1";
+const ROUTE = "r1";
+
+/**
+ * A fake drizzle: it answers by TABLE and ignores the where-clause, which is
+ * enough to prove the orchestration — the ordering of writes, how many times
+ * the compile runs, and what each row ends up as. What it deliberately cannot
+ * prove is the SQL itself.
+ */
+const state = {
+	routes: [{ id: ROUTE, projectId: PROJECT }] as any[],
+	suites: [] as any[],
+	/** every UPDATE in the order it was issued */
+	updates: [] as Array<{ table: string; values: any }>,
+};
+
+const label = (table: unknown) =>
+	table === testRunsEntity
+		? "run"
+		: table === testSuiteRunsEntity
+			? "suiteRun"
+			: "other";
+
+mock.module("../../../db", () => ({
+	db: {
+		select: () => ({
+			from: (table: unknown) => ({
+				where: async () =>
+					table === routesEntity
+						? state.routes
+						: table === testSuitesEntity
+							? state.suites
+							: [],
+			}),
+		}),
+		insert: (table: unknown) => ({
+			values: (values: any) => ({
+				returning: async () =>
+					table === testRunsEntity
+						? [{ id: "run-1" }]
+						: (values as any[]).map((row, i) => ({
+								id: `sr-${i}`,
+								testSuiteId: row.testSuiteId,
+							})),
+			}),
+		}),
+		update: (table: unknown) => ({
+			set: (values: any) => ({
+				where: async () => {
+					state.updates.push({ table: label(table), values });
+				},
+			}),
+		}),
+	},
+}));
+
+const { startTestRun, TestRunError } = await import("../runner");
+
+function suite(id: string, overrides: Record<string, unknown> = {}) {
+	return {
+		id,
+		name: `suite ${id}`,
+		routeId: ROUTE,
+		headers: {},
+		params: {},
+		queryParams: {},
+		routeParams: {},
+		body: null,
+		assertions: [{ target: "status", operator: "eq", expectedValue: "200" }],
+		integrationOverrides: [],
+		appConfigOverrides: [],
+		...overrides,
+	};
+}
+
+const compiled = {
+	route: {
+		id: ROUTE,
+		method: "GET",
+		path: "/demo",
+		projectId: PROJECT,
+		projectName: "demo",
+		bodySchema: null,
+		querySchema: null,
+		paramsSchema: null,
+		timeoutSeconds: 30,
+	},
+	source: "compiled",
+	customBlocks: [],
+};
+
+/** unlimited concurrency — the pool has its own spec */
+const openPool: Pool = {
+	run: (task) => task(),
+	active: 0,
+	queued: 0,
+	limit: 99,
+};
+
+function deps(spawn: (b: any) => Promise<TestResult>) {
+	const compile = mock(async () => compiled as any);
+	return {
+		compile,
+		resolve: mock(async () => ({}) as any),
+		spawn: mock(spawn),
+		pool: openPool,
+	};
+}
+
+const ok = (status: number): TestResult => ({
+	ok: true,
+	status,
+	data: { hello: "world" },
+	headers: { "x-suite": "ok" },
+	durationMs: 5,
+});
+
+beforeEach(() => {
+	state.suites = [];
+	state.updates = [];
+	for (const key of Object.keys(dbIntegrationsCache)) {
+		delete dbIntegrationsCache[key];
+	}
+});
+
+describe("startTestRun", () => {
+	it("runs the whole fleet and settles the parent on the suites' verdicts", async () => {
+		state.suites = [suite("s1"), suite("s2")];
+		const d = deps(async (b) => ok(b.request.path === "/demo" ? 200 : 500));
+
+		const { runId, done } = await startTestRun(
+			{ projectId: PROJECT, routeId: ROUTE },
+			d,
+		);
+		await done;
+
+		expect(runId).toBe("run-1");
+		expect(d.spawn).toHaveBeenCalledTimes(2);
+
+		const suiteRuns = state.updates.filter((u) => u.table === "suiteRun");
+		// running first, then the terminal write — the UI polls between the two
+		expect(suiteRuns.map((u) => u.values.status)).toEqual([
+			"running",
+			"running",
+			"passed",
+			"passed",
+		]);
+		// the response headers actually reach the assertion context
+		expect(suiteRuns.at(-1)!.values.result.headers).toEqual({ "x-suite": "ok" });
+
+		const parent = state.updates.filter((u) => u.table === "run");
+		expect(parent[0]!.values.status).toBe("running");
+		expect(parent.at(-1)!.values).toMatchObject({
+			status: "passed",
+			passedCount: 2,
+			failedCount: 0,
+			result: { total: 2, passed: 2, failed: 0, suites: { s1: "passed", s2: "passed" } },
+		});
+	});
+
+	it("fails the run when one suite's assertions fail", async () => {
+		state.suites = [suite("s1"), suite("s2")];
+		let first = true;
+		const d = deps(async () => {
+			const status = first ? 200 : 500;
+			first = false;
+			return ok(status);
+		});
+
+		await (await startTestRun({ projectId: PROJECT, routeId: ROUTE }, d)).done;
+
+		const parent = state.updates.filter((u) => u.table === "run").at(-1)!;
+		expect(parent.values).toMatchObject({
+			status: "failed",
+			passedCount: 1,
+			failedCount: 1,
+		});
+	});
+
+	it("compiles exactly once no matter how many suites run", async () => {
+		state.suites = [suite("s1"), suite("s2"), suite("s3")];
+		const d = deps(async () => ok(200));
+
+		await (await startTestRun({ projectId: PROJECT, routeId: ROUTE }, d)).done;
+
+		// per-suite compilation would be the same work three times — and could
+		// hand two suites of one run different code if the route were edited
+		expect(d.compile).toHaveBeenCalledTimes(1);
+		expect(d.resolve).toHaveBeenCalledTimes(3);
+	});
+
+	it("records a hung suite as a timeout and still settles the run", async () => {
+		state.suites = [suite("s1"), suite("s2")];
+		let first = true;
+		const d = deps(async () => {
+			if (first) {
+				first = false;
+				return { ok: false, timedOut: true, error: "suite timed out", durationMs: 32_000 };
+			}
+			return ok(200);
+		});
+
+		await (await startTestRun({ projectId: PROJECT, routeId: ROUTE }, d)).done;
+
+		const timedOut = state.updates.find(
+			(u) => u.table === "suiteRun" && u.values.status === "timeout",
+		)!;
+		expect(timedOut.values.durationMs).toBe(32_000);
+		// a killed process has no partial verdicts
+		expect(timedOut.values.result).toEqual({
+			success: false,
+			result: [],
+			error: "suite timed out",
+		});
+
+		const parent = state.updates.filter((u) => u.table === "run").at(-1)!;
+		expect(parent.values.status).toBe("failed");
+		expect(parent.values.finishedAt).toBeInstanceOf(Date);
+	});
+
+	it("marks the run and its suites `error` when the compile throws", async () => {
+		state.suites = [suite("s1")];
+		const d = deps(async () => ok(200));
+		d.compile = mock(async () => {
+			throw new Error("graph is not connected");
+		});
+
+		await (await startTestRun({ projectId: PROJECT, routeId: ROUTE }, d)).done;
+
+		expect(d.spawn).not.toHaveBeenCalled();
+		const parent = state.updates.filter((u) => u.table === "run").at(-1)!;
+		expect(parent.values.status).toBe("error");
+		expect(parent.values.result.error).toContain("graph is not connected");
+		// a row left on `running` makes the UI poll forever
+		expect(
+			state.updates.filter((u) => u.table === "suiteRun").at(-1)!.values.status,
+		).toBe("error");
+	});
+
+	it("rejects a foreign integration override before anything is spawned", async () => {
+		dbIntegrationsCache.foreign = { [OWNER_KEY]: "other-project" };
+		state.suites = [
+			suite("s1", {
+				integrationOverrides: [{ existingId: "mine", newId: "foreign" }],
+			}),
+		];
+		const d = deps(async () => ok(200));
+
+		// an ownership check performed inside the sandbox would be worthless
+		await expect(
+			startTestRun({ projectId: PROJECT, routeId: ROUTE }, d),
+		).rejects.toThrow(TestRunError);
+		expect(d.spawn).not.toHaveBeenCalled();
+		expect(state.updates).toEqual([]);
+	});
+
+	it("404s an unknown route and 403s another project's", async () => {
+		const d = deps(async () => ok(200));
+		state.routes = [];
+		await expect(
+			startTestRun({ projectId: PROJECT, routeId: ROUTE }, d),
+		).rejects.toMatchObject({ status: 404 });
+
+		state.routes = [{ id: ROUTE, projectId: "someone-else" }];
+		await expect(
+			startTestRun({ projectId: PROJECT, routeId: ROUTE }, d),
+		).rejects.toMatchObject({ status: 403 });
+
+		state.routes = [{ id: ROUTE, projectId: PROJECT }];
+	});
+
+	it("404s a route that has no suites", async () => {
+		const d = deps(async () => ok(200));
+		await expect(
+			startTestRun({ projectId: PROJECT, routeId: ROUTE }, d),
+		).rejects.toMatchObject({ status: 404 });
+	});
+});


### PR DESCRIPTION
Closes #219.

Part 5 of 6 of the sandboxed test runner. #215 gave us the tables, #216 config resolution, #217 the isolated child process, #218 the concurrency pool. This wires them into a run that actually persists.

## What

**Orchestration — `modules/testRunner/runner.ts`**

`startTestRun({ projectId, routeId, suiteIds? })` does everything that can reject the request synchronously — route ownership, suite lookup, and the integration-override ownership check — then inserts the parent row plus one child row per suite and hands back the `runId`. Everything after that is background.

The background phase compiles **once** for the whole fleet and reuses that one source for every suite. Per suite it resolves that suite's own config (overrides live on the suite, so two suites of one fleet can legitimately point at different databases), spawns the child through the pool, judges the response in the parent, and writes the row **the moment it settles** — a UI polling this sees progress, not a spinner. When every suite has settled the parent gets its counts, summary and duration.

Nothing throws out of the background body. An unhandled rejection in a fire-and-forget task leaves the parent on `running` and the UI polling until the next restart, so the catch marks the run and every unsettled suite `error` with the message.

**Assertion extraction — `modules/testRunner/assertions.ts`**

`evaluateAssertions` moves out of `api/v1/test-suites/runner.ts` with its output shape unchanged (`{ success, result, actualData }`) — #220 deletes the old caller and the frontend already renders that shape. Assertions are evaluated in the **parent**, never in the child: the sandbox is the thing being contained, so it does not get to report its own verdict, and a killed child has no verdicts to report anyway.

`buildSuiteRequest` moves with it so both runners send the same request. A suite that passes in one path and fails in the other because a path param was substituted differently is the worst kind of bug to chase.

## Cross-tenant gap fixed along the way

`assertOverridesOwned` looked the override target up in **only** the db and observability caches. An id in the kv or ai cache found no config, so the filter dropped it and the check passed — an override naming another tenant's kv or ai integration went through unchecked, on the live request path as well as in tests.

It now resolves the id across all four caches via a new `findIntegrationConfig`, and is exported so the orchestrator can run it in the parent before any child exists. An ownership check performed inside the sandbox is worthless.

## Behaviour change worth knowing

Header assertions have never evaluated: `resHeaders` was hardcoded `{}` because `executeRouteInternal` returns no headers. That stays true on the legacy path, but the child **does** return real headers, so on the sandboxed path they now evaluate for real. A `header` + `not_exists` assertion that passes today will correctly start failing there.

## Tests

20 new. Orchestration is covered against a fake drizzle that answers by table and records every UPDATE in order, which is enough to prove the write ordering, the compile count and the terminal states without a database:

- the fleet runs, rows go `running` then terminal, parent settles on the suites' verdicts
- compile is called **once** for three suites, resolve three times
- a hung suite lands as `timeout` with a duration and no assertion detail, and the run still settles
- a throwing compile marks the run and its suites `error` rather than stranding them on `running`
- a foreign integration override rejects before anything is spawned and before any row is written
- unknown route 404s, another project's route 403s

`bun test` across `modules/testRunner`, `api/v1/test-suites`, `modules/requestRouter` and `loaders`: 109 pass. `bun run --cwd apps/server lint` clean.

## Out of scope

Endpoints and the deletion of the old in-process path — that is #220. Nothing user-facing changes here. The boot call to `sweepStrandedTestRuns` also lands with #220, since nothing can strand a row until the endpoint exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pjR2Xuyxu5UTUDFo9smSd
