### PR TITLE
fix(harness): block builder emits real block types

### DIFF
--- a/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/normalize.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/normalize.ts
@@ -134,8 +134,10 @@ function key(value: string) {
 }
 
 function canonicalType(raw: string) {
-	// custom blocks are named by the user, so only built-ins are mapped
-	if (raw.startsWith("custom:")) return raw;
+	// A custom block instance stores the block's own name — the `custom:` prefix
+	// is prompt syntax for "this one is custom" and has no meaning to storage or
+	// to the block factory, so it is dropped here rather than persisted.
+	if (raw.startsWith("custom:")) return raw.slice("custom:".length);
 	return CANONICAL_TYPE.get(key(raw)) ?? raw;
 }
 

--- a/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/validator.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/validator.ts
@@ -1,14 +1,10 @@
-import { builtinBlockSchemas } from "@fluxify/blocks";
+import { builtinBlockSchemas, BlockTypes } from "@fluxify/blocks";
 import type { AgentOutputValidator } from "../../../types";
 import { detectCycles } from "./cycleDetector";
 import type { BlockBuilderResult, ValidatableBlock } from "./schemas";
 
-const BUILTIN_WHITELIST = new Set([
-	"entrypoint",
-	"consolelog",
-	"httpgetrequestbody",
-	"sticky_note",
-]);
+/** Storage stores these exact strings — anything else is a broken canvas. */
+const BUILTIN_TYPES = new Set<string>(Object.values(BlockTypes));
 
 function extractBlocksToValidate(
 	typedResult: BlockBuilderResult,
@@ -50,15 +46,10 @@ function collectCustomBlockNames(
 		const bType = block.blockType || "";
 		if (bType.startsWith("custom:")) {
 			customBlockNames.add(bType.slice(7));
-		} else {
-			const normType = bType.toLowerCase().replace(/_/g, "");
-			if (
-				!builtinBlockSchemas[normType] &&
-				bType &&
-				!BUILTIN_WHITELIST.has(bType)
-			) {
-				customBlockNames.add(bType);
-			}
+		} else if (bType && !BUILTIN_TYPES.has(bType)) {
+			// not a stored built-in type — the only other thing it can legally be
+			// is a custom block the user authored, so look that up before failing it
+			customBlockNames.add(bType);
 		}
 	}
 	return customBlockNames;
@@ -111,9 +102,7 @@ function validateBlockAgainstSchemas(
 	const errors: string[] = [];
 	const rawType = block.blockType || "";
 	const normType = rawType.toLowerCase().replace(/_/g, "");
-	const isCustom =
-		rawType.startsWith("custom:") ||
-		(!builtinBlockSchemas[normType] && customBlockSchemasMap.has(rawType));
+	const isCustom = rawType.startsWith("custom:") || !BUILTIN_TYPES.has(rawType);
 	const customName = isCustom
 		? rawType.startsWith("custom:")
 			? rawType.slice(7)
@@ -123,8 +112,15 @@ function validateBlockAgainstSchemas(
 	if (isCustom && customName) {
 		const inputParams = customBlockSchemasMap.get(customName);
 		if (!inputParams) {
+			// A near-miss on a built-in name (`get_http_header` for `httpgetheader`)
+			// used to sail through and persist a type nothing can execute.
+			const suggestion = [...BUILTIN_TYPES].find(
+				(type) => type.replace(/_/g, "").toLowerCase() === normType,
+			);
 			errors.push(
-				`Block "${block.id}" specifies custom block type "${customName}", but no custom block with that name exists in the project.`,
+				suggestion
+					? `Block "${block.id}" uses blockType "${rawType}", which is not a valid type. Use "${suggestion}" exactly as listed in the available blocks table.`
+					: `Block "${block.id}" specifies block type "${customName}", but it is neither a built-in block nor a custom block in this project. Use a type exactly as listed in the available blocks table.`,
 			);
 			return errors;
 		}

--- a/apps/ai-gateway/src/harness/errors.ts
+++ b/apps/ai-gateway/src/harness/errors.ts
@@ -104,6 +104,8 @@ export function explainErrorReason(raw: string): string {
 	if (
 		lower.includes("timeout") ||
 		lower.includes("timed out") ||
+		// what LangChain raises when the per-call timeout fires
+		lower.includes("invocation was aborted") ||
 		lower.includes("etimedout") ||
 		lower.includes("econnreset") ||
 		lower.includes("socket") ||
@@ -149,4 +151,18 @@ export function redactSecrets(text: string): string {
 			/\b(api[-_]?key|authorization|token)("?\s*[:=]\s*"?)[A-Za-z0-9._-]{8,}/gi,
 			"$1$2[redacted]",
 		);
+}
+
+/**
+ * True for the per-call timeout in the model wrapper (LangChain raises
+ * `ModelAbortError`/`AbortError` for it). Distinct from a user interrupt, which
+ * also aborts the run's signal — callers check that first.
+ */
+export function isCallTimeout(error: unknown): boolean {
+	const name = (error as { name?: string })?.name;
+	return (
+		name === "ModelAbortError" ||
+		name === "TimeoutError" ||
+		name === "AbortError"
+	);
 }

--- a/apps/ai-gateway/src/harness/models/base.ts
+++ b/apps/ai-gateway/src/harness/models/base.ts
@@ -12,7 +12,7 @@ import { StructuredTool } from "@langchain/core/tools";
 import { z } from "zod";
 import { logger } from "@fluxify/common";
 import { withRetry } from "../../lib/retry";
-import { UserInterruptError } from "../errors";
+import { UserInterruptError, isCallTimeout } from "../errors";
 import {
 	summarizeToolResult,
 	parseJsonLoose,
@@ -24,6 +24,7 @@ import {
 	SUBMIT_RESULT_TOOL,
 	SUBMIT_RESULT_INSTRUCTION,
 	compactToolHistory,
+	debugPrompt,
 	flattenToolMessages,
 	makeSubmitResultTool,
 	parseAsSchema,
@@ -462,6 +463,7 @@ export abstract class BaseAgentWrapper {
 			const response = (await withRetry(
 				async () => {
 					const startedAt = Date.now();
+					debugPrompt(agentNode, finalMessages);
 					const message = await model.invoke(
 						finalMessages,
 						this.withSignal(config),
@@ -660,6 +662,11 @@ ${JSON.stringify(jsonSchema, null, 2)}`;
 				return schema.parse(parseJsonLoose(content));
 			} catch (error) {
 				if (this.signal?.aborted) throw error;
+				// A call that timed out produced no output to correct. Re-asking just
+				// spends another full MODEL_CALL_TIMEOUT_MS on a provider that is
+				// already too slow, and the run dies on its deadline instead of
+				// reporting the real reason.
+				if (isCallTimeout(error)) throw error;
 				lastError = error;
 
 				// Nothing came back at all, so the provider rejected the request

--- a/apps/ai-gateway/src/harness/models/toolLoop.ts
+++ b/apps/ai-gateway/src/harness/models/toolLoop.ts
@@ -5,6 +5,7 @@ import {
 	ToolMessage,
 } from "@langchain/core/messages";
 import { StructuredTool, tool } from "@langchain/core/tools";
+import { logger } from "@fluxify/common";
 import { z } from "zod";
 import {
 	summarizeToolResult,
@@ -136,4 +137,25 @@ export function flattenToolMessages(messages: BaseMessage[]): BaseMessage[] {
 		);
 	}
 	return out;
+}
+
+/**
+ * Logs what a call is about to send, per message. Off unless
+ * HARNESS_DEBUG_PROMPT=1 — a run's prompt growth is invisible otherwise, and
+ * "the block builder is slow" is usually "its history grew to six figures".
+ */
+export function debugPrompt(
+	agentNode: string | undefined,
+	messages: BaseMessage[],
+): void {
+	if (process.env.HARNESS_DEBUG_PROMPT !== "1") return;
+	const size = (m: BaseMessage) =>
+		JSON.stringify(m.content).length +
+		JSON.stringify(m.additional_kwargs ?? {}).length;
+	logger.info("[Harness] prompt", {
+		agent: agentNode,
+		messages: messages.length,
+		chars: messages.reduce((sum, m) => sum + size(m), 0),
+		breakdown: messages.map((m) => `${m.getType()}:${size(m)}`).join(" "),
+	});
 }

--- a/apps/ai-gateway/src/lib/retry.spec.ts
+++ b/apps/ai-gateway/src/lib/retry.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "bun:test";
+import { rateLimitDelayMs } from "./retry";
+
+const rateLimited = (headers?: Record<string, string>) => ({
+	statusCode: 429,
+	headers,
+});
+
+describe("rateLimitDelayMs", () => {
+	it("ignores anything that is not a rate limit", () => {
+		expect(rateLimitDelayMs({ statusCode: 500 })).toBeNull();
+	});
+
+	it("doubles from 5s and caps at a minute", () => {
+		const delays = [1, 2, 3, 4, 5].map((attempt) =>
+			rateLimitDelayMs(rateLimited(), attempt),
+		);
+		expect(delays).toEqual([5000, 10000, 20000, 40000, 60000]);
+	});
+
+	it("prefers the provider's retry-after", () => {
+		expect(rateLimitDelayMs(rateLimited({ "retry-after": "3" }), 3)).toBe(3000);
+		expect(rateLimitDelayMs(rateLimited({ "retry-after": "600" }), 1)).toBe(60000);
+	});
+});

--- a/apps/ai-gateway/src/lib/retry.ts
+++ b/apps/ai-gateway/src/lib/retry.ts
@@ -14,13 +14,14 @@ export interface RetryOptions {
 
 /**
  * Rate limits are quota windows, not blips: a provider's per-minute token bucket
- * refills in seconds, so the exponential 0.5s/1s ladder just burns both retries
- * inside the same window and fails the run. Honour `retry-after` when the
- * provider sends one, otherwise wait a flat window.
+ * refills in seconds, so the 0.5s/1s ladder just burns both retries inside the
+ * same window and fails the run. Honour `retry-after` when the provider sends
+ * one, otherwise climb 5s → 10s → 20s, capped at a minute.
  */
-const RATE_LIMIT_WAIT_MS = 20000;
+const RATE_LIMIT_BASE_MS = 5000;
+const RATE_LIMIT_MAX_MS = 60000;
 
-export function rateLimitDelayMs(error: unknown): number | null {
+export function rateLimitDelayMs(error: unknown, attempt = 1): number | null {
   const status = (error as { statusCode?: number; status?: number })?.statusCode
     ?? (error as { status?: number })?.status;
   if (status !== 429) return null;
@@ -30,9 +31,12 @@ export function rateLimitDelayMs(error: unknown): number | null {
       ? headers.get("retry-after")
       : (headers as Record<string, string> | undefined)?.["retry-after"];
   const seconds = Number(retryAfter);
-  return Number.isFinite(seconds) && seconds > 0
-    ? Math.min(seconds * 1000, 60000)
-    : RATE_LIMIT_WAIT_MS;
+  if (Number.isFinite(seconds) && seconds > 0)
+    return Math.min(seconds * 1000, RATE_LIMIT_MAX_MS);
+  return Math.min(
+    RATE_LIMIT_BASE_MS * Math.pow(2, Math.max(attempt, 1) - 1),
+    RATE_LIMIT_MAX_MS,
+  );
 }
 
 export async function withRetry<T>(
@@ -70,7 +74,7 @@ export async function withRetry<T>(
       }
       
       const delay =
-        rateLimitDelayMs(error) ??
+        rateLimitDelayMs(error, attempt) ??
         Math.min(baseDelayMs * Math.pow(factor, attempt - 1), maxDelayMs);
       const errorMessage = error instanceof Error ? error.message : String(error);
       logger.warn(`[Retry] Operation failed (attempt ${attempt}/${maxRetries}). Retrying in ${delay}ms...`, { error: errorMessage });

--- a/apps/ai-gateway/src/lib/retry.ts
+++ b/apps/ai-gateway/src/lib/retry.ts
@@ -12,6 +12,29 @@ export interface RetryOptions {
   onRetry?: (attempt: number, maxRetries: number, error: unknown) => void;
 }
 
+/**
+ * Rate limits are quota windows, not blips: a provider's per-minute token bucket
+ * refills in seconds, so the exponential 0.5s/1s ladder just burns both retries
+ * inside the same window and fails the run. Honour `retry-after` when the
+ * provider sends one, otherwise wait a flat window.
+ */
+const RATE_LIMIT_WAIT_MS = 20000;
+
+export function rateLimitDelayMs(error: unknown): number | null {
+  const status = (error as { statusCode?: number; status?: number })?.statusCode
+    ?? (error as { status?: number })?.status;
+  if (status !== 429) return null;
+  const headers = (error as { headers?: Headers | Record<string, string> })?.headers;
+  const retryAfter =
+    headers instanceof Headers
+      ? headers.get("retry-after")
+      : (headers as Record<string, string> | undefined)?.["retry-after"];
+  const seconds = Number(retryAfter);
+  return Number.isFinite(seconds) && seconds > 0
+    ? Math.min(seconds * 1000, 60000)
+    : RATE_LIMIT_WAIT_MS;
+}
+
 export async function withRetry<T>(
   operation: () => Promise<T>,
   options: RetryOptions = {}
@@ -46,7 +69,9 @@ export async function withRetry<T>(
         throw error;
       }
       
-      const delay = Math.min(baseDelayMs * Math.pow(factor, attempt - 1), maxDelayMs);
+      const delay =
+        rateLimitDelayMs(error) ??
+        Math.min(baseDelayMs * Math.pow(factor, attempt - 1), maxDelayMs);
       const errorMessage = error instanceof Error ? error.message : String(error);
       logger.warn(`[Retry] Operation failed (attempt ${attempt}/${maxRetries}). Retrying in ${delay}ms...`, { error: errorMessage });
       options.onRetry?.(attempt, maxRetries, error);

--- a/apps/server/src/modules/canvas/repository.ts
+++ b/apps/server/src/modules/canvas/repository.ts
@@ -223,6 +223,31 @@ export async function parentExists(
 	return rows.length > 0;
 }
 
+/**
+ * The custom block names usable on this canvas — a custom block instance stores
+ * the block's `name` as its type (see `blocksLoader`'s customBlockGetter), so
+ * this is the other half of the valid-type set, next to `BlockTypes`.
+ */
+export async function getCustomBlockNames(
+	parent: CanvasParent,
+	tx?: DbTransactionType,
+): Promise<string[]> {
+	const table = parent.type === "route" ? routesEntity : customBlocksListEntity;
+	const rows = await (tx ?? db)
+		.select({ name: customBlocksListEntity.name })
+		.from(customBlocksListEntity)
+		.where(
+			eq(
+				customBlocksListEntity.projectId,
+				(tx ?? db)
+					.select({ projectId: table.projectId })
+					.from(table)
+					.where(eq(table.id, parent.id)),
+			),
+		);
+	return rows.map((row) => row.name);
+}
+
 export async function touchParent(
 	parent: CanvasParent,
 	tx?: DbTransactionType,

--- a/apps/server/src/modules/canvas/service.ts
+++ b/apps/server/src/modules/canvas/service.ts
@@ -14,6 +14,7 @@ import {
 	deleteStructuralBlocks,
 	getBlocks,
 	getBlocksCountByType,
+	getCustomBlockNames,
 	getEdges,
 	parentExists,
 	parentKeys,
@@ -114,6 +115,35 @@ async function assertCanvasHasNoCycles(
 }
 
 /**
+ * A block whose type is neither a built-in nor one of the project's custom
+ * blocks cannot be built — `BlockFactory` throws "Unknown block type" the first
+ * time the route is hit. Storage used to take any string, so a typo (or an AI
+ * agent using a near-miss name) was persisted and only surfaced at request time,
+ * on a canvas that looked fine in the editor.
+ */
+async function assertBlockTypesExist(
+	parent: CanvasParent,
+	data: CanvasChanges,
+	tx: DbTransactionType,
+) {
+	const builtin = new Set<string>(Object.values(BlockTypes));
+	const unknown = [
+		...new Set(
+			data.changes.blocks.map((b) => b.type).filter((t) => !builtin.has(t)),
+		),
+	];
+	if (unknown.length === 0) return;
+
+	const custom = new Set(await getCustomBlockNames(parent, tx));
+	const bad = unknown.filter((type) => !custom.has(type));
+	if (bad.length === 0) return;
+
+	throw new BadRequestError(
+		`Unknown block type(s): ${bad.join(", ")}. Use a built-in block type or a custom block defined in this project.`,
+	);
+}
+
+/**
  * A verified agent run's canvas can arrive after the entrypoint/error handler
  * it means to replace already exist under different ids (e.g. the route was
  * created with its own defaults before this canvas landed). The agent's
@@ -186,6 +216,7 @@ export async function saveCanvas(
 
 	// a tx nests as a savepoint, so the outer transaction still decides the outcome
 	await (outer ?? db).transaction(async (tx) => {
+		await assertBlockTypesExist(parent, data, tx);
 		await assertEdgeTargetsExist(parent, data, deleteBlockIds, tx);
 		await assertCanvasHasNoCycles(
 			parent,

--- a/apps/server/src/modules/canvas/tests/service.spec.ts
+++ b/apps/server/src/modules/canvas/tests/service.spec.ts
@@ -41,6 +41,16 @@ const delBlocks = spyOn(repository, "deleteBlocks");
 const delEdges = spyOn(repository, "deleteEdges");
 const delStructural = spyOn(repository, "deleteStructuralBlocks");
 const getEdges = spyOn(repository, "getEdges");
+const customBlockNames = spyOn(repository, "getCustomBlockNames");
+
+/** `changes` with its single block retyped */
+const withBlockType = (type: string) => ({
+	...changes,
+	changes: {
+		...changes.changes,
+		blocks: [{ ...changes.changes.blocks[0], type }],
+	},
+});
 
 describe("canvas saveCanvas", () => {
 	beforeEach(() => {
@@ -55,6 +65,29 @@ describe("canvas saveCanvas", () => {
 			spy.mockResolvedValue(undefined);
 		}
 		parentExists.mockResolvedValue(true);
+		customBlockNames.mockResolvedValue([]);
+	});
+
+	it("rejects a block type that is neither built-in nor a custom block", async () => {
+		// the exact shape an AI agent used to persist: a near-miss built-in name
+		const bad = withBlockType("get_http_header");
+
+		expect(saveCanvas({ type: "route", id: "r-1" }, bad, ["p1"])).rejects.toThrow(
+			BadRequestError,
+		);
+		expect(upsertBlocks).not.toHaveBeenCalled();
+	});
+
+	it("accepts a custom block defined in the project", async () => {
+		customBlockNames.mockResolvedValue(["stripe_charge"]);
+
+		await saveCanvas({ type: "route", id: "r-1" }, withBlockType("stripe_charge"), [
+			"p1",
+		]);
+
+		expect(upsertBlocks.mock.calls[0][0][0]).toMatchObject({
+			type: "stripe_charge",
+		});
 	});
 
 	it("writes a custom block canvas through the custom_block foreign key", async () => {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,9 @@
 services:
+  phoenix:
+    image: arizephoenix/phoenix:latest
+    ports:
+      - "6006:6006" # UI and OTLP HTTP collector
+      - "4317:4317" # OTLP gRPC collector
   postgres:
     image: postgres:bullseye
     container_name: postgres

--- a/packages/blocks/builtin/arrayOperations.ts
+++ b/packages/blocks/builtin/arrayOperations.ts
@@ -1,3 +1,4 @@
+import { BlockTypes } from "../blockTypes";
 import z from "zod";
 import { BaseBlock, baseBlockDataSchema, BlockOutput } from "../baseBlock";
 import { conditionSchema } from "@fluxify/lib";
@@ -39,7 +40,7 @@ export const arrayOperationsBlockSchema = z
   .extend(baseBlockDataSchema.shape);
 
 export const arrayOperationsAiDescription = {
-  name: "array_operations",
+  name: BlockTypes.arrayops,
   description:
     "Performs operations on an array variable (push, pop, shift, unshift).",
   jsonSchema: JSON.stringify(z.toJSONSchema(arrayOperationsBlockSchema)),

--- a/packages/blocks/builtin/blockAiDescriptions.spec.ts
+++ b/packages/blocks/builtin/blockAiDescriptions.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "bun:test";
+import { BlockTypes } from "../blockTypes";
+import { blockAiDescriptions } from "./blockAiDescriptions";
+import { builtinBlockSchemas } from "./blockSchemasMap";
+
+/**
+ * The name an AI description carries IS the block type the agent writes into a
+ * canvas, and storage only accepts `BlockTypes` values. When the two drifted
+ * apart (`get_http_header` vs `httpgetheader`) every AI-built route using those
+ * blocks persisted an unknown type — silently, because nothing validated it.
+ */
+describe("blockAiDescriptions", () => {
+	const storedTypes = new Set<string>(Object.values(BlockTypes));
+
+	it("names every block by its stored block type", () => {
+		for (const description of blockAiDescriptions) {
+			expect({ name: description.name, valid: storedTypes.has(description.name) }).toEqual({
+				name: description.name,
+				valid: true,
+			});
+		}
+	});
+
+	it("offers every block the agent is told to build", () => {
+		const offered = new Set(blockAiDescriptions.map((d) => d.name as string));
+		// the block builder prompt requires exactly one of each on a new canvas
+		expect(offered.has(BlockTypes.entrypoint)).toBe(true);
+		expect(offered.has(BlockTypes.errorHandler)).toBe(true);
+	});
+
+	it("keys every data schema by a stored block type", () => {
+		const keys = new Set(Object.values(BlockTypes).map((t) => t.replace(/_/g, "").toLowerCase()));
+		for (const key of Object.keys(builtinBlockSchemas)) {
+			expect({ key, valid: keys.has(key) }).toEqual({ key, valid: true });
+		}
+	});
+});

--- a/packages/blocks/builtin/blockAiDescriptions.ts
+++ b/packages/blocks/builtin/blockAiDescriptions.ts
@@ -26,6 +26,7 @@ import { consoleAiDescription } from "./log/console";
 import { forLoopAiDescription } from "./loops/for";
 import { foreachLoopAiDescription } from "./loops/foreach";
 import { cloudLogsAiDescription } from "./log/cloudLogs";
+import { errorHandlerAiDescription } from "./errorHandler";
 
 export const blockAiDescriptions = [
   arrayOperationsAiDescription,
@@ -56,4 +57,5 @@ export const blockAiDescriptions = [
   forLoopAiDescription,
   foreachLoopAiDescription,
   cloudLogsAiDescription,
+  errorHandlerAiDescription,
 ];

--- a/packages/blocks/builtin/blockSchemasMap.ts
+++ b/packages/blocks/builtin/blockSchemasMap.ts
@@ -5,6 +5,7 @@ import { getHttpHeaderBlockSchema } from "./http/getHttpHeader";
 import { getHttpParamBlockSchema } from "./http/getHttpParam";
 import { getHttpCookieBlockSchema } from "./http/getHttpCookie";
 import { setHttpCookieBlockSchema } from "./http/setHttpCookie";
+import { setHttpHeaderBlockSchema } from "./http/setHttpHeader";
 import { forLoopBlockSchema } from "./loops/for";
 import { forEachLoopBlockSchema } from "./loops/foreach";
 import { transformerBlockSchema } from "./transformer";
@@ -28,7 +29,7 @@ export const builtinBlockSchemas: Record<string, z.ZodTypeAny> = {
 	if: ifBlockSchema,
 	httprequest: httpRequestBlockSchema,
 	httpgetheader: getHttpHeaderBlockSchema,
-	httpsetheader: getHttpHeaderBlockSchema,
+	httpsetheader: setHttpHeaderBlockSchema,
 	httpgetparam: getHttpParamBlockSchema,
 	httpgetcookie: getHttpCookieBlockSchema,
 	httpsetcookie: setHttpCookieBlockSchema,
@@ -40,7 +41,6 @@ export const builtinBlockSchemas: Record<string, z.ZodTypeAny> = {
 	jsrunner: jsRunnerBlockSchema,
 	response: responseBlockSchema,
 	arrayops: arrayOperationsBlockSchema,
-	arrayoperations: arrayOperationsBlockSchema,
 	dbgetsingle: getSingleDbBlockSchema,
 	dbgetall: getAllDbBlockSchema,
 	dbdelete: deleteDbBlockSchema,

--- a/packages/blocks/builtin/db/delete.ts
+++ b/packages/blocks/builtin/db/delete.ts
@@ -1,3 +1,4 @@
+import { BlockTypes } from "../../blockTypes";
 import z from "zod";
 import {
   BaseBlock,
@@ -25,7 +26,7 @@ export const deleteDbBlockSchema = z
   .extend(baseBlockDataSchema.shape);
 
 export const deleteDbAiDescription = {
-  name: "db_delete",
+  name: BlockTypes.db_delete,
   description:
     "Deletes records from a database table matching specific conditions.",
   jsonSchema: JSON.stringify(z.toJSONSchema(deleteDbBlockSchema)),

--- a/packages/blocks/builtin/db/getAll.ts
+++ b/packages/blocks/builtin/db/getAll.ts
@@ -1,3 +1,4 @@
+import { BlockTypes } from "../../blockTypes";
 import z from "zod";
 import {
 	baseBlockDataSchema,
@@ -53,7 +54,7 @@ export const getAllDbBlockSchema = z
 	.extend(baseBlockDataSchema.shape);
 
 export const getAllDbAiDescription = {
-	name: "db_get_all",
+	name: BlockTypes.db_getall,
 	description: "Retrieves multiple records from a database table.",
 	jsonSchema: JSON.stringify(z.toJSONSchema(getAllDbBlockSchema)),
 };

--- a/packages/blocks/builtin/db/getSingle.ts
+++ b/packages/blocks/builtin/db/getSingle.ts
@@ -1,3 +1,4 @@
+import { BlockTypes } from "../../blockTypes";
 import z from "zod";
 import {
 	baseBlockDataSchema,
@@ -34,7 +35,7 @@ export const getSingleDbBlockSchema = z
 	.extend(baseBlockDataSchema.shape);
 
 export const getSingleDbAiDescription = {
-	name: "get_single",
+	name: BlockTypes.db_getsingle,
 	description: "Retrieves a single record from a database table.",
 	jsonSchema: JSON.stringify(z.toJSONSchema(getSingleDbBlockSchema)),
 };

--- a/packages/blocks/builtin/db/insert.ts
+++ b/packages/blocks/builtin/db/insert.ts
@@ -1,3 +1,4 @@
+import { BlockTypes } from "../../blockTypes";
 import z from "zod";
 import {
   baseBlockDataSchema,
@@ -26,7 +27,7 @@ export const insertDbBlockSchema = z
   .extend(baseBlockDataSchema.shape);
 
 export const insertDbAiDescription = {
-  name: "db_insert",
+  name: BlockTypes.db_insert,
   description:
     "Inserts a single record into a database table.",
   jsonSchema: JSON.stringify(z.toJSONSchema(insertDbBlockSchema)),

--- a/packages/blocks/builtin/db/insertBulk.ts
+++ b/packages/blocks/builtin/db/insertBulk.ts
@@ -1,3 +1,4 @@
+import { BlockTypes } from "../../blockTypes";
 import z from "zod";
 import {
   baseBlockDataSchema,
@@ -23,7 +24,7 @@ export const insertBulkDbBlockSchema = z
   .extend(baseBlockDataSchema.shape);
 
 export const insertBulkAiDescription = {
-  name: "db_insert_bulk",
+  name: BlockTypes.db_insertbulk,
   description:
     "Inserts multiple records into a database table in a batch.",
   jsonSchema: JSON.stringify(z.toJSONSchema(insertBulkDbBlockSchema)),

--- a/packages/blocks/builtin/db/native.ts
+++ b/packages/blocks/builtin/db/native.ts
@@ -1,3 +1,4 @@
+import { BlockTypes } from "../../blockTypes";
 import z from "zod";
 import {
 	baseBlockDataSchema,
@@ -22,7 +23,7 @@ export const nativeDbBlockSchema = z
 	.extend(baseBlockDataSchema.shape);
 
 export const nativeDbAiDescription = {
-	name: "db_native",
+	name: BlockTypes.db_native,
 	description: "Executes raw SQL or database-specific commands via JavaScript.",
 	jsonSchema: JSON.stringify(z.toJSONSchema(nativeDbBlockSchema)),
 };

--- a/packages/blocks/builtin/db/transaction.ts
+++ b/packages/blocks/builtin/db/transaction.ts
@@ -1,3 +1,4 @@
+import { BlockTypes } from "../../blockTypes";
 import z from "zod";
 import {
   baseBlockDataSchema,
@@ -22,7 +23,7 @@ export const transactionDbBlockSchema = z
   .extend(baseBlockDataSchema.shape);
 
 export const transactionDbAiDescription = {
-  name: "db_transaction",
+  name: BlockTypes.db_transaction,
   description:
     "Executes a sequence of database operations as a single atomic transaction.",
   jsonSchema: JSON.stringify(z.toJSONSchema(transactionDbBlockSchema)),

--- a/packages/blocks/builtin/db/update.ts
+++ b/packages/blocks/builtin/db/update.ts
@@ -1,3 +1,4 @@
+import { BlockTypes } from "../../blockTypes";
 import z from "zod";
 import {
 	baseBlockDataSchema,
@@ -39,7 +40,7 @@ export const updateDbBlockSchema = z
 	.extend(baseBlockDataSchema.shape);
 
 export const updateDbAiDescription = {
-	name: "db_update",
+	name: BlockTypes.db_update,
 	description:
 		"Updates records in a database table matching specific conditions.",
 	jsonSchema: JSON.stringify(z.toJSONSchema(updateDbBlockSchema)),

--- a/packages/blocks/builtin/entrypoint.ts
+++ b/packages/blocks/builtin/entrypoint.ts
@@ -1,3 +1,4 @@
+import { BlockTypes } from "../blockTypes";
 import z from "zod";
 import { BaseBlock, baseBlockDataSchema, BlockOutput } from "../baseBlock";
 import type { EmitNode } from "../compiler";
@@ -5,7 +6,7 @@ import type { EmitNode } from "../compiler";
 export const entrypointBlockSchema = z.object(baseBlockDataSchema.shape);
 
 export const entrypointAiDescription = {
-	name: "entrypoint",
+	name: BlockTypes.entrypoint,
 	description: "The initial block triggered by every incoming API request.",
 	jsonSchema: JSON.stringify(z.toJSONSchema(entrypointBlockSchema)),
 };

--- a/packages/blocks/builtin/errorHandler.ts
+++ b/packages/blocks/builtin/errorHandler.ts
@@ -1,3 +1,4 @@
+import { BlockTypes } from "../blockTypes";
 import {
   BaseBlock,
   baseBlockDataSchema,
@@ -18,6 +19,13 @@ export const errorHandlerBlockSchema = z
       }),
   })
   .extend(baseBlockDataSchema.shape);
+
+export const errorHandlerAiDescription = {
+  name: BlockTypes.errorHandler,
+  description:
+    "Catches a failure from any block on the canvas. Exactly one per canvas; connect its source handle to whatever should run when a block fails.",
+  jsonSchema: JSON.stringify(z.toJSONSchema(errorHandlerBlockSchema)),
+};
 
 export class ErrorHandlerBlock extends BaseBlock {
   private processed: boolean = false;

--- a/packages/blocks/builtin/getVar.ts
+++ b/packages/blocks/builtin/getVar.ts
@@ -1,3 +1,4 @@
+import { BlockTypes } from "../blockTypes";
 import z from "zod";
 import { BaseBlock, baseBlockDataSchema, BlockOutput } from "../baseBlock";
 import type { EmitNode } from "../compiler";
@@ -9,7 +10,7 @@ export const getVarBlockSchema = z
   .extend(baseBlockDataSchema.shape);
 
 export const getVarAiDescription = {
-  name: "get_var",
+  name: BlockTypes.getvar,
   description:
     "Retrieves a value from the global execution context.",
   jsonSchema: JSON.stringify(z.toJSONSchema(getVarBlockSchema)),

--- a/packages/blocks/builtin/http/getHttpCookie.ts
+++ b/packages/blocks/builtin/http/getHttpCookie.ts
@@ -1,3 +1,4 @@
+import { BlockTypes } from "../../blockTypes";
 import z from "zod";
 import { BaseBlock, BlockOutput } from "../../baseBlock";
 import { baseBlockDataSchema } from "../../baseBlock";
@@ -10,7 +11,7 @@ export const getHttpCookieBlockSchema = z
   .extend(baseBlockDataSchema.shape);
 
 export const getCookieAiDescription = {
-  name: "get_request_cookie",
+  name: BlockTypes.httpGetCookie,
   description:
     "Retrieves a specific cookie from the incoming request.",
   jsonSchema: JSON.stringify(z.toJSONSchema(getHttpCookieBlockSchema)),

--- a/packages/blocks/builtin/http/getHttpHeader.ts
+++ b/packages/blocks/builtin/http/getHttpHeader.ts
@@ -1,3 +1,4 @@
+import { BlockTypes } from "../../blockTypes";
 import z from "zod";
 import { BaseBlock, BlockOutput } from "../../baseBlock";
 import { baseBlockDataSchema } from "../../baseBlock";
@@ -10,7 +11,7 @@ export const getHttpHeaderBlockSchema = z
   .extend(baseBlockDataSchema.shape);
 
 export const getHttpHeaderAiDescription = {
-  name: "get_http_header",
+  name: BlockTypes.httpGetHeader,
   description:
     "Retrieves a specific header from the incoming request.",
   jsonSchema: JSON.stringify(z.toJSONSchema(getHttpHeaderBlockSchema)),

--- a/packages/blocks/builtin/http/getHttpParam.ts
+++ b/packages/blocks/builtin/http/getHttpParam.ts
@@ -1,3 +1,4 @@
+import { BlockTypes } from "../../blockTypes";
 import z from "zod";
 import { BaseBlock, BlockOutput } from "../../baseBlock";
 import { baseBlockDataSchema } from "../../baseBlock";
@@ -11,7 +12,7 @@ export const getHttpParamBlockSchema = z
   .extend(baseBlockDataSchema.shape);
 
 export const getHttpParamAiDescription = {
-  name: "get_http_param",
+  name: BlockTypes.httpGetParam,
   description:
     "Retrieves a query parameter or route parameter from the request.",
   jsonSchema: JSON.stringify(z.toJSONSchema(getHttpParamBlockSchema)),

--- a/packages/blocks/builtin/http/getHttpRequestBody.ts
+++ b/packages/blocks/builtin/http/getHttpRequestBody.ts
@@ -1,3 +1,4 @@
+import { BlockTypes } from "../../blockTypes";
 import z from "zod";
 import { BaseBlock, BlockOutput } from "../../baseBlock";
 import type { EmitNode } from "../../compiler";
@@ -5,7 +6,7 @@ import type { EmitNode } from "../../compiler";
 export const getHttpRequestBodyBlockSchema = z.any();
 
 export const getHttpRequestBodyAiDescription = {
-  name: "get_http_request_body",
+  name: BlockTypes.httpGetRequestBody,
   description:
     "Returns the body of the incoming request, parsed into the shape the route's content type implies: a JSON value, an object of form fields (multipart files arrive as File objects), a Blob for a raw binary body, or a string for plain text. Null when the request carries no body.",
   jsonSchema: JSON.stringify(z.toJSONSchema(getHttpRequestBodyBlockSchema)),

--- a/packages/blocks/builtin/http/setHttpCookie.ts
+++ b/packages/blocks/builtin/http/setHttpCookie.ts
@@ -1,3 +1,4 @@
+import { BlockTypes } from "../../blockTypes";
 import z from "zod";
 import {
   baseBlockDataSchema,
@@ -33,7 +34,7 @@ export const setHttpCookieBlockSchema = z
   .extend(baseBlockDataSchema.shape);
 
 export const setCookieAiDescription = {
-  name: "set_http_cookie",
+  name: BlockTypes.httpSetCookie,
   description:
     "Sets a cookie in the HTTP response.",
   jsonSchema: JSON.stringify(z.toJSONSchema(setHttpCookieBlockSchema)),

--- a/packages/blocks/builtin/http/setHttpHeader.ts
+++ b/packages/blocks/builtin/http/setHttpHeader.ts
@@ -1,3 +1,4 @@
+import { BlockTypes } from "../../blockTypes";
 import { baseBlockDataSchema, BaseBlock, BlockOutput } from "../../baseBlock";
 import z from "zod";
 import type { EmitNode } from "../../compiler";
@@ -10,7 +11,7 @@ export const setHttpHeaderBlockSchema = z
   .extend(baseBlockDataSchema.shape);
 
 export const setHeaderAiDescription = {
-  name: "set_http_header",
+  name: BlockTypes.httpSetHeader,
   description:
     "Sets a header in the HTTP response.",
   jsonSchema: JSON.stringify(z.toJSONSchema(setHttpHeaderBlockSchema)),

--- a/packages/blocks/builtin/httpRequest.ts
+++ b/packages/blocks/builtin/httpRequest.ts
@@ -1,3 +1,4 @@
+import { BlockTypes } from "../blockTypes";
 import z from "zod";
 import {
   BaseBlock,
@@ -18,7 +19,7 @@ export const httpRequestBlockSchema = z
   .extend(baseBlockDataSchema.shape);
 
 export const httpRequestAiDescription = {
-  name: "http_request",
+  name: BlockTypes.httprequest,
   description:
     "Sends an HTTP request to an external URL.",
   jsonSchema: JSON.stringify(z.toJSONSchema(httpRequestBlockSchema)),

--- a/packages/blocks/builtin/if.ts
+++ b/packages/blocks/builtin/if.ts
@@ -1,3 +1,4 @@
+import { BlockTypes } from "../blockTypes";
 import {
   conditionSchema,
   evaluateOperator,
@@ -24,7 +25,7 @@ export const ifBlockSchema = z
   .extend(baseBlockDataSchema.shape);
 
 export const ifConditionAiDescription = {
-  name: "if_condition",
+  name: BlockTypes.if,
   description:
     "Branches the flow like an IF/ELSE statement. Directs flow based on whether the condition returns TRUE or FALSE.",
   jsonSchema: JSON.stringify(z.toJSONSchema(ifBlockSchema)),

--- a/packages/blocks/builtin/jsRunner.ts
+++ b/packages/blocks/builtin/jsRunner.ts
@@ -1,3 +1,4 @@
+import { BlockTypes } from "../blockTypes";
 import z from "zod";
 import { BaseBlock, baseBlockDataSchema, BlockOutput } from "../baseBlock";
 import type { EmitNode } from "../compiler";
@@ -9,7 +10,7 @@ export const jsRunnerBlockSchema = z
 	.extend(baseBlockDataSchema.shape);
 
 export const jsRunnerAiDescription = {
-	name: "js_runner",
+	name: BlockTypes.jsrunner,
 	description: "Executes JavaScript code within an isolated function scope.",
 	jsonSchema: JSON.stringify(z.toJSONSchema(jsRunnerBlockSchema)),
 };

--- a/packages/blocks/builtin/log/cloudLogs.ts
+++ b/packages/blocks/builtin/log/cloudLogs.ts
@@ -1,3 +1,4 @@
+import { BlockTypes } from "../../blockTypes";
 import z from "zod";
 import { BaseBlock, BlockOutput, Context } from "../../baseBlock";
 import { formatMessage, logBlockSchema } from ".";
@@ -12,7 +13,7 @@ export const cloudLogsBlockSchema = z
 	.extend(logBlockSchema.shape);
 
 export const cloudLogsAiDescription = {
-	name: "cloud_logs",
+	name: BlockTypes.cloudLogs,
 	description: "Logs a message to the cloud logging service.",
 	jsonSchema: JSON.stringify(z.toJSONSchema(cloudLogsBlockSchema)),
 };

--- a/packages/blocks/builtin/log/console.ts
+++ b/packages/blocks/builtin/log/console.ts
@@ -1,3 +1,4 @@
+import { BlockTypes } from "../../blockTypes";
 import z from "zod";
 import { BaseBlock, BlockOutput, Context } from "../../baseBlock";
 import { formatMessage, logBlockSchema } from ".";
@@ -39,7 +40,7 @@ export function emitConsoleLog(node: EmitNode) {
 }
 
 export const consoleAiDescription = {
-  name: "console_log",
+  name: BlockTypes.consolelog,
   description:
     "Logs a message to the system console.",
   jsonSchema: JSON.stringify(z.toJSONSchema(logBlockSchema)),

--- a/packages/blocks/builtin/loops/for.ts
+++ b/packages/blocks/builtin/loops/for.ts
@@ -1,3 +1,4 @@
+import { BlockTypes } from "../../blockTypes";
 import z from "zod";
 import {
   baseBlockDataSchema,
@@ -34,7 +35,7 @@ export const forLoopBlockSchema = z
   .extend(baseBlockDataSchema.shape);
 
 export const forLoopAiDescription = {
-  name: "for_loop",
+  name: BlockTypes.forloop,
   description:
     "Iterates a specific number of times, executing a child block each iteration.",
   jsonSchema: JSON.stringify(z.toJSONSchema(forLoopBlockSchema)),

--- a/packages/blocks/builtin/loops/foreach.ts
+++ b/packages/blocks/builtin/loops/foreach.ts
@@ -1,3 +1,4 @@
+import { BlockTypes } from "../../blockTypes";
 import z from "zod";
 import {
   baseBlockDataSchema,
@@ -27,7 +28,7 @@ export const forEachLoopBlockSchema = z
   .extend(baseBlockDataSchema.shape);
 
 export const foreachLoopAiDescription = {
-  name: "foreach_loop",
+  name: BlockTypes.foreachloop,
   description:
     "Iterates over an array of items, executing a child block for each item.",
   jsonSchema: JSON.stringify(z.toJSONSchema(forEachLoopBlockSchema)),

--- a/packages/blocks/builtin/response.ts
+++ b/packages/blocks/builtin/response.ts
@@ -1,3 +1,4 @@
+import { BlockTypes } from "../blockTypes";
 import z from "zod";
 import {
   BaseBlock,
@@ -15,9 +16,9 @@ export const responseBlockSchema = z
   .extend(baseBlockDataSchema.shape);
 
 export const responseAiDescription = {
-  name: "response",
+  name: BlockTypes.response,
   description:
-    "Terminates the request and returns the result to the client.",
+    "Terminates the request and returns the result to the client. Only sets the status code — the response body is whatever the previous block output, so shape the body in the block feeding this one.",
   jsonSchema: JSON.stringify(z.toJSONSchema(responseBlockSchema)),
 };
 

--- a/packages/blocks/builtin/setVar.ts
+++ b/packages/blocks/builtin/setVar.ts
@@ -1,3 +1,4 @@
+import { BlockTypes } from "../blockTypes";
 import z from "zod";
 import {
   BaseBlock,
@@ -20,7 +21,7 @@ export const setVarSchema = z
   .describe("A useful block to set a variable in the context");
 
 export const setVarBlockAiDescription = {
-  name: "set_var",
+  name: BlockTypes.setvar,
   description:
     "Assigns a value to a variable in the global execution context.",
   jsonSchema: JSON.stringify(z.toJSONSchema(setVarSchema)),

--- a/packages/blocks/builtin/stickyNote.ts
+++ b/packages/blocks/builtin/stickyNote.ts
@@ -1,3 +1,4 @@
+import { BlockTypes } from "../blockTypes";
 import z from "zod";
 import { BaseBlock, BlockOutput, baseBlockDataSchema } from "../baseBlock";
 
@@ -13,7 +14,7 @@ export const stickyNotesSchema = z
   .extend(baseBlockDataSchema.shape);
 
 export const stickyNoteBlockAiDescription = {
-  name: "sticky_note",
+  name: BlockTypes.sticky_note,
   description:
     "Adds an annotation or note to the canvas. Does not affect execution flow.",
   jsonSchema: JSON.stringify(z.toJSONSchema(stickyNotesSchema)),

--- a/packages/blocks/builtin/transformer.ts
+++ b/packages/blocks/builtin/transformer.ts
@@ -1,3 +1,4 @@
+import { BlockTypes } from "../blockTypes";
 import z from "zod";
 import { BaseBlock, BlockOutput, Context } from "../baseBlock";
 import { baseBlockDataSchema } from "../baseBlock";
@@ -23,7 +24,7 @@ export const transformerBlockSchema = z
 export const transformerParamsSchema = z.record(z.string(), z.any().optional());
 
 export const transformBlockAiDescription = {
-  name: "transformer",
+  name: BlockTypes.transformer,
   description:
     "Transforms input data into a new structure using JavaScript.",
   jsonSchema: JSON.stringify(z.toJSONSchema(transformerBlockSchema)),


### PR DESCRIPTION
## Why

The harness failed at the block builder on every run. Root cause: the AI-facing block catalogue named blocks differently from what storage stores. `blockAiDescriptions` advertised names like `get_http_header` while `BlockTypes` (the canonical stored string) is `httpgetheader`. Nothing caught the drift — the artifact normalizer fell back to the raw string, and the supervisor validator silently skipped types it could not resolve — so a run either failed validation or persisted a canvas whose blocks `BlockFactory` cannot build.

Two smaller bugs rode along: `error_handler` was missing from the catalogue entirely even though the block-builder prompt requires exactly one per canvas, and `httpsetheader` was mapped to the *get* schema.

## What

- **`packages/blocks`** — every `*AiDescription.name` is now its `BlockTypes` value; added `errorHandlerAiDescription`; fixed the `httpsetheader` schema mapping; `response`'s description now says the body comes from the previous block (a run burned ~12 doc searches hunting a `body` field that does not exist). New spec asserts every AI name is a real `BlockTypes` value, so the drift cannot come back.
- **validator** — the ad-hoc whitelist is replaced by `BlockTypes` itself; an unknown type now errors with a near-miss suggestion instead of being skipped.
- **normalizer** — strips the `custom:` prefix (prompt syntax; a custom block instance stores the block's bare name).
- **`apps/server` canvas** — `saveCanvas` rejects a block type that is neither built-in nor a custom block in the project, so an unbuildable canvas can no longer be persisted by any caller. The extra lookup only runs when something is not a built-in.
- **rate limits** — a 429 waited a flat 20s; now 5s → 10s → 20s → 40s, capped at a minute, with `retry-after` still winning.
- **timeouts** — a provider call that times out is no longer re-asked by the structured-output loop (it only burned the run deadline), and `explainErrorReason` recognises `invocation was aborted` instead of reporting "an unexpected error".
- **compose** — phoenix service for local LLM trace inspection.

## Testing

Full harness run end to end against mistral-medium-latest: completed in 86s, and the persisted artifact contained `httpgetheader / jsrunner / if / response` with every block parsing clean against its real zod schema. The new backoff ladder was observed live (`Retrying in 5000ms` → `10000ms`). Lint clean on `apps/server` and `apps/ai-gateway`; 723 tests across 126 files, 0 fail.

Not exercised: the artifact apply path over the NATS ops bus (needs the server worker running).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
