### PR TITLE
fix(instance-settings): expose auth_config/sso_config on the public settings feed

### DIFF
--- a/apps/server/src/api/v1/instance-settings/upsert/repository.ts
+++ b/apps/server/src/api/v1/instance-settings/upsert/repository.ts
@@ -2,6 +2,7 @@ import { eq } from "drizzle-orm";
 import { db } from "../../../../db";
 import { instanceSettingsEntity } from "../../../../db/schema";
 import { generateID } from "@fluxify/lib";
+import { resolveIsPublic } from "../../../../lib/instance-settings/schemas";
 
 export async function getInstanceSettingByKey(key: string) {
 	const rows = await db
@@ -19,7 +20,7 @@ export async function upsertInstanceSetting(data: {
 }) {
 	const now = new Date();
 	const existing = await getInstanceSettingByKey(data.key);
-	const isPublic = data.isPublic ?? existing?.isPublic ?? false;
+	const isPublic = resolveIsPublic(data.key, data.isPublic, existing?.isPublic);
 
 	const [updated] = await db
 		.insert(instanceSettingsEntity)

--- a/apps/server/src/lib/instance-settings/schemas.ts
+++ b/apps/server/src/lib/instance-settings/schemas.ts
@@ -43,11 +43,15 @@ export const INSTANCE_SETTINGS_REGISTRY = {
 		category: "auth",
 		schema: ssoConfigSchema,
 		publicSchema: ssoConfigPublicSchema,
+		// the login screen needs provider/enabled/issuer/domain before the user
+		// is authenticated; publicSchema already strips secrets, so this is safe.
+		alwaysPublic: true,
 	},
 	auth_config: {
 		category: "auth",
 		schema: authConfigSchema,
 		publicSchema: authConfigSchema,
+		alwaysPublic: true,
 	},
 } as const;
 
@@ -60,6 +64,22 @@ export type InstanceSettingValue<K extends InstanceSettingKey> = z.infer<
 
 export function isInstanceSettingKey(key: string): key is InstanceSettingKey {
 	return key in INSTANCE_SETTINGS_REGISTRY;
+}
+
+/**
+ * Registry-forced keys (auth_config/sso_config) are always public — the
+ * login screen needs them pre-auth, and publicSchema already strips
+ * secrets — so no caller can opt them back into private.
+ */
+export function resolveIsPublic(
+	key: string,
+	callerIsPublic: boolean | undefined,
+	existingIsPublic: boolean | undefined,
+): boolean {
+	if (isInstanceSettingKey(key) && INSTANCE_SETTINGS_REGISTRY[key].alwaysPublic) {
+		return true;
+	}
+	return callerIsPublic ?? existingIsPublic ?? false;
 }
 
 // ponytail: name-based secret list; add fields as new secret-bearing keys appear.

--- a/apps/server/src/lib/instance-settings/tests/schemas.spec.ts
+++ b/apps/server/src/lib/instance-settings/tests/schemas.spec.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "bun:test";
+import { resolveIsPublic } from "../schemas";
+
+describe("resolveIsPublic", () => {
+	it("forces sso_config public even when the caller explicitly sends false", () => {
+		expect(resolveIsPublic("sso_config", false, false)).toBe(true);
+	});
+
+	it("forces auth_config public when nothing is passed at all", () => {
+		expect(resolveIsPublic("auth_config", undefined, undefined)).toBe(true);
+	});
+
+	it("leaves a non-registry key at the normal default (false)", () => {
+		expect(resolveIsPublic("some_other_key", undefined, undefined)).toBe(false);
+	});
+
+	it("still respects the caller/stored isPublic for a non-forced key", () => {
+		expect(resolveIsPublic("some_other_key", undefined, true)).toBe(true);
+		expect(resolveIsPublic("some_other_key", true, undefined)).toBe(true);
+		expect(resolveIsPublic("some_other_key", false, true)).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary
- The unauthenticated `/public-settings` feed (`_/admin/api/public-settings`) already existed and already redacts via each key's `publicSchema` — but `auth_config`/`sso_config` were only ever written with `isPublic` defaulting to `false`, so an unauthenticated login screen could never see whether SSO is enabled.
- `resolveIsPublic()` (`lib/instance-settings/schemas.ts`) now forces those two registry keys public on every write, applied in the single shared write path (`upsert/repository.ts`) both the legacy PUT and the new PATCH auth-settings endpoint go through.
- Secrets never leave the row regardless — `sso_config`'s `publicSchema` only ever projects `provider/enabled/providerId/issuer/domain`.

## Test plan
- [x] `bun run lint` (tsgo --noEmit) clean
- [x] `bun test src/api/v1/instance-settings src/lib/instance-settings` — 23 pass, 0 fail
- [x] Full pre-commit suite — 733 pass, 0 fail
- [x] Verified live against a running dev server: `GET /_/admin/api/public-settings` → 200, redacted `sso_config`/`auth_config`, no auth; `GET /_/admin/api/v1/instance-settings/auth` → still 403 without a session

🤖 Generated with [Claude Code](https://claude.com/claude-code)