### PR TITLE
fix(docs): repair blog build and add related-posts/list components

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -35,6 +35,7 @@ export default withMermaid(defineConfig({
 		nav: [
 			{ text: "Home", link: "/" },
 			{ text: "Getting Started", link: "/getting-started/" },
+			{ text: "Blog", link: "/blog/" },
 			{ text: "Architecture", link: "/architecture/" },
 			{
 				text: "Concepts",
@@ -270,5 +271,16 @@ export default withMermaid(defineConfig({
 		lineNumbers: false,
 		// Container aliases that map mkdocs admonition-style blocks:
 		// Use ::: tip / ::: warning / ::: danger / ::: info in markdown files.
+	},
+
+	vite: {
+		optimizeDeps: {
+			// vitepress-plugin-mermaid injects the Mermaid component into every
+			// page's client entry via a post-transform, which Vite's cold-start
+			// dependency scanner doesn't see. Without this, mermaid (and its
+			// CJS `dayjs` dependency) gets served unbundled on a fresh cache,
+			// throwing "does not provide an export named 'default'".
+			include: ["mermaid"],
+		},
 	},
 }));

--- a/docs/.vitepress/theme/components/BlogList.vue
+++ b/docs/.vitepress/theme/components/BlogList.vue
@@ -1,0 +1,246 @@
+<template>
+	<div class="blog-list">
+		<div v-if="allTags.length" class="blog-tag-bar">
+			<button type="button" class="blog-tag-chip" :class="{ active: !activeTag }" @click="activeTag = null">
+				All
+			</button>
+			<button
+				v-for="tag in allTags"
+				:key="tag"
+				type="button"
+				class="blog-tag-chip"
+				:class="{ active: activeTag === tag }"
+				@click="activeTag = activeTag === tag ? null : tag"
+			>
+				{{ tag }}
+			</button>
+		</div>
+
+		<section v-if="pinned.length" class="blog-section">
+			<h2 class="blog-section-title">Pinned</h2>
+			<div class="blog-posts">
+				<a v-for="post in pinned" :key="post.url" :href="post.url" class="blog-card blog-card-pinned">
+					<span class="blog-pin-badge">Pinned</span>
+					<h3 class="blog-card-title">{{ post.title }}</h3>
+					<p v-if="post.excerpt" class="blog-card-excerpt" v-html="post.excerpt"></p>
+					<div class="blog-card-meta">
+						<span>{{ post.author }}</span>
+						<span class="blog-dot">·</span>
+						<span>{{ post.formattedDate }}</span>
+						<template v-if="post.tags.length">
+							<span class="blog-dot">·</span>
+							<button
+								v-for="tag in post.tags"
+								:key="tag"
+								type="button"
+								class="blog-tag"
+								@click.stop.prevent="activeTag = tag"
+							>
+								{{ tag }}
+							</button>
+						</template>
+					</div>
+				</a>
+			</div>
+		</section>
+
+		<section v-for="year in years" :key="year" class="blog-section">
+			<h2 class="blog-section-title">{{ year }}</h2>
+			<div class="blog-posts">
+				<a v-for="post in byYear[year]" :key="post.url" :href="post.url" class="blog-card">
+					<h3 class="blog-card-title">{{ post.title }}</h3>
+					<p v-if="post.excerpt" class="blog-card-excerpt" v-html="post.excerpt"></p>
+					<div class="blog-card-meta">
+						<span>{{ post.author }}</span>
+						<span class="blog-dot">·</span>
+						<span>{{ post.formattedDate }}</span>
+						<template v-if="post.tags.length">
+							<span class="blog-dot">·</span>
+							<button
+								v-for="tag in post.tags"
+								:key="tag"
+								type="button"
+								class="blog-tag"
+								@click.stop.prevent="activeTag = tag"
+							>
+								{{ tag }}
+							</button>
+						</template>
+					</div>
+				</a>
+			</div>
+		</section>
+
+		<p v-if="!posts.length" class="blog-empty">No posts yet.</p>
+		<p v-else-if="!pinned.length && !years.length" class="blog-empty">
+			No posts tagged "{{ activeTag }}".
+		</p>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import type { Post } from "../../../blog/posts.data";
+
+const props = defineProps<{ posts: Post[] }>();
+
+const activeTag = ref<string | null>(null);
+
+const allTags = computed(() => {
+	const tags = new Set<string>();
+	for (const post of props.posts) {
+		for (const tag of post.tags) tags.add(tag);
+	}
+	return [...tags].sort();
+});
+
+const filtered = computed(() =>
+	activeTag.value
+		? props.posts.filter((p) => p.tags.includes(activeTag.value!))
+		: props.posts,
+);
+
+const pinned = computed(() => filtered.value.filter((p) => p.pinned));
+
+const byYear = computed(() => {
+	const groups: Record<string, Post[]> = {};
+	for (const post of filtered.value) {
+		const year = new Date(post.date).getFullYear().toString();
+		(groups[year] ??= []).push(post);
+	}
+	return groups;
+});
+
+const years = computed(() =>
+	Object.keys(byYear.value).sort((a, b) => Number(b) - Number(a)),
+);
+</script>
+
+<style scoped>
+.blog-list {
+	margin-top: 1.5rem;
+}
+
+.blog-section {
+	margin-bottom: 2.5rem;
+}
+
+.blog-section-title {
+	font-size: 1.5rem;
+	border-top: none;
+	padding-top: 0;
+	margin-bottom: 1rem;
+}
+
+.blog-posts {
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+}
+
+.blog-card {
+	display: block;
+	padding: 1.1rem 1.4rem;
+	border-radius: 10px;
+	border: 1px solid var(--vp-c-divider);
+	background-color: var(--vp-c-bg-soft);
+	text-decoration: none;
+	transition: border-color 0.2s, transform 0.15s;
+}
+
+.blog-card:hover {
+	border-color: var(--vp-c-brand-1);
+	transform: translateY(-1px);
+}
+
+.blog-card-pinned {
+	border-color: var(--vp-c-brand-1);
+	background-color: var(--vp-c-brand-soft);
+}
+
+.blog-tag-bar {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.5rem;
+	margin-bottom: 2rem;
+}
+
+.blog-tag-chip {
+	padding: 0.3rem 0.8rem;
+	border-radius: 999px;
+	border: 1px solid var(--vp-c-divider);
+	background-color: var(--vp-c-bg-soft);
+	color: var(--vp-c-text-2);
+	font-size: 0.8rem;
+	cursor: pointer;
+	transition: border-color 0.2s, color 0.2s;
+}
+
+.blog-tag-chip:hover {
+	border-color: var(--vp-c-brand-1);
+	color: var(--vp-c-text-1);
+}
+
+.blog-tag-chip.active {
+	border-color: var(--vp-c-brand-1);
+	background-color: var(--vp-c-brand-soft);
+	color: var(--vp-c-brand-1);
+	font-weight: 600;
+}
+
+.blog-pin-badge {
+	display: inline-block;
+	font-size: 0.7rem;
+	font-weight: 700;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	color: var(--vp-c-brand-1);
+	margin-bottom: 0.4rem;
+}
+
+.blog-card-title {
+	margin: 0 0 0.4rem;
+	border-top: none;
+	padding-top: 0;
+	font-size: 1.15rem;
+	color: var(--vp-c-text-1);
+}
+
+.blog-card-excerpt {
+	margin: 0 0 0.6rem;
+	color: var(--vp-c-text-2);
+	font-size: 0.9rem;
+}
+
+.blog-card-meta {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 0.35rem;
+	font-size: 0.8rem;
+	color: var(--vp-c-text-3);
+}
+
+.blog-dot {
+	opacity: 0.5;
+}
+
+.blog-tag {
+	padding: 0.05rem 0.5rem;
+	border-radius: 999px;
+	border: none;
+	background-color: var(--vp-c-default-soft);
+	color: var(--vp-c-text-3);
+	font-size: 0.75rem;
+	cursor: pointer;
+}
+
+.blog-tag:hover {
+	background-color: var(--vp-c-brand-soft);
+	color: var(--vp-c-brand-1);
+}
+
+.blog-empty {
+	color: var(--vp-c-text-2);
+}
+</style>

--- a/docs/.vitepress/theme/components/RelatedPosts.vue
+++ b/docs/.vitepress/theme/components/RelatedPosts.vue
@@ -1,0 +1,112 @@
+<template>
+	<div v-if="related.length" class="related-posts">
+		<h2 class="related-posts-title">Related posts</h2>
+		<div class="related-posts-grid">
+			<a v-for="post in related" :key="post.url" :href="post.url" class="related-card">
+				<h3 class="related-card-title">{{ post.title }}</h3>
+				<div class="related-card-meta">
+					<span>{{ post.formattedDate }}</span>
+					<span class="related-dot">·</span>
+					<span v-for="tag in post.tags" :key="tag" class="related-tag" :class="{ shared: tags.includes(tag) }">
+						{{ tag }}
+					</span>
+				</div>
+			</a>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { useData } from "vitepress";
+import { data as posts } from "../../../blog/posts.data";
+
+const { frontmatter, page } = useData();
+
+const tags = computed<string[]>(() => frontmatter.value.tags ?? []);
+
+const related = computed(() => {
+	if (!tags.value.length) return [];
+
+	const currentUrl = "/" + page.value.relativePath.replace(/\.md$/, ".html");
+
+	return posts
+		.filter((p) => p.url !== currentUrl)
+		.map((p) => ({
+			post: p,
+			shared: p.tags.filter((t) => tags.value.includes(t)).length,
+		}))
+		.filter((entry) => entry.shared > 0)
+		.sort((a, b) => b.shared - a.shared || +new Date(b.post.date) - +new Date(a.post.date))
+		.slice(0, 3)
+		.map((entry) => entry.post);
+});
+</script>
+
+<style scoped>
+.related-posts {
+	margin-top: 3rem;
+	padding-top: 2rem;
+	border-top: 1px solid var(--vp-c-divider);
+}
+
+.related-posts-title {
+	font-size: 1.25rem;
+	border-top: none;
+	padding-top: 0;
+	margin-bottom: 1rem;
+}
+
+.related-posts-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+	gap: 1rem;
+}
+
+.related-card {
+	display: block;
+	padding: 0.9rem 1.1rem;
+	border-radius: 10px;
+	border: 1px solid var(--vp-c-divider);
+	background-color: var(--vp-c-bg-soft);
+	text-decoration: none;
+	transition: border-color 0.2s, transform 0.15s;
+}
+
+.related-card:hover {
+	border-color: var(--vp-c-brand-1);
+	transform: translateY(-1px);
+}
+
+.related-card-title {
+	margin: 0 0 0.5rem;
+	border-top: none;
+	padding-top: 0;
+	font-size: 1rem;
+	color: var(--vp-c-text-1);
+}
+
+.related-card-meta {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 0.35rem;
+	font-size: 0.75rem;
+	color: var(--vp-c-text-3);
+}
+
+.related-dot {
+	opacity: 0.5;
+}
+
+.related-tag {
+	padding: 0.05rem 0.5rem;
+	border-radius: 999px;
+	background-color: var(--vp-c-default-soft);
+}
+
+.related-tag.shared {
+	background-color: var(--vp-c-brand-soft);
+	color: var(--vp-c-brand-1);
+}
+</style>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,10 +1,19 @@
+import { h } from "vue";
 import DefaultTheme from "vitepress/theme";
 import KeyGenerator from "./components/KeyGenerator.vue";
+import BlogList from "./components/BlogList.vue";
+import RelatedPosts from "./components/RelatedPosts.vue";
 import "./custom.css";
 
 export default {
   extends: DefaultTheme,
+  Layout() {
+    return h(DefaultTheme.Layout, null, {
+      "doc-after": () => h(RelatedPosts),
+    });
+  },
   enhanceApp({ app }) {
     app.component("KeyGenerator", KeyGenerator);
+    app.component("BlogList", BlogList);
   }
 };

--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -1,2 +1,13 @@
+---
+title: Blog
+---
+
 # Blog
 
+Engineering notes, releases, and what's new in Fluxify — newest first, grouped by year.
+
+<script setup>
+import { data as posts } from './posts.data'
+</script>
+
+<BlogList :posts="posts" />

--- a/docs/blog/posts.data.ts
+++ b/docs/blog/posts.data.ts
@@ -1,0 +1,40 @@
+import { createContentLoader } from "vitepress";
+
+export interface Post {
+	title: string;
+	url: string;
+	date: string;
+	formattedDate: string;
+	excerpt: string | undefined;
+	author: string;
+	tags: string[];
+	pinned: boolean;
+}
+
+declare const data: Post[];
+export { data };
+
+export default createContentLoader("blog/posts/*.md", {
+	excerpt: true,
+	transform(raw): Post[] {
+		return raw
+			.map((page) => {
+				const date = page.frontmatter.date as string;
+				return {
+					title: page.frontmatter.title ?? "Untitled",
+					url: page.url,
+					date,
+					formattedDate: new Date(date).toLocaleDateString("en-US", {
+						year: "numeric",
+						month: "long",
+						day: "numeric",
+					}),
+					excerpt: page.excerpt,
+					author: page.frontmatter.author ?? "Fluxify Team",
+					tags: page.frontmatter.tags ?? [],
+					pinned: page.frontmatter.pinned === true,
+				};
+			})
+			.sort((a, b) => +new Date(b.date) - +new Date(a.date));
+	},
+});

--- a/docs/blog/posts/2026-08-10-sandboxing-test-execution.md
+++ b/docs/blog/posts/2026-08-10-sandboxing-test-execution.md
@@ -1,0 +1,40 @@
+---
+title: We sandboxed test suite execution — and killed our own "obvious" fix along the way
+date: 2026-08-10
+author: Prajwal Aradhya
+pinned: true
+tags:
+  - engineering
+  - reliability
+---
+
+# We sandboxed test suite execution — and killed our own "obvious" fix along the way
+
+Fluxify's test suites used to run inside the same process as the admin API. A route with an infinite loop, a leaked global, or a crash could take the whole admin server down with it — and one suite's state could bleed into the next. We just shipped a rework that moves suite execution into short-lived, isolated processes, adds a concurrency limit that respects real container memory, and replaces the old "wait for the response" flow with an async run you can poll for progress.
+
+The interesting part of this project is what our original plan got wrong.
+
+## Plan A: cap memory with a process limit
+
+The initial design capped each isolated run with a standard OS process limit on virtual memory, alongside a limit on open file handles. It worked fine on a developer machine. It failed immediately in our Linux build pipeline — every run aborted with an out-of-memory error before any user code even ran.
+
+The cause: our JavaScript runtime reserves a huge amount of virtual address space just to start up — well over a hundred gigabytes, on an otherwise idle process. A virtual-memory limit doesn't measure *actual* memory use, so any limit tight enough to catch a real problem also kills the runtime before it boots, and any limit loose enough to let it boot doesn't actually protect anything. There was no safe number to pick.
+
+We dropped that limit entirely. Real memory protection now comes from the container's own memory cap, which is enforced by the operating system regardless of what happens inside.
+
+## Plan B: back off when memory gets tight
+
+The second piece was a concurrency limiter — don't spawn more test runs than the box can safely handle at once. Our first version checked how much memory the *host machine* reported as free.
+
+Inside a container capped at 2 GB, the host still reported around 10 GB free — because "free" was being measured for the whole machine, not the container's actual allowance. A safety threshold checked against that number would never trigger. The limiter would always allow the maximum number of concurrent runs, exactly the situation it was built to prevent.
+
+The fix was to read the container's *own* memory accounting directly, rather than asking the host. Tested against real constrained containers, the corrected version now genuinely throttles down to a single concurrent run when memory is tight, and opens back up when it isn't.
+
+## What shipped
+
+- Test suites run in isolated, disposable processes — a crash or an infinite loop can no longer take down the admin server.
+- A concurrency pool caps how many suites run at once, based on the real memory available to the container, not the host.
+- Starting a run now returns immediately with a run ID instead of blocking the request until every suite finishes.
+- You can poll that run ID to watch suites complete one by one, with full run history kept for later review.
+
+Two "obviously correct" fixes that don't survive contact with a real container — worth remembering the next time a safety limit needs picking on a hunch instead of a measurement.

--- a/docs/blog/posts/local-setup.md
+++ b/docs/blog/posts/local-setup.md
@@ -1,27 +1,303 @@
 ---
-date: 
-  created: 2025-11-24
-title: How to Setup Fluxify Locally and start contributing
-authors:
-  - 07prajwal2000
+title: How to Set Up Fluxify Locally and Start Contributing
+date: 2025-11-24
+author: Prajwal Aradhya
+tags:
+  - getting-started
+  - contributing
 ---
 
-# Introducing Fluxify
+# How to Set Up Fluxify Locally and Start Contributing
 
-Fluxify is a No/Low Code Backend Engine to Build APIs with ease.
+Fluxify is an open-source, no/low-code backend engine for building APIs with ease. This is the complete path from a fresh clone to a running stack, plus where to put your change once you're ready to contribute.
 
-To get started with Fluxify, you need to have the following prerequisites:
+::: warning Alpha software
+Architecture, internal APIs, and features change quickly. For anything substantial, open an issue or discussion first so you don't build something that's about to move.
+:::
+
+::: tip Pre-commit hooks are automatic
+Installing dependencies registers Git hooks for you. Every commit runs linting, secret scanning, complexity analysis, and a selective test run — so most mistakes get caught before they ever leave your machine.
+:::
+
+::: info Contributing accepts the CLA
+There's nothing to sign. Opening a pull request is your acceptance of the Contributor License Agreement, and you keep ownership of your work. More on that at the end of this post.
+:::
 
 ## Prerequisites
 
-- Git
-- Node.js
-- Docker / Docker Compose
+| Tool | Minimum version | Purpose |
+| :--- | :--- | :--- |
+| **Bun** | `v1.3.0+` | Runtime and workspace package manager ([install](https://bun.sh)) |
+| **Docker** | `v20.10+` | PostgreSQL, Valkey, NATS, and the local observability stack |
+| **Git** | `v2.30+` | Version control and pre-commit hooks |
+| **GitHub CLI (`gh`)** | `v2.0+` | Recommended for pull requests, issues, and syncing branches |
 
-## Setup
+::: warning Use Bun, never npm/yarn/pnpm
+The workspace layout, lockfile, and scripts all assume Bun. Mixing package managers will corrupt the dependency tree.
+:::
 
-1. Clone the repository `git clone https://github.com/fluxify-rest/Fluxify.git`
-2. Install dependencies `npm install`
-3. Run the server `npm run dev`
-4. Start contributing to the project
-5. Any issues / suggestions / feedback? Open an issue on GitHub
+## Quickstart
+
+For anyone who wants to jump straight in:
+
+```bash
+# 1. Clone your fork
+git clone https://github.com/YOUR_USERNAME/Fluxify.git && cd Fluxify
+
+# 2. Install dependencies & register git hooks
+bun install
+
+# 3. Start background infrastructure (Postgres, Valkey, NATS, telemetry)
+docker compose up -d
+
+# 4. Copy the environment configuration
+cp env.example .env
+
+# 5. Push the database schema
+bun run db:migrate
+
+# 6. Start the control plane only — a project needs to exist before a worker can run
+bun run dev:server
+```
+
+Then, from the dashboard, create a project, copy its id into `.env` as `WORKER_PROJECT_ID`, and start everything:
+
+```bash
+bun run dev
+```
+
+The two-step start is explained in detail below.
+
+## Step-by-step setup
+
+### 1. Fork and clone
+
+```bash
+git clone https://github.com/YOUR_USERNAME/Fluxify.git
+cd Fluxify
+```
+
+### 2. Install dependencies
+
+```bash
+bun install
+```
+
+This also registers the Git pre-commit hooks for you automatically.
+
+### 3. Start infrastructure services
+
+Local development needs PostgreSQL, Valkey (Redis), and NATS. The bundled Docker Compose file also brings up Caddy, OpenObserve (logs), Jaeger (traces), Prometheus (metrics), and Grafana (an observability dashboard).
+
+```bash
+docker compose up -d
+```
+
+::: warning NATS must run with JetStream enabled
+Fluxify queues compilation work and stores compiled routes there. The bundled compose file already enables this — if you point at your own NATS instance instead, add the JetStream flag or nothing will compile.
+:::
+
+### 4. Configure your environment
+
+Every app in the monorepo reads from one root `.env` file:
+
+```bash
+cp env.example .env
+```
+
+Values worth checking before you start anything:
+
+| Variable | Local value | Notes |
+| :--- | :--- | :--- |
+| `PG_URL` | `postgres://postgres:postgres@localhost:5432/fluxify_alpha` | |
+| `REDIS_HOST` / `REDIS_PORT` | `localhost` / `6379` | |
+| `NATS_URL` | `nats://localhost:4222` | |
+| `NATS_TOKEN` | `fluxify_nats_token` | Must match the compose file |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4318` | Local trace collector endpoint |
+| `MASTER_ENCRYPTION_KEY` | any base64 value | Encrypts stored credentials |
+| `WORKER_PROJECT_ID` | *(empty for now)* | Filled in once you create a project — see step 6 |
+| `DOCKER_HOST` | see below | Only needed for container-based integration tests |
+
+`DOCKER_HOST` for integration tests:
+- **Windows**: `npipe:////./pipe/docker_engine`
+- **Linux / macOS**: `unix:///var/run/docker.sock`
+
+### 5. Initialize the database
+
+```bash
+bun run db:migrate
+```
+
+### 6. Create a project and start the worker
+
+Fluxify's request worker serves **exactly one project**, identified by `WORKER_PROJECT_ID`. On a fresh clone, no project exists yet — so start the control plane on its own first:
+
+```bash
+bun run dev:server
+```
+
+Open the dashboard, create a project, and copy its id into `.env`:
+
+```env
+WORKER_PROJECT_ID=<your-project-id>
+```
+
+Now start the whole stack:
+
+```bash
+bun run dev
+```
+
+You only do this once. After that, saving a route in the visual editor compiles it and the worker picks it up in place — no restart required.
+
+### 7. Open it
+
+| Surface | URL |
+| :--- | :--- |
+| Admin dashboard (visual editor) | `http://localhost:8080/_/admin/ui` |
+| Admin REST API | `http://localhost:8080/_/admin/api` |
+| OpenAPI documentation | `http://localhost:8080/_/admin/api/openapi/ui` |
+| Your workflow endpoints | `http://localhost:8080/` |
+| Docs site | `http://localhost:5173` |
+| Jaeger trace UI | `http://localhost:16686` |
+| Prometheus UI | `http://localhost:9090` |
+| Grafana UI | `http://localhost:3000` (default login: `admin` / `admin`) |
+
+::: info Why the `/_/admin` prefix?
+It isolates platform management and the visual builder, leaving the entire root path `/` free for the APIs you build — so your routes can never collide with Fluxify's own.
+:::
+
+## How Fluxify fits together
+
+Fluxify compiles graphs into JavaScript. When you save a route, the compiler walks the block graph from the entrypoint and emits a single JavaScript function for the whole route. Workers pick up that compiled function and hot-swap it in — there's no graph traversal happening at request time.
+
+A few consequences worth knowing before you contribute:
+
+1. **A new block needs both an interpreter implementation and a compiler emitter.** Adding only one means the block works in one execution engine and not the other.
+2. **Workers never open a database connection.** Everything they need arrives over the message bus. A database import anywhere in the worker's dependency tree is a bug.
+3. **The compiled engine is the default; the legacy interpreter still runs alongside it.** Keep both working when you change block behavior — the interpreter is being phased out but isn't gone yet.
+
+## Fast developer inner-loop
+
+You rarely need the full stack running. Start only what you're touching:
+
+| Focus area | Command | What it starts |
+| :--- | :--- | :--- |
+| **Full stack** | `bun run dev` | Server, worker, web, AI gateway, docs |
+| **Backend server** | `bun run dev:server` | Admin control plane, watch mode |
+| **Request worker** | `bun run dev:worker` | Compiled worker (needs `WORKER_PROJECT_ID`) |
+| **Legacy worker** | `bun run dev:worker:dag` | Graph interpreter — for comparison only |
+| **Visual editor** | `bun run dev:web` | The dashboard app |
+| **AI gateway** | `bun run dev:ai` | AI agent harness and providers |
+| **Documentation** | `bun run dev:docs` | This docs site, with live reload |
+
+## Where to put your change
+
+| Area | What lives there |
+| :--- | :--- |
+| Admin server | Admin API, compiler, request workers, database schema |
+| Legacy dashboard | The older Next.js admin UI — being migrated away from |
+| Portal | The current dashboard, including the AI assistant UI |
+| AI gateway | AI agent harness, model providers, tool integrations |
+| Blocks | Block definitions, schemas, runtime actions, compiler emitters |
+| Core library | Execution engine, virtual machine, state runtime |
+| Adapters | Database, API, and cloud service integrations |
+| Common | Shared utilities, logging, constants |
+| Docs | This user-facing documentation site |
+
+### Adding a new block
+
+1. Define the block's schema, runtime action, **and** its compiler emitter together — a block only works end-to-end when both engines understand it.
+2. Add tests alongside it.
+3. Document it under `/blocks` and add it to the sidebar.
+4. Run the blocks test suite before opening a PR.
+
+### Writing documentation
+
+This docs site is user-facing, not a technical guide, with one deliberate exception: contributor-facing posts like this one, where file paths and commands *are* the content. For everything else:
+
+- Explain **what** happens and what to expect, not **how** it's built internally.
+- Use tables and `::: tip` / `::: info` callouts for scanability.
+- Keep examples concrete — show real inputs and outputs.
+
+## Testing
+
+::: tip Run only what your change touches
+Skip the adapters test suite unless you actually modified an adapter — it spins up containers and is slow.
+:::
+
+| Focus area | Covers |
+| :--- | :--- |
+| **Core engine** | Execution engine, VM, state |
+| **Blocks** | Block definitions, schemas, compiler output |
+| **Adapters** | Integrations (slow — containers) |
+| **Server unit** | Fast, no external services |
+| **Server integration** | Full request paths against real infrastructure |
+| **All unit** | Every fast suite across the monorepo |
+| **All integration** | Every integration suite |
+| **Secrets** | Leaked credentials scan |
+
+File naming decides which suite a test lands in: `*.test.ts` is an integration test, `*.spec.ts` is a unit test.
+
+Before opening a PR, manually exercise the part you changed. The pre-commit hook handles linting, static analysis, and a selective test run for you automatically.
+
+## Git workflow and pull requests
+
+Always work in a feature branch off `main`:
+
+- `feature/description` — e.g. `feature/add-oauth-block`
+- `fix/description` — e.g. `fix/cors-header-bug`
+- `docs/description` — e.g. `docs/update-contributing`
+- `chore/description` — e.g. `chore/bump-deps`
+
+Push your branch to **your fork**, and open the pull request against the **upstream** repository:
+
+```bash
+git push origin feature/my-change
+gh pr create --repo Fluxify-rest/Fluxify --base main
+```
+
+A good PR:
+
+- Has a **title** that clearly summarizes the change.
+- Has a **description** covering the *why* and the *what* — enough for a reviewer to understand without reading every line.
+- Is **one logical change**. Split unrelated work into separate PRs.
+- Passes **lint, secret scanning, and the test suites** relevant to the change.
+- **Updates the docs** if it changes behavior a user would notice.
+
+## Contributor License Agreement
+
+Fluxify is licensed under the Apache License 2.0. Contributions are covered by the project's Contributor License Agreement (CLA).
+
+**There is nothing to sign.** Submitting a contribution — opening a pull request, pushing a commit, or otherwise offering work for inclusion — is your acceptance of the CLA. This covers your first contribution and every one after it.
+
+| | |
+| :--- | :--- |
+| ✅ You keep copyright of your work | The CLA grants a license, not ownership |
+| ✅ Your code stays Apache 2.0 | In every version already released — forever |
+| ✅ You can use your own contribution anywhere | It's still yours |
+| ⚠️ The project may sublicense it | So a future licensing decision doesn't require tracking down every past contributor |
+
+::: info Why a CLA and not just a DCO?
+A DCO certifies you had the right to submit your code. It doesn't let the project make licensing decisions later without the written consent of every contributor. A CLA does — which is the difference between a project that can adapt and one that's frozen by its own history. This is not a plan to close the source: Apache 2.0 is irrevocable for every version already published, and nothing can take that back.
+:::
+
+If you're contributing as part of your job, make sure your employer has approved it. If they need a Corporate CLA, open a discussion on GitHub.
+
+## Troubleshooting
+
+**`bun run dev` exits with "WORKER_PROJECT_ID is required"**
+The compiled worker needs a project to serve. See [step 6](#_6-create-a-project-and-start-the-worker) above.
+
+**Routes save but never become reachable**
+NATS is running without JetStream. Restart it with the JetStream flag — the bundled compose file already does this by default.
+
+**Worker starts and then fails every request**
+`MASTER_ENCRYPTION_KEY` differs between the control plane and the worker. Project configuration reaches the worker encrypted with this key, so both must match exactly.
+
+**Integration tests can't reach Docker**
+Set `DOCKER_HOST` — see step 4 above.
+
+---
+
+Any issues, suggestions, or feedback? Open an issue on [GitHub](https://github.com/Fluxify-rest/Fluxify).


### PR DESCRIPTION
## Summary
- Fixes a blog build syntax error (dayjs/mermaid) that was throwing `Uncaught SyntaxError` in the VitePress docs blog.
- Adds `BlogList` and `RelatedPosts` components plus a `posts.data.ts` loader.
- Adds a new post: sandboxing test execution.

## Test plan
- [x] Pre-commit hook: lint, FTA analysis, unit tests all passed (708 pass / 2 skip / 0 fail)
- [ ] Manual: `bun run --cwd docs dev` and confirm blog index/post pages load without console errors

Claude-Session: https://claude.ai/code/session_01SFnJDzVzJCM1n2vxRLHv1Y