### PR TITLE
feat(instance-settings): simplify auth settings API

### DIFF
--- a/apps/server/src/api/v1/instance-settings/get-auth-settings/dto.ts
+++ b/apps/server/src/api/v1/instance-settings/get-auth-settings/dto.ts
@@ -1,0 +1,6 @@
+import z from "zod";
+
+export const responseSchema = z.object({
+	type: z.enum(["traditional", "sso"]),
+	sso_config: z.record(z.string(), z.unknown()),
+});

--- a/apps/server/src/api/v1/instance-settings/get-auth-settings/route.ts
+++ b/apps/server/src/api/v1/instance-settings/get-auth-settings/route.ts
@@ -1,0 +1,59 @@
+import { describeRoute, DescribeRouteOptions, resolver } from "hono-openapi";
+import { responseSchema } from "./dto";
+import handleRequest from "./service";
+import { errorSchema } from "../../../../errors/customError";
+import { HonoServer } from "../../../../types";
+import { requireSystemAdmin } from "../../../auth/middleware";
+
+const openapiRouteOptions: DescribeRouteOptions = {
+	description:
+		"Get simplified authentication settings: a single 'type' (traditional|sso) plus the SSO config, instead of the raw auth_config/sso_config pair.",
+	operationId: "get-auth-settings",
+	tags: ["Instance Settings"],
+	responses: {
+		200: {
+			description: "Successful",
+			content: {
+				"application/json": {
+					schema: resolver(responseSchema),
+				},
+			},
+		},
+		401: {
+			description: "Unauthorized",
+			content: {
+				"application/json": {
+					schema: resolver(errorSchema),
+				},
+			},
+		},
+		403: {
+			description: "Forbidden",
+			content: {
+				"application/json": {
+					schema: resolver(errorSchema),
+				},
+			},
+		},
+		500: {
+			description: "Internal Server Error",
+			content: {
+				"application/json": {
+					schema: resolver(errorSchema),
+				},
+			},
+		},
+	},
+};
+
+export default function (app: HonoServer) {
+	app.get(
+		"/auth",
+		describeRoute(openapiRouteOptions),
+		requireSystemAdmin,
+		async (c) => {
+			const result = await handleRequest();
+			return c.json(result);
+		},
+	);
+}

--- a/apps/server/src/api/v1/instance-settings/get-auth-settings/service.ts
+++ b/apps/server/src/api/v1/instance-settings/get-auth-settings/service.ts
@@ -1,0 +1,15 @@
+import { redactSecrets } from "../../../../lib/instance-settings/schemas";
+import { getInstanceSettingByKey } from "../upsert/repository";
+
+export default async function handleRequest() {
+	const [authRow, ssoRow] = await Promise.all([
+		getInstanceSettingByKey("auth_config"),
+		getInstanceSettingByKey("sso_config"),
+	]);
+	const mode = (authRow?.value as { mode?: string } | undefined)?.mode;
+
+	return {
+		type: mode === "sso_only" ? "sso" : "traditional",
+		sso_config: redactSecrets((ssoRow?.value as Record<string, unknown>) ?? {}),
+	};
+}

--- a/apps/server/src/api/v1/instance-settings/patch-auth-settings/dto.ts
+++ b/apps/server/src/api/v1/instance-settings/patch-auth-settings/dto.ts
@@ -1,0 +1,16 @@
+import z from "zod";
+import { ssoConfigSchema } from "../../../../lib/instance-settings/schemas";
+
+// enabled is derived from `type`, never sent by the client
+const ssoConfigPatchSchema = ssoConfigSchema.omit({ enabled: true }).partial();
+
+export const requestBodySchema = z.object({
+	type: z.enum(["traditional", "sso"]),
+	sso_config: ssoConfigPatchSchema.optional(),
+});
+
+export const responseSchema = z.object({
+	message: z.string(),
+	type: z.enum(["traditional", "sso"]),
+	sso_config: z.record(z.string(), z.unknown()),
+});

--- a/apps/server/src/api/v1/instance-settings/patch-auth-settings/route.ts
+++ b/apps/server/src/api/v1/instance-settings/patch-auth-settings/route.ts
@@ -1,0 +1,76 @@
+import {
+	describeRoute,
+	DescribeRouteOptions,
+	resolver,
+	validator,
+} from "hono-openapi";
+import { requestBodySchema, responseSchema } from "./dto";
+import handleRequest from "./service";
+import zodErrorCallbackParser from "../../../../middlewares/zodErrorCallbackParser";
+import { errorSchema } from "../../../../errors/customError";
+import { validationErrorSchema } from "../../../../errors/validationError";
+import { HonoServer } from "../../../../types";
+import { requireSystemAdmin } from "../../../auth/middleware";
+
+const openapiRouteOptions: DescribeRouteOptions = {
+	description:
+		"Set authentication type (traditional|sso) and partially patch the SSO config. Only the SSO keys sent are merged into the stored config — omitted keys keep their current value.",
+	operationId: "patch-auth-settings",
+	tags: ["Instance Settings"],
+	responses: {
+		200: {
+			description: "Successful",
+			content: {
+				"application/json": {
+					schema: resolver(responseSchema),
+				},
+			},
+		},
+		400: {
+			description: "Validation Error",
+			content: {
+				"application/json": {
+					schema: resolver(validationErrorSchema),
+				},
+			},
+		},
+		401: {
+			description: "Unauthorized",
+			content: {
+				"application/json": {
+					schema: resolver(errorSchema),
+				},
+			},
+		},
+		403: {
+			description: "Forbidden",
+			content: {
+				"application/json": {
+					schema: resolver(errorSchema),
+				},
+			},
+		},
+		500: {
+			description: "Internal Server Error",
+			content: {
+				"application/json": {
+					schema: resolver(errorSchema),
+				},
+			},
+		},
+	},
+};
+
+export default function (app: HonoServer) {
+	app.patch(
+		"/auth",
+		describeRoute(openapiRouteOptions),
+		requireSystemAdmin,
+		validator("json", requestBodySchema, zodErrorCallbackParser),
+		async (c) => {
+			const body = c.req.valid("json");
+			const result = await handleRequest(body);
+			return c.json(result);
+		},
+	);
+}

--- a/apps/server/src/api/v1/instance-settings/patch-auth-settings/service.ts
+++ b/apps/server/src/api/v1/instance-settings/patch-auth-settings/service.ts
@@ -1,0 +1,79 @@
+import { BadRequestError } from "../../../../errors/badRequestError";
+import { ssoConfigSchema, redactSecrets } from "../../../../lib/instance-settings/schemas";
+import { getInstanceSettingByKey, upsertInstanceSetting } from "../upsert/repository";
+import { CHAN_ON_INSTANCE_SETTING_CHANGE, publishMessage } from "../../../../db/redis";
+
+export interface AuthSettingsPayload {
+	type: "traditional" | "sso";
+	sso_config?: Record<string, unknown>;
+}
+
+function formatIssues(error: import("zod").ZodError) {
+	return error.issues
+		.map((e) => `${e.path.join(".") || "value"}: ${e.message}`)
+		.join("; ");
+}
+
+function requireProviderFields(sso: ReturnType<typeof ssoConfigSchema.parse>) {
+	if (sso.provider === "oidc") {
+		if (!sso.clientId?.trim() || !sso.clientSecret?.trim()) {
+			throw new BadRequestError(
+				"Authentication type 'sso' requires 'clientId' and 'clientSecret' for the OIDC provider.",
+			);
+		}
+	} else if (sso.provider === "saml") {
+		if (!sso.entryPoint?.trim() || !sso.samlCert?.trim()) {
+			throw new BadRequestError(
+				"Authentication type 'sso' requires 'entryPoint' and 'samlCert' for the SAML provider.",
+			);
+		}
+	}
+}
+
+export default async function handleRequest(payload: AuthSettingsPayload) {
+	const { type, sso_config: ssoPatch } = payload;
+	const wantsSso = type === "sso";
+	const hasPatch = !!ssoPatch && Object.keys(ssoPatch).length > 0;
+
+	const existingSsoRow = await getInstanceSettingByKey("sso_config");
+	let ssoValue = (existingSsoRow?.value as Record<string, unknown>) ?? {};
+
+	// Only touch sso_config when there's something to merge or the row already
+	// exists — switching to 'traditional' with no prior SSO setup is a no-op.
+	if (wantsSso || hasPatch || existingSsoRow) {
+		const merged = { ...ssoValue, ...ssoPatch, enabled: wantsSso };
+		const parsed = ssoConfigSchema.safeParse(merged);
+
+		if (!parsed.success) {
+			if (wantsSso || hasPatch) {
+				throw new BadRequestError(
+					`Validation failed for SSO configuration: ${formatIssues(parsed.error)}`,
+				);
+			}
+			// disabling, no patch, and the stored config was already incomplete — leave it alone
+		} else {
+			if (wantsSso) requireProviderFields(parsed.data);
+			const updated = await upsertInstanceSetting({
+				key: "sso_config",
+				category: "auth",
+				value: parsed.data,
+			});
+			ssoValue = updated.value as Record<string, unknown>;
+		}
+	}
+
+	await upsertInstanceSetting({
+		key: "auth_config",
+		category: "auth",
+		value: { mode: wantsSso ? "sso_only" : "traditional" },
+	});
+
+	// One reload covers both keys — the subscriber re-reads the whole table.
+	await publishMessage(CHAN_ON_INSTANCE_SETTING_CHANGE, { key: "auth_config" });
+
+	return {
+		message: "Authentication settings saved successfully",
+		type,
+		sso_config: redactSecrets(ssoValue),
+	};
+}

--- a/apps/server/src/api/v1/instance-settings/patch-auth-settings/tests/service.spec.ts
+++ b/apps/server/src/api/v1/instance-settings/patch-auth-settings/tests/service.spec.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+const store: Record<string, { key: string; category: string; value: any; isPublic: boolean }> = {};
+const published = mock((_channel: string, _payload: unknown) => {});
+
+mock.module("../../upsert/repository", () => ({
+	getInstanceSettingByKey: async (key: string) => store[key] ?? null,
+	upsertInstanceSetting: async (data: { key: string; category: string; value: Record<string, unknown>; isPublic?: boolean }) => {
+		store[data.key] = {
+			key: data.key,
+			category: data.category,
+			value: data.value,
+			isPublic: data.isPublic ?? store[data.key]?.isPublic ?? false,
+		};
+		return store[data.key];
+	},
+}));
+
+mock.module("../../../../../db/redis", () => ({
+	CHAN_ON_INSTANCE_SETTING_CHANGE: "instance_setting_change",
+	publishMessage: (channel: string, payload: unknown) => published(channel, payload),
+}));
+
+const handleRequest = (await import("../service")).default;
+
+const validOidc = {
+	provider: "oidc",
+	providerId: "enterprise",
+	issuer: "https://idp.example.com",
+	domain: "example.com",
+	clientId: "client-1",
+	clientSecret: "secret-1",
+};
+
+beforeEach(() => {
+	for (const k of Object.keys(store)) delete store[k];
+	published.mockClear();
+});
+
+describe("patch-auth-settings service", () => {
+	it("enables SSO from a complete existing config with no patch", async () => {
+		store.sso_config = { key: "sso_config", category: "auth", value: { ...validOidc, enabled: false }, isPublic: false };
+
+		const result = await handleRequest({ type: "sso" });
+
+		expect(result.type).toBe("sso");
+		expect(store.sso_config.value.enabled).toBe(true);
+		expect(store.auth_config.value.mode).toBe("sso_only");
+		expect(published).toHaveBeenCalledTimes(1);
+	});
+
+	it("rejects enabling SSO when required provider fields are missing", async () => {
+		store.sso_config = {
+			key: "sso_config",
+			category: "auth",
+			value: { ...validOidc, clientSecret: undefined, enabled: false },
+			isPublic: false,
+		};
+
+		await expect(handleRequest({ type: "sso" })).rejects.toThrow(/clientSecret|clientId/);
+	});
+
+	it("disables SSO without wiping the stored config", async () => {
+		store.sso_config = { key: "sso_config", category: "auth", value: { ...validOidc, enabled: true }, isPublic: false };
+
+		const result = await handleRequest({ type: "traditional" });
+
+		expect(result.type).toBe("traditional");
+		expect(store.sso_config.value.enabled).toBe(false);
+		expect(store.sso_config.value.issuer).toBe(validOidc.issuer); // preserved
+		expect(store.auth_config.value.mode).toBe("traditional");
+	});
+
+	it("merges a partial sso_config patch instead of replacing it", async () => {
+		store.sso_config = { key: "sso_config", category: "auth", value: { ...validOidc, enabled: true }, isPublic: false };
+
+		const result = await handleRequest({ type: "sso", sso_config: { clientId: "new-client-id" } });
+
+		expect(result.type).toBe("sso");
+		expect(store.sso_config.value.clientId).toBe("new-client-id");
+		expect(store.sso_config.value.issuer).toBe(validOidc.issuer); // untouched key survives the patch
+		expect(store.sso_config.value.domain).toBe(validOidc.domain);
+	});
+
+	it("is a no-op for sso_config when switching to traditional with nothing stored", async () => {
+		const result = await handleRequest({ type: "traditional" });
+
+		expect(result.type).toBe("traditional");
+		expect(store.sso_config).toBeUndefined();
+		expect(store.auth_config.value.mode).toBe("traditional");
+	});
+});

--- a/apps/server/src/api/v1/instance-settings/register.ts
+++ b/apps/server/src/api/v1/instance-settings/register.ts
@@ -2,6 +2,8 @@ import registerGetAllRoute from "./get-all/route";
 import registerGetByCategoryRoute from "./get-by-category/route";
 import registerGetByKeyRoute from "./get-by-key/route";
 import registerUpsertRoute from "./upsert/route";
+import registerGetAuthSettingsRoute from "./get-auth-settings/route";
+import registerPatchAuthSettingsRoute from "./patch-auth-settings/route";
 import { HonoServer } from "../../../types";
 
 export default {
@@ -12,5 +14,7 @@ export default {
 		registerGetByCategoryRoute(router);
 		registerGetByKeyRoute(router);
 		registerUpsertRoute(router);
+		registerGetAuthSettingsRoute(router);
+		registerPatchAuthSettingsRoute(router);
 	},
 };


### PR DESCRIPTION
## Summary
- Add `GET`/`PATCH /instance-settings/auth`, replacing the confusing enable+mode two-call flow with a single `type: "traditional"|"sso"` field.
- `PATCH` treats `sso_config` as a partial patch — only sent keys are merged into the stored JSONB value, so the frontend never has to resend the full config just to change one field.
- Existing `PUT /instance-settings` upsert route and `sso_config`/`auth_config` storage keys are untouched, so `lib/auth.ts` (`ssoDefaults`, `trustedOrigins`) and the settings reload loader keep working unchanged.

## Test plan
- [x] `bun run lint` (tsgo --noEmit) clean
- [x] `bun test src/api/v1/instance-settings` — 17 pass, 0 fail (new + existing sibling endpoints)
- [x] Full pre-commit suite — 729 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)