### PR TITLE
feat(canvas): enhance canvas layout controls

### DIFF
--- a/apps/portal/src/components/canvas/BlockCanvas.tsx
+++ b/apps/portal/src/components/canvas/BlockCanvas.tsx
@@ -3,17 +3,18 @@ import {
 	addEdge,
 	Background,
 	BackgroundVariant,
-	Controls,
 	ReactFlow,
 	ReactFlowProvider,
 	useEdgesState,
 	useNodesState,
+	useReactFlow,
 	type Connection,
 	type EdgeChange,
 	type NodeChange,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import "./canvas.css";
+import { CanvasLayoutLockProvider } from "./CanvasLayoutLockContext";
 import { flowToGraph, graphToFlow } from "./adapters";
 import { AiCanvasButton } from "./aiButton";
 import {
@@ -32,12 +33,18 @@ import { findCycleEdgeIds } from "./cycleDetection";
 import { uuidv7 } from "./ids";
 import {
 	CanvasHistoryProvider,
-	HistoryControls,
 	useCanvasHistory,
 	type CanvasSnapshot,
 } from "./history";
-import { CanvasFormatProvider, FormatControls, layoutBlocks } from "./layout";
+import { CanvasFormatProvider, layoutBlocks } from "./layout";
 import { BlockPanel, CanvasPanelProvider, useBlockPanel } from "./panel";
+import { CanvasToolbar } from "./CanvasToolbar";
+import { Button, toast } from "@fluxify/components";
+import { TbNote, TbPlus } from "react-icons/tb";
+import { BlockPickerSidebar } from "./BlockPickerSidebar";
+import { BLOCK_TYPES, canAddBlock, type BlockType } from "./blocks";
+import { stickyNoteData } from "./blocks/stickyNoteData";
+import { useBlockPicker } from "./useBlockPicker";
 import type { BlockCanvasProps, BlockEdge, BlockNode } from "./types";
 
 const EMPTY_NODE_TYPES = {};
@@ -97,6 +104,7 @@ function CanvasInner({
 	enableFormat = true,
 	enableClipboard = true,
 	enablePanel = true,
+	enableBlockPicker = false,
 	fitViewOnInit = true,
 	defaultViewport,
 	className,
@@ -104,6 +112,7 @@ function CanvasInner({
 	children,
 }: BlockCanvasProps) {
 	const readOnly = mode === "readonly";
+	const { screenToFlowPosition } = useReactFlow();
 	const initial = useMemo(() => graphToFlow(graph), [graph]);
 	const [nodes, setNodes, onNodesChange] = useNodesState<BlockNode>(
 		initial.nodes,
@@ -111,6 +120,8 @@ function CanvasInner({
 	const [edges, setEdges, onEdgesChange] = useEdgesState<BlockEdge>(
 		initial.edges,
 	);
+	const blockPicker = useBlockPicker();
+	const canvasRef = useRef<HTMLDivElement>(null);
 	const latest = useRef({ nodes, edges });
 	latest.current = { nodes, edges };
 	const [flashingCycleEdgeIds, setFlashingCycleEdgeIds] = useState<Set<string>>(
@@ -270,7 +281,8 @@ function CanvasInner({
 	);
 
 	const [isFormatting, setIsFormatting] = useState(false);
-	const formatEnabled = enableFormat && !readOnly;
+	const [layoutLocked, setLayoutLocked] = useState(false);
+	const formatEnabled = enableFormat && !readOnly && !layoutLocked;
 
 	const format = useCallback(async () => {
 		if (!formatEnabled) return;
@@ -297,6 +309,7 @@ function CanvasInner({
 		() => ({ enabled: formatEnabled, format, isFormatting }),
 		[formatEnabled, format, isFormatting],
 	);
+	const canEditLayout = !readOnly && !layoutLocked;
 
 	const handleNodesChange = useCallback(
 		(changes: NodeChange<BlockNode>[]) => {
@@ -318,10 +331,34 @@ function CanvasInner({
 		[onEdgesChange, readOnly, tracker],
 	);
 
-	const onBeforeDelete = useCallback(async () => {
-		if (!readOnly) history.commit();
-		return true;
-	}, [readOnly, history]);
+	const onBeforeDelete = useCallback(
+		async ({ nodes: deletingNodes, edges: deletingEdges }: { nodes: BlockNode[]; edges: BlockEdge[] }) => {
+			const protectedNodeIds = new Set(
+				deletingNodes
+					.filter(
+						(node) =>
+							node.type === BLOCK_TYPES.entrypoint ||
+							node.type === BLOCK_TYPES.errorHandler,
+					)
+					.map((node) => node.id),
+			);
+			const nodes = deletingNodes.filter((node) => !protectedNodeIds.has(node.id));
+			const edges = deletingEdges.filter(
+				(edge) => !protectedNodeIds.has(edge.source) && !protectedNodeIds.has(edge.target),
+			);
+
+			// Reject protected nodes even when they are part of a keyboard or bulk
+			// delete. Returning the remaining candidates lets React Flow delete only
+			// the allowed elements.
+			if (protectedNodeIds.size > 0) {
+				toast.danger("Entrypoint and error handler blocks cannot be deleted.");
+			}
+			if (nodes.length === 0 && edges.length === 0) return false;
+			if (!readOnly) history.commit();
+			return { nodes, edges };
+		},
+		[readOnly, history],
+	);
 
 	// Cycles are shown immediately and rejected on save. Connections remain
 	// creatable so users can see and remove the entire invalid path.
@@ -332,7 +369,7 @@ function CanvasInner({
 
 	const onConnect = useCallback(
 		(connection: Connection) => {
-			if (readOnly || !isValidConnection(connection)) return;
+			if (!canEditLayout || !isValidConnection(connection)) return;
 			// Own the id (uuidv7, what the save endpoint requires) so the new edge can
 			// be tracked without diffing state afterwards.
 			const edge: BlockEdge = {
@@ -345,7 +382,7 @@ function CanvasInner({
 			pendingEmit.current = true;
 			setEdges((current) => addEdge(edge, current));
 		},
-		[setEdges, readOnly, history, isValidConnection, tracker],
+		[setEdges, canEditLayout, history, isValidConnection, tracker],
 	);
 
 	// Fires once per drag gesture, before anything moves — so a multi-select drag
@@ -354,14 +391,42 @@ function CanvasInner({
 		if (!readOnly) history.commit();
 	}, [readOnly, history]);
 
+	const addBlock = useCallback(
+		(type: BlockType) => {
+			if (readOnly || !canAddBlock(type)) return;
+			const bounds = canvasRef.current?.getBoundingClientRect();
+			const center = bounds
+				? { x: bounds.left + bounds.width / 2, y: bounds.top + bounds.height / 2 }
+				: { x: window.innerWidth / 2, y: window.innerHeight / 2 };
+			const node: BlockNode = {
+				id: uuidv7(),
+				type,
+				position: screenToFlowPosition(center),
+				data: type === BLOCK_TYPES.stickynote ? stickyNoteData({}) : {},
+				zIndex: type === BLOCK_TYPES.stickynote ? -1 : 0,
+				selected: true,
+			};
+			history.commit();
+			tracker.markUpserted("blocks", [node.id]);
+			pendingEmit.current = true;
+			setNodes((current) => [
+				...current.map((item) => (item.selected ? { ...item, selected: false } : item)),
+				node,
+			]);
+		},
+		[history, readOnly, screenToFlowPosition, setNodes, tracker],
+	);
+
 	return (
 		<CanvasHistoryProvider history={history}>
 			<CanvasChangesProvider value={tracker}>
 			<CanvasClipboardProvider value={clipboard}>
 			<CanvasFormatProvider value={formatValue}>
+			<CanvasLayoutLockProvider locked={layoutLocked}>
 			<CanvasPanelProvider value={panel}>
 			<div className="fx-canvas-shell">
 			<div
+				ref={canvasRef}
 				className={[
 					"fx-canvas",
 					readOnly ? "fx-canvas--readonly" : "",
@@ -383,10 +448,12 @@ function CanvasInner({
 					isValidConnection={isValidConnection}
 					onNodeDragStart={onNodeDragStart}
 					onNodeDoubleClick={onNodeDoubleClick}
-					nodesDraggable={!readOnly}
-					nodesConnectable={!readOnly}
+					nodesDraggable={canEditLayout}
+					nodesConnectable={canEditLayout}
 					elementsSelectable={true}
 					deleteKeyCode={readOnly ? null : ["Backspace", "Delete"]}
+					elevateNodesOnSelect={false}
+					zIndexMode="manual"
 					fitView={fitViewOnInit}
 					defaultViewport={defaultViewport}
 					proOptions={{ hideAttribution: true }}
@@ -395,15 +462,37 @@ function CanvasInner({
 						variant={BackgroundVariant.Dots}
 						color="var(--fx-canvas-dot)"
 					/>
-					{/* React Flow's Controls has no icon props; its buttons are styled in canvas.css */}
-					<Controls showInteractive={!readOnly}>
-						<HistoryControls />
-						<FormatControls />
-					</Controls>
+					<CanvasToolbar
+						readOnly={readOnly}
+						layoutLocked={layoutLocked}
+						onToggleLayoutLock={() => setLayoutLocked((locked) => !locked)}
+					/>
 					{children}
 				</ReactFlow>
 				{/* the AI edits the graph — nothing to offer on a readonly view */}
 				{!readOnly && <AiCanvasButton />}
+				{!readOnly && !layoutLocked && enableBlockPicker && (
+					<div className="fx-canvas__quick-actions">
+						<Button
+							isIconOnly
+							aria-label="Add block"
+							variant="ghost"
+							className="fx-canvas__quick-action"
+							onPress={blockPicker.open}
+						>
+							<TbPlus />
+						</Button>
+						<Button
+							isIconOnly
+							aria-label="Add note"
+							variant="ghost"
+							className="fx-canvas__quick-action"
+							onPress={() => addBlock(BLOCK_TYPES.stickynote)}
+						>
+							<TbNote />
+						</Button>
+					</div>
+				)}
 				{nodes.length === 0 && (
 					<div className="fx-canvas__empty">
 						{readOnly
@@ -412,9 +501,17 @@ function CanvasInner({
 					</div>
 				)}
 			</div>
+			{!readOnly && !layoutLocked && enableBlockPicker && (
+				<BlockPickerSidebar
+					isOpen={blockPicker.isOpen}
+					onOpenChange={blockPicker.onOpenChange}
+					onAdd={addBlock}
+				/>
+			)}
 			{panel.enabled && <BlockPanel block={openBlock} onClose={panel.close} />}
 			</div>
 			</CanvasPanelProvider>
+			</CanvasLayoutLockProvider>
 			</CanvasFormatProvider>
 			</CanvasClipboardProvider>
 			</CanvasChangesProvider>

--- a/apps/portal/src/components/canvas/BlockPickerSidebar.tsx
+++ b/apps/portal/src/components/canvas/BlockPickerSidebar.tsx
@@ -1,0 +1,206 @@
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { Button, Input, Label, Sidebar, TextField } from "@fluxify/components";
+import {
+	TbArrowLeft,
+	TbChevronRight,
+	TbCode,
+	TbDatabase,
+	TbLayoutGrid,
+	TbPlus,
+	TbSearch,
+	TbTerminal2,
+	TbWorld,
+	TbX,
+} from "react-icons/tb";
+import {
+	pickerBlockCatalogEntries,
+	blockIcon,
+	type BlockDefinition,
+	type BlockType,
+} from "./blocks";
+import "./blockPickerSidebar.css";
+
+type BlockCategory = BlockDefinition["category"];
+
+type CategoryDetails = {
+	description: string;
+	icon: ReactNode;
+};
+
+const CATEGORY_DETAILS: Record<BlockCategory, CategoryDetails> = {
+	Core: {
+		description: "Start, respond, and work with route data",
+		icon: <TbLayoutGrid />,
+	},
+	Flow: {
+		description: "Branch, repeat, and control execution",
+		icon: <TbCode />,
+	},
+	Database: {
+		description: "Read and write database records",
+		icon: <TbDatabase />,
+	},
+	HTTP: {
+		description: "Read requests and call external services",
+		icon: <TbWorld />,
+	},
+	Logging: {
+		description: "Record values and events",
+		icon: <TbTerminal2 />,
+	},
+	Misc: {
+		description: "Transform data and annotate the canvas",
+		icon: <TbPlus />,
+	},
+};
+
+const categories = Object.keys(CATEGORY_DETAILS) as BlockCategory[];
+
+export type BlockPickerSidebarProps = {
+	isOpen: boolean;
+	onOpenChange: (isOpen: boolean) => void;
+	onAdd: (type: BlockType) => void;
+};
+
+/** Core-block picker. Custom blocks join this catalog after their API lands. */
+export function BlockPickerSidebar({
+	isOpen,
+	onOpenChange,
+	onAdd,
+}: BlockPickerSidebarProps) {
+	const [query, setQuery] = useState("");
+	const [selectedCategory, setSelectedCategory] = useState<BlockCategory | null>(
+		null,
+	);
+
+	useEffect(() => {
+		if (!isOpen) {
+			setQuery("");
+			setSelectedCategory(null);
+		}
+	}, [isOpen]);
+
+	const blocks = useMemo(() => pickerBlockCatalogEntries(), []);
+	const visibleBlocks = useMemo(() => {
+		const normalizedQuery = query.trim().toLowerCase();
+		return blocks.filter(([type, definition]) => {
+			if (!normalizedQuery && selectedCategory && definition.category !== selectedCategory) {
+				return false;
+			}
+			if (!normalizedQuery) return true;
+			return [type, definition.name, definition.description, definition.category]
+				.join(" ")
+				.toLowerCase()
+				.includes(normalizedQuery);
+		});
+	}, [blocks, query, selectedCategory]);
+
+	const isShowingCategories = !selectedCategory && !query.trim();
+	const title = query.trim() ? "Search blocks" : (selectedCategory ?? "Categories");
+
+	function addBlock(type: BlockType) {
+		onAdd(type);
+		onOpenChange(false);
+	}
+
+	return (
+		<Sidebar
+			isOpen={isOpen}
+			onOpenChange={onOpenChange}
+			aria-label="Add a block"
+			className="fx-block-picker"
+		>
+			<header className="fx-block-picker__header">
+				<div>
+					<p className="fx-block-picker__eyebrow">Canvas</p>
+					<h2 className="fx-block-picker__heading">Add block</h2>
+				</div>
+				<Button
+					isIconOnly
+					aria-label="Close block picker"
+					variant="ghost"
+					onPress={() => onOpenChange(false)}
+				>
+					<TbX />
+				</Button>
+			</header>
+
+			<div className="fx-block-picker__search">
+				<TextField value={query} onChange={setQuery} aria-label="Search blocks">
+					<Label className="sr-only">Search blocks</Label>
+					<TbSearch aria-hidden className="fx-block-picker__search-icon" />
+					<Input autoFocus placeholder="Search blocks…" />
+				</TextField>
+			</div>
+
+			<div className="fx-block-picker__content">
+				<div className="fx-block-picker__section-header">
+					{selectedCategory ? (
+						<Button
+							variant="ghost"
+							onPress={() => setSelectedCategory(null)}
+							className="fx-block-picker__back"
+						>
+							<TbArrowLeft />
+							Categories
+						</Button>
+					) : (
+						<span>{title}</span>
+					)}
+					{selectedCategory && <span>{title}</span>}
+				</div>
+
+				{isShowingCategories ? (
+					<div className="fx-block-picker__list">
+						{categories.map((category) => {
+							const details = CATEGORY_DETAILS[category];
+							return (
+								<button
+									key={category}
+									type="button"
+									className="fx-block-picker__item fx-block-picker__category"
+									onClick={() => setSelectedCategory(category)}
+								>
+									<span className="fx-block-picker__icon" aria-hidden>
+										{details.icon}
+									</span>
+									<span className="fx-block-picker__copy">
+										<span className="fx-block-picker__name">{category}</span>
+										<span className="fx-block-picker__description">
+											{details.description}
+										</span>
+									</span>
+									<TbChevronRight className="fx-block-picker__chevron" aria-hidden />
+								</button>
+							);
+						})}
+					</div>
+				) : (
+					<div className="fx-block-picker__list">
+						{visibleBlocks.map(([type, definition]) => (
+							<button
+								key={type}
+								type="button"
+								className="fx-block-picker__item"
+								onClick={() => addBlock(type)}
+							>
+								<span className="fx-block-picker__icon" aria-hidden>
+									{blockIcon(type)}
+								</span>
+								<span className="fx-block-picker__copy">
+									<span className="fx-block-picker__name">{definition.name}</span>
+									<span className="fx-block-picker__description">
+										{definition.description}
+									</span>
+								</span>
+							</button>
+						))}
+						{visibleBlocks.length === 0 && (
+							<p className="fx-block-picker__empty">No core blocks match.</p>
+						)}
+					</div>
+				)}
+			</div>
+		</Sidebar>
+	);
+}

--- a/apps/portal/src/components/canvas/CanvasLayoutLockContext.tsx
+++ b/apps/portal/src/components/canvas/CanvasLayoutLockContext.tsx
@@ -1,0 +1,22 @@
+import { createContext, useContext, type ReactNode } from "react";
+
+const CanvasLayoutLockContext = createContext(false);
+
+export function CanvasLayoutLockProvider({
+	locked,
+	children,
+}: {
+	locked: boolean;
+	children: ReactNode;
+}) {
+	return (
+		<CanvasLayoutLockContext.Provider value={locked}>
+			{children}
+		</CanvasLayoutLockContext.Provider>
+	);
+}
+
+/** Whether canvas positions and note dimensions are currently protected. */
+export function useCanvasLayoutLocked(): boolean {
+	return useContext(CanvasLayoutLockContext);
+}

--- a/apps/portal/src/components/canvas/CanvasToolbar.tsx
+++ b/apps/portal/src/components/canvas/CanvasToolbar.tsx
@@ -1,0 +1,124 @@
+import { Panel, useReactFlow, useViewport } from "@xyflow/react";
+import type { ReactNode } from "react";
+import {
+	TbArrowBackUp,
+	TbLock,
+	TbLockOpen,
+} from "react-icons/tb";
+import {
+	MdFormatPaint,
+	MdOutlineFitScreen,
+	MdZoomIn,
+	MdZoomOut,
+} from "react-icons/md";
+import { useCanvasHistoryContext } from "./history";
+import { useCanvasFormat } from "./layout";
+
+type CanvasToolbarProps = {
+	readOnly: boolean;
+	layoutLocked: boolean;
+	onToggleLayoutLock: () => void;
+};
+
+type ToolbarButtonProps = {
+	label: string;
+	onClick: () => void;
+	disabled?: boolean;
+	pressed?: boolean;
+	children: ReactNode;
+};
+
+function ToolbarButton({
+	label,
+	onClick,
+	disabled = false,
+	pressed,
+	children,
+}: ToolbarButtonProps) {
+	return (
+		<button
+			type="button"
+			className="fx-canvas-toolbar__button"
+			title={label}
+			aria-label={label}
+			aria-pressed={pressed}
+			disabled={disabled}
+			onClick={onClick}
+		>
+			{children}
+		</button>
+	);
+}
+
+/** Portal-native canvas controls. Kept separate from React Flow's stock toolbar
+ * so the product owns both its actions and visual language. */
+export function CanvasToolbar({
+	readOnly,
+	layoutLocked,
+	onToggleLayoutLock,
+}: CanvasToolbarProps) {
+	const { fitView, setViewport, zoomIn, zoomOut } = useReactFlow();
+	const viewport = useViewport();
+	const history = useCanvasHistoryContext();
+	const format = useCanvasFormat();
+
+	return (
+		<Panel position="bottom-left" className="fx-canvas-toolbar">
+			<div className="fx-canvas-toolbar__group">
+				<ToolbarButton label="Zoom out" onClick={() => void zoomOut({ duration: 150 })}>
+					<MdZoomOut />
+				</ToolbarButton>
+				<button
+					type="button"
+					className="fx-canvas-toolbar__zoom"
+					title="Reset zoom to 100%"
+					aria-label="Reset zoom to 100%"
+					onClick={() => void setViewport({ x: 0, y: 0, zoom: 1 }, { duration: 150 })}
+				>
+					{Math.round(viewport.zoom * 100)}%
+				</button>
+				<ToolbarButton label="Zoom in" onClick={() => void zoomIn({ duration: 150 })}>
+					<MdZoomIn />
+				</ToolbarButton>
+				<ToolbarButton label="Fit canvas to view" onClick={() => void fitView({ padding: 0.2, duration: 200 })}>
+					<MdOutlineFitScreen />
+				</ToolbarButton>
+			</div>
+
+			<div className="fx-canvas-toolbar__divider" />
+
+			<div className="fx-canvas-toolbar__group">
+				<ToolbarButton
+					label="Undo"
+					disabled={!history.enabled || !history.canUndo}
+					onClick={history.undo}
+				>
+					<TbArrowBackUp />
+				</ToolbarButton>
+				<ToolbarButton
+					label="Redo"
+					disabled={!history.enabled || !history.canRedo}
+					onClick={history.redo}
+				>
+					<TbArrowBackUp className="-scale-x-100" />
+				</ToolbarButton>
+				<ToolbarButton
+					label="Format blocks"
+					disabled={!format.enabled || format.isFormatting || layoutLocked}
+					onClick={() => void format.format()}
+				>
+					<MdFormatPaint />
+				</ToolbarButton>
+				<ToolbarButton
+					label={layoutLocked ? "Unlock canvas layout" : "Lock canvas layout"}
+					disabled={readOnly}
+					pressed={layoutLocked}
+					onClick={onToggleLayoutLock}
+				>
+					{layoutLocked ? <TbLock /> : <TbLockOpen />}
+				</ToolbarButton>
+			</div>
+
+		</Panel>
+	);
+}

--- a/apps/portal/src/components/canvas/CanvasWorkbench.tsx
+++ b/apps/portal/src/components/canvas/CanvasWorkbench.tsx
@@ -17,6 +17,8 @@ import type { BlockData, CanvasGraph } from "./types";
 export type CanvasWorkbenchProps = {
 	title: string;
 	items: { data: CanvasItems | undefined; isLoading: boolean; isError: boolean };
+	/** Opt-in only: this workbench is reused by route, custom-block, and embedded canvases. */
+	enableBlockPicker?: boolean;
 	/** re-read from the server, for diagnosing a rejected save */
 	reload: () => Promise<CanvasItems>;
 	save: (payload: CanvasSavePayload) => Promise<unknown>;
@@ -37,7 +39,13 @@ function toGraph(data: CanvasItems | undefined): CanvasGraph {
 
 const nodeTypes = createBlockNodeTypes();
 
-export function CanvasWorkbench({ title, items, reload, save }: CanvasWorkbenchProps) {
+export function CanvasWorkbench({
+	title,
+	items,
+	reload,
+	save,
+	enableBlockPicker = false,
+}: CanvasWorkbenchProps) {
 	const [readOnly, setReadOnly] = useState(false);
 	const [pendingCount, setPendingCount] = useState(0);
 	const [isSaving, setIsSaving] = useState(false);
@@ -121,6 +129,7 @@ export function CanvasWorkbench({ title, items, reload, save }: CanvasWorkbenchP
 						graph={graph}
 						mode={readOnly ? "readonly" : "edit"}
 						nodeTypes={nodeTypes}
+						enableBlockPicker={enableBlockPicker}
 						cycleFeedbackToken={cycleFeedbackToken}
 						onChange={(next, changes) => {
 							edited.current = { graph: next, changes };

--- a/apps/portal/src/components/canvas/adapters.ts
+++ b/apps/portal/src/components/canvas/adapters.ts
@@ -16,10 +16,10 @@ import type {
  */
 function noteNodeFields(
 	block: CanvasBlock,
-): Partial<Pick<BlockNode, "data" | "width" | "height">> {
+): Partial<Pick<BlockNode, "data" | "width" | "height" | "zIndex">> {
 	if (block.type !== BLOCK_TYPES.stickynote) return {};
 	const data = stickyNoteData(block.data);
-	return { data, width: data.size.width, height: data.size.height };
+	return { data, width: data.size.width, height: data.size.height, zIndex: -1 };
 }
 
 export function blockToNode(block: CanvasBlock): BlockNode {

--- a/apps/portal/src/components/canvas/aiButton/AiCanvasButton.tsx
+++ b/apps/portal/src/components/canvas/aiButton/AiCanvasButton.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@fluxify/components";
 import { TbSparkles } from "react-icons/tb";
 import clsx from "clsx";
+import "./aiCanvasButton.css";
 
 export type AiCanvasButtonProps = {
 	/** Click/press handler, e.g. to open AI assistant panel or route */
@@ -27,15 +28,12 @@ export function AiCanvasButton({
 			<Button
 				isIconOnly
 				aria-label={ariaLabel}
-				variant="secondary"
-				className={clsx(
-					"size-10 rounded-xl border border-[#161820] bg-[#141720] p-0 shadow-lg backdrop-blur-md hover:bg-[#1c202d] transition-all",
-					className,
-				)}
+				variant="ghost"
+				className={clsx("fx-ai-canvas-button", className)}
 				onPress={onPress}
 				onClick={onClick}
 			>
-				<TbSparkles className="size-5 text-[#D0F237] shrink-0" />
+				<TbSparkles className="fx-ai-canvas-button__icon" />
 			</Button>
 		</div>
 	);

--- a/apps/portal/src/components/canvas/aiButton/aiCanvasButton.css
+++ b/apps/portal/src/components/canvas/aiButton/aiCanvasButton.css
@@ -1,0 +1,22 @@
+.fx-ai-canvas-button {
+	width: 2.5rem;
+	height: 2.5rem;
+	padding: 0;
+	border: 1px solid var(--border);
+	border-radius: var(--radius);
+	background: transparent;
+	box-shadow: 0 0.25rem 0.75rem color-mix(in srgb, var(--foreground) 14%, transparent);
+	backdrop-filter: blur(0.75rem);
+	transition: background-color 150ms ease, border-color 150ms ease, box-shadow 150ms ease;
+}
+
+.fx-ai-canvas-button:hover {
+	background: color-mix(in srgb, var(--surface) 72%, transparent);
+}
+
+.fx-ai-canvas-button__icon {
+	width: 1.25rem;
+	height: 1.25rem;
+	flex-shrink: 0;
+	color: var(--accent);
+}

--- a/apps/portal/src/components/canvas/blockPickerSidebar.css
+++ b/apps/portal/src/components/canvas/blockPickerSidebar.css
@@ -1,0 +1,154 @@
+.fx-block-picker {
+	background: var(--background-secondary);
+}
+
+.fx-block-picker__header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	border-bottom: 1px solid var(--border);
+	padding: 1rem;
+}
+
+.fx-block-picker__eyebrow {
+	margin: 0;
+	font-size: 0.75rem;
+	font-weight: 500;
+	color: var(--muted);
+}
+
+.fx-block-picker__heading {
+	margin: 0.125rem 0 0;
+	font-size: 1rem;
+	font-weight: 600;
+	color: var(--foreground);
+}
+
+.fx-block-picker__search {
+	position: relative;
+	border-bottom: 1px solid var(--border);
+	padding: 0.75rem 1rem;
+}
+
+.fx-block-picker__search [data-slot="input"] {
+	padding-left: 2.25rem;
+}
+
+.fx-block-picker__search-icon {
+	pointer-events: none;
+	position: absolute;
+	left: 1.75rem;
+	top: 50%;
+	z-index: 1;
+	transform: translateY(-50%);
+	color: var(--muted);
+}
+
+.fx-block-picker__content {
+	display: flex;
+	min-height: 0;
+	flex: 1;
+	flex-direction: column;
+	padding: 0.75rem;
+}
+
+.fx-block-picker__section-header {
+	display: flex;
+	min-height: 2rem;
+	align-items: center;
+	justify-content: space-between;
+	padding: 0 0.25rem 0.5rem;
+	font-size: 0.75rem;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.08em;
+	color: var(--muted);
+}
+
+.fx-block-picker__back {
+	gap: 0.375rem;
+	padding: 0.25rem;
+	font-size: 0.75rem;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.08em;
+}
+
+.fx-block-picker__list {
+	display: flex;
+	min-height: 0;
+	flex: 1;
+	flex-direction: column;
+	gap: 0.25rem;
+	overflow-y: auto;
+}
+
+.fx-block-picker__item {
+	display: flex;
+	width: 100%;
+	align-items: center;
+	gap: 0.75rem;
+	border: 1px solid transparent;
+	border-radius: var(--radius);
+	background: transparent;
+	padding: 0.75rem;
+	text-align: left;
+	color: var(--foreground);
+	transition: background-color 150ms ease, border-color 150ms ease;
+}
+
+.fx-block-picker__item:hover,
+.fx-block-picker__item:focus-visible {
+	border-color: var(--border);
+	background: var(--surface-secondary);
+	outline: none;
+}
+
+.fx-block-picker__item:focus-visible {
+	box-shadow: 0 0 0 2px var(--focus);
+}
+
+.fx-block-picker__icon {
+	display: grid;
+	width: 2rem;
+	height: 2rem;
+	flex: 0 0 auto;
+	place-items: center;
+	border-radius: calc(var(--radius) * 0.75);
+	background: color-mix(in srgb, var(--accent) 14%, var(--surface));
+	color: var(--accent);
+}
+
+.fx-block-picker__copy {
+	display: flex;
+	min-width: 0;
+	flex: 1;
+	flex-direction: column;
+	gap: 0.125rem;
+}
+
+.fx-block-picker__name {
+	font-size: 0.875rem;
+	font-weight: 500;
+}
+
+.fx-block-picker__description {
+	overflow: hidden;
+	font-size: 0.75rem;
+	line-height: 1.25rem;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	color: var(--muted);
+}
+
+.fx-block-picker__chevron {
+	flex: 0 0 auto;
+	color: var(--muted);
+}
+
+.fx-block-picker__empty {
+	margin: 2rem 1rem;
+	text-align: center;
+	font-size: 0.875rem;
+	color: var(--muted);
+}

--- a/apps/portal/src/components/canvas/blocks/BaseBlock.tsx
+++ b/apps/portal/src/components/canvas/blocks/BaseBlock.tsx
@@ -25,6 +25,8 @@ export type BaseBlockProps = {
 	/** Show the hover action strip (open/duplicate/copy/delete). Default `true`;
 	 *  always hidden in readonly mode. */
 	showToolbar?: boolean;
+	/** Permit delete, copy and duplicate in the action strip. */
+	allowMutatingActions?: boolean;
 	className?: string;
 	/** `<BlockHandle>` children get routed to edge rails; anything else renders
 	 *  after the text column. */
@@ -65,6 +67,7 @@ export function BaseBlock({
 	status,
 	color,
 	showToolbar = true,
+	allowMutatingActions = true,
 	className,
 	children,
 }: BaseBlockProps) {
@@ -94,6 +97,7 @@ export function BaseBlock({
 					blockId={blockId}
 					visible={hovered}
 					hoverProps={hoverProps}
+					allowMutatingActions={allowMutatingActions}
 				/>
 			)}
 			{status != null && (

--- a/apps/portal/src/components/canvas/blocks/BlockNode.tsx
+++ b/apps/portal/src/components/canvas/blocks/BlockNode.tsx
@@ -24,6 +24,8 @@ export function BlockNode({
 	positionAbsoluteY,
 }: NodeProps) {
 	const { name, description, definition } = blockLabels(type, data);
+	const isRouteOwned =
+		type === BLOCK_TYPES.entrypoint || type === BLOCK_TYPES.errorHandler;
 
 	return (
 		<BaseBlock
@@ -36,6 +38,7 @@ export function BlockNode({
 			color={definition.tint}
 			selected={selected}
 			status={status(data?.status)}
+			allowMutatingActions={!isRouteOwned}
 		>
 			{definition.handles.map((kind) => (
 				<BlockHandle key={kind} blockId={id} kind={kind} />

--- a/apps/portal/src/components/canvas/blocks/BlockToolbar.tsx
+++ b/apps/portal/src/components/canvas/blocks/BlockToolbar.tsx
@@ -59,6 +59,8 @@ export function useHoverIntent(
 export type BlockToolbarProps = {
 	blockId: string;
 	visible: boolean;
+	/** System-owned blocks can still be opened, but cannot be copied or removed. */
+	allowMutatingActions?: boolean;
 	/** Keeps the toolbar open while the pointer is on it. */
 	hoverProps?: HoverIntent["hoverProps"];
 };
@@ -71,6 +73,7 @@ export type BlockToolbarProps = {
 export function BlockToolbar({
 	blockId,
 	visible,
+	allowMutatingActions = true,
 	hoverProps,
 }: BlockToolbarProps) {
 	const { deleteElements } = useReactFlow();
@@ -105,7 +108,7 @@ export function BlockToolbar({
 					<TbExternalLink />
 				</button>
 			)}
-			{editable && clipboard.enabled && (
+			{editable && allowMutatingActions && clipboard.enabled && (
 				<>
 					<button
 						type="button"
@@ -127,7 +130,7 @@ export function BlockToolbar({
 					</button>
 				</>
 			)}
-			{editable && (
+			{editable && allowMutatingActions && (
 				<button
 					type="button"
 					className="fx-block__action fx-block__action--danger"

--- a/apps/portal/src/components/canvas/blocks/StickyNoteBlock.tsx
+++ b/apps/portal/src/components/canvas/blocks/StickyNoteBlock.tsx
@@ -1,9 +1,11 @@
 import { useCallback, useState, type KeyboardEvent, type MouseEvent } from "react";
 import Markdown from "react-markdown";
 import { NodeResizer, useReactFlow, type NodeProps } from "@xyflow/react";
+import { TbTrash } from "react-icons/tb";
 import "./blocks.css";
 import { useCanvasChanges } from "../changes/ChangesContext";
-import { NOTE_COLORS, NOTE_SIZE_LIMITS, stickyNoteData } from "./stickyNoteData";
+import { useCanvasLayoutLocked } from "../CanvasLayoutLockContext";
+import { NOTE_COLORS, NOTE_MIN_SIZE, stickyNoteData } from "./stickyNoteData";
 
 /**
  * A resizable comment on the canvas: renders its `notes` as markdown and has no
@@ -18,9 +20,10 @@ import { NOTE_COLORS, NOTE_SIZE_LIMITS, stickyNoteData } from "./stickyNoteData"
  */
 export function StickyNoteBlock({ id, data, selected }: NodeProps) {
 	const note = stickyNoteData(data);
-	const { updateNodeData } = useReactFlow();
+	const { deleteElements, updateNode, updateNodeData } = useReactFlow();
 	// Disabled tracking means a readonly canvas: view the note, don't edit it.
 	const { enabled: editable } = useCanvasChanges();
+	const layoutLocked = useCanvasLayoutLocked();
 	// `null` = not editing; anything else is the in-progress markdown.
 	const [draft, setDraft] = useState<string | null>(null);
 
@@ -29,9 +32,12 @@ export function StickyNoteBlock({ id, data, selected }: NodeProps) {
 			if (!editable) return;
 			// Otherwise React Flow zooms in on the double click.
 			event.stopPropagation();
+			// A note is normally a background grouping layer. Raise it only while
+			// its editor needs to receive the pointer and keyboard interaction.
+			updateNode(id, { zIndex: 1 });
 			setDraft(note.notes);
 		},
-		[editable, note.notes],
+		[editable, id, note.notes, updateNode],
 	);
 
 	const commit = useCallback(() => {
@@ -41,16 +47,26 @@ export function StickyNoteBlock({ id, data, selected }: NodeProps) {
 			}
 			return null;
 		});
-	}, [id, note.notes, updateNodeData]);
+		updateNode(id, { zIndex: -1 });
+	}, [id, note.notes, updateNode, updateNodeData]);
+
+	const cancel = useCallback(() => {
+		setDraft(null);
+		updateNode(id, { zIndex: -1 });
+	}, [id, updateNode]);
+
+	const remove = useCallback(() => {
+		void deleteElements({ nodes: [{ id }] });
+	}, [deleteElements, id]);
 
 	const onKeyDown = useCallback(
 		(event: KeyboardEvent<HTMLTextAreaElement>) => {
 			// Stop the canvas from treating typing as shortcuts (delete, undo…).
 			event.stopPropagation();
-			if (event.key === "Escape") setDraft(null);
+			if (event.key === "Escape") cancel();
 			else if (event.key === "Enter" && (event.ctrlKey || event.metaKey)) commit();
 		},
-		[commit],
+		[cancel, commit],
 	);
 
 	return (
@@ -64,8 +80,9 @@ export function StickyNoteBlock({ id, data, selected }: NodeProps) {
 		>
 			<NodeResizer
 				nodeId={id}
-				isVisible={selected && editable}
-				{...NOTE_SIZE_LIMITS}
+				isVisible={selected && editable && !layoutLocked}
+				minWidth={NOTE_MIN_SIZE}
+				minHeight={NOTE_MIN_SIZE}
 				handleClassName="fx-note__grip"
 				lineClassName="fx-note__edge"
 			/>
@@ -85,6 +102,15 @@ export function StickyNoteBlock({ id, data, selected }: NodeProps) {
 							onClick={() => updateNodeData(id, { color })}
 						/>
 					))}
+					<button
+						type="button"
+						title="Delete note"
+						aria-label="Delete note"
+						className="fx-note__swatch fx-note__delete"
+						onClick={remove}
+					>
+						<TbTrash />
+					</button>
 				</div>
 			)}
 

--- a/apps/portal/src/components/canvas/blocks/blockCatalog.ts
+++ b/apps/portal/src/components/canvas/blocks/blockCatalog.ts
@@ -13,9 +13,9 @@ export type BlockDefinition = {
 	category: "Core" | "Flow" | "Database" | "HTTP" | "Logging" | "Misc";
 };
 
-const GREEN = "var(--success, #40c057)";
-const VIOLET = "var(--violet, #7c5cff)";
-const RED = "var(--danger, #e5484d)";
+const GREEN = "var(--success)";
+const VIOLET = "var(--accent)";
+const RED = "var(--danger)";
 
 /** Inbound + one outbound "next" — the shape almost every block has. */
 const STD: HandleKind[] = ["target", "source"];
@@ -213,6 +213,29 @@ export const BLOCK_CATALOG: Record<BlockType, BlockDefinition> = {
 
 export function blockCatalogEntries(): [BlockType, BlockDefinition][] {
 	return Object.entries(BLOCK_CATALOG) as [BlockType, BlockDefinition][];
+}
+
+/** Route-owned blocks are created by the route, never by the canvas picker. */
+const ROUTE_OWNED_BLOCK_TYPES = new Set<BlockType>([
+	BLOCK_TYPES.entrypoint,
+	BLOCK_TYPES.errorHandler,
+]);
+
+/** Notes have their own quick action beside the picker trigger. */
+const CANVAS_QUICK_ACTION_BLOCK_TYPES = new Set<BlockType>([
+	BLOCK_TYPES.stickynote,
+]);
+
+export function canAddBlock(type: BlockType): boolean {
+	return !ROUTE_OWNED_BLOCK_TYPES.has(type);
+}
+
+export function canPickBlock(type: BlockType): boolean {
+	return canAddBlock(type) && !CANVAS_QUICK_ACTION_BLOCK_TYPES.has(type);
+}
+
+export function pickerBlockCatalogEntries(): [BlockType, BlockDefinition][] {
+	return blockCatalogEntries().filter(([type]) => canPickBlock(type));
 }
 
 /** Definition for any type, including unknown/custom ones. */

--- a/apps/portal/src/components/canvas/blocks/blocks.css
+++ b/apps/portal/src/components/canvas/blocks/blocks.css
@@ -293,19 +293,29 @@ html[data-theme="dark"] .fx-block,
 /* Colour strip, sits just above the note (legacy sticky note had the same). */
 .fx-note__palette {
 	position: absolute;
-	top: -12px;
+	top: -25px;
 	right: 0;
 	display: flex;
-	gap: 3px;
+	align-items: center;
+	gap: 4px;
+	padding: 3px;
+	border: 1px solid var(--fx-block-border);
+	border-radius: var(--radius, 6px);
+	background: var(--fx-block-bg);
+	box-shadow: 0 3px 8px color-mix(in oklab, #000 18%, transparent);
 }
 
 .fx-note__swatch {
-	width: 9px;
-	height: 9px;
+	display: inline-flex;
+	width: 15px;
+	height: 15px;
+	align-items: center;
+	justify-content: center;
 	padding: 0;
 	border: 1px solid color-mix(in oklab, var(--fx-block-fg) 25%, transparent);
 	border-radius: 2px;
 	cursor: pointer;
+	transition: border-color 120ms ease, background-color 120ms ease, color 120ms ease;
 }
 
 .fx-note__swatch--active {
@@ -326,6 +336,21 @@ html[data-theme="dark"] .fx-block,
 
 .fx-note__swatch--blue {
 	background: #3b82f6;
+}
+
+.fx-note__delete {
+	background: color-mix(in oklab, var(--danger, #e5484d) 10%, var(--fx-block-bg));
+	color: var(--danger, #e5484d);
+}
+
+.fx-note__delete:hover {
+	border-color: var(--danger, #e5484d);
+	background: color-mix(in oklab, var(--danger, #e5484d) 15%, var(--fx-block-bg));
+}
+
+.fx-note__delete svg {
+	width: 10px;
+	height: 10px;
 }
 
 /* Resize frame: React Flow's own controls, restyled — a small rect on every

--- a/apps/portal/src/components/canvas/blocks/blocks.test.tsx
+++ b/apps/portal/src/components/canvas/blocks/blocks.test.tsx
@@ -1,13 +1,19 @@
 import { expect, test } from "bun:test";
 import { blockToNode, nodeToBlock } from "../adapters";
 import { splitChildren } from "./BaseBlock";
-import { BLOCK_CATALOG, blockDefinition } from "./blockCatalog";
+import {
+	BLOCK_CATALOG,
+	blockDefinition,
+	canAddBlock,
+	canPickBlock,
+	pickerBlockCatalogEntries,
+} from "./blockCatalog";
 import { BLOCK_ICON_MAP } from "./blockIconMap";
 import { blockLabels } from "./blockLabels";
 import { createBlockNodeTypes } from "./BlockNode";
 import { BLOCK_TYPES, BLOCK_TYPE_LIST } from "./blockTypes";
 import { StickyNoteBlock } from "./StickyNoteBlock";
-import { NOTE_SIZE_LIMITS, stickyNoteData } from "./stickyNoteData";
+import { NOTE_MIN_SIZE, stickyNoteData } from "./stickyNoteData";
 import { BlockHandle } from "./handles/BlockHandle";
 import { HANDLE_CONFIG, type HandleKind } from "./handles/handleConfig";
 
@@ -35,6 +41,19 @@ test("every block type has an icon and a catalog entry", () => {
 	}
 	// Unknown types still render rather than crashing the canvas.
 	expect(blockDefinition("some_plugin_block").handles).toEqual(["target", "source"]);
+});
+
+test("route-owned blocks cannot be added from the canvas picker", () => {
+	expect(canAddBlock(BLOCK_TYPES.entrypoint)).toBe(false);
+	expect(canAddBlock(BLOCK_TYPES.errorHandler)).toBe(false);
+	expect(canAddBlock(BLOCK_TYPES.response)).toBe(true);
+	expect(pickerBlockCatalogEntries().map(([type]) => type)).not.toContain(
+		BLOCK_TYPES.entrypoint,
+	);
+	expect(pickerBlockCatalogEntries().map(([type]) => type)).not.toContain(
+		BLOCK_TYPES.errorHandler,
+	);
+	expect(canPickBlock(BLOCK_TYPES.stickynote)).toBe(false);
 });
 
 test("a block's own name wins over the catalog, placeholders do not", () => {
@@ -77,14 +96,13 @@ test("note data is normalised into the shape the server validates", () => {
 	const fresh = stickyNoteData(undefined);
 	expect(fresh.notes).toBe("");
 	expect(fresh.color).toBe("yellow");
-	expect(fresh.size.width).toBeGreaterThanOrEqual(NOTE_SIZE_LIMITS.minWidth);
-	expect(fresh.size.height).toBeLessThanOrEqual(NOTE_SIZE_LIMITS.maxHeight);
+	expect(fresh.size).toEqual({ width: 180, height: 120 });
 
 	expect(
 		stickyNoteData({ notes: "# hi", color: "blue", size: { width: 90, height: 80 } }),
 	).toEqual({ notes: "# hi", color: "blue", size: { width: 90, height: 80 } });
 
-	// Out-of-range or junk values are clamped/replaced, never passed through.
+	// Notes can be arbitrarily large grouping layers; only invalid values reset.
 	const fixed = stickyNoteData({
 		notes: 12,
 		color: "purple",
@@ -92,8 +110,12 @@ test("note data is normalised into the shape the server validates", () => {
 	});
 	expect(fixed.notes).toBe("");
 	expect(fixed.color).toBe("yellow");
-	expect(fixed.size.width).toBe(NOTE_SIZE_LIMITS.maxWidth);
+	expect(fixed.size.width).toBe(4000);
 	expect(fixed.size.height).toBe(fresh.size.height);
+	expect(stickyNoteData({ size: { width: 1, height: 0 } }).size).toEqual({
+		width: NOTE_MIN_SIZE,
+		height: NOTE_MIN_SIZE,
+	});
 });
 
 test("a loaded note is sized from its data and normalised", () => {
@@ -107,6 +129,7 @@ test("a loaded note is sized from its data and normalised", () => {
 	const data = stickyNoteData(node.data);
 	expect(node.width).toBe(data.size.width);
 	expect(node.height).toBe(data.size.height);
+	expect(node.zIndex).toBe(-1);
 	expect(data.color).toBe("yellow");
 });
 

--- a/apps/portal/src/components/canvas/blocks/index.ts
+++ b/apps/portal/src/components/canvas/blocks/index.ts
@@ -11,6 +11,9 @@ export {
 export {
 	BLOCK_CATALOG,
 	blockCatalogEntries,
+	canAddBlock,
+	canPickBlock,
+	pickerBlockCatalogEntries,
 	blockDefinition,
 	type BlockDefinition,
 } from "./blockCatalog";
@@ -19,7 +22,7 @@ export { BLOCK_TYPES, BLOCK_TYPE_LIST, type BlockType } from "./blockTypes";
 export { StickyNoteBlock } from "./StickyNoteBlock";
 export {
 	NOTE_COLORS,
-	NOTE_SIZE_LIMITS,
+	NOTE_MIN_SIZE,
 	stickyNoteData,
 	type NoteColor,
 	type NoteSize,

--- a/apps/portal/src/components/canvas/blocks/stickyNoteData.ts
+++ b/apps/portal/src/components/canvas/blocks/stickyNoteData.ts
@@ -10,20 +10,15 @@ export type StickyNoteData = {
 	size: NoteSize;
 };
 
-/** Bounds the server enforces on a note's box; the resizer must not exceed them. */
-export const NOTE_SIZE_LIMITS = {
-	minWidth: 75,
-	minHeight: 75,
-	maxWidth: 200,
-	maxHeight: 200,
-} as const;
+/** Notes can grow without a cap, but must remain usable on the canvas. */
+export const NOTE_MIN_SIZE = 50;
 
 const DEFAULT_SIZE: NoteSize = { width: 180, height: 120 };
 
-function dimension(value: unknown, fallback: number, min: number, max: number) {
+function dimension(value: unknown, fallback: number) {
 	const size =
 		typeof value === "number" && Number.isFinite(value) ? value : fallback;
-	return Math.min(Math.max(Math.round(size), min), max);
+	return Math.max(Math.round(size), NOTE_MIN_SIZE);
 }
 
 /**
@@ -43,18 +38,8 @@ export function stickyNoteData(data: unknown): StickyNoteData {
 			? (color as NoteColor)
 			: "yellow",
 		size: {
-			width: dimension(
-				size.width,
-				DEFAULT_SIZE.width,
-				NOTE_SIZE_LIMITS.minWidth,
-				NOTE_SIZE_LIMITS.maxWidth,
-			),
-			height: dimension(
-				size.height,
-				DEFAULT_SIZE.height,
-				NOTE_SIZE_LIMITS.minHeight,
-				NOTE_SIZE_LIMITS.maxHeight,
-			),
+			width: dimension(size.width, DEFAULT_SIZE.width),
+			height: dimension(size.height, DEFAULT_SIZE.height),
 		},
 	};
 }

--- a/apps/portal/src/components/canvas/canvas.css
+++ b/apps/portal/src/components/canvas/canvas.css
@@ -3,14 +3,13 @@
    are overridable CSS variables so a host app can theme the canvas. */
 
 .fx-canvas {
-	/* Tokens first (host app theme), hex only as a standalone fallback. */
-	--fx-canvas-bg: var(--background, #fafafa);
-	--fx-canvas-fg: var(--foreground, #18181b);
-	--fx-canvas-surface: var(--surface, #ffffff);
+	--fx-canvas-bg: var(--background);
+	--fx-canvas-fg: var(--foreground);
+	--fx-canvas-surface: var(--surface);
 	--fx-canvas-border: color-mix(in oklab, var(--fx-canvas-fg) 16%, var(--fx-canvas-bg));
 	--fx-canvas-dot: color-mix(in oklab, var(--fx-canvas-fg) 22%, var(--fx-canvas-bg));
 	--fx-canvas-muted: color-mix(in oklab, var(--fx-canvas-fg) 60%, var(--fx-canvas-bg));
-	--fx-canvas-accent: var(--accent, #6366f1);
+	--fx-canvas-accent: var(--accent);
 
 	position: relative;
 	width: 100%;
@@ -23,73 +22,121 @@
 /* The app switches theme with a class, not the OS scheme — cover both. */
 .dark .fx-canvas,
 [data-theme="dark"] .fx-canvas {
-	--fx-canvas-bg: var(--background, #18181b);
-	--fx-canvas-fg: var(--foreground, #fafafa);
-	--fx-canvas-surface: var(--surface, #27272a);
+	--fx-canvas-bg: var(--background);
+	--fx-canvas-fg: var(--foreground);
+	--fx-canvas-surface: var(--surface);
 }
 
 @media (prefers-color-scheme: dark) {
 	.fx-canvas {
-		--fx-canvas-bg: var(--background, #18181b);
-		--fx-canvas-fg: var(--foreground, #fafafa);
-		--fx-canvas-surface: var(--surface, #27272a);
+		--fx-canvas-bg: var(--background);
+		--fx-canvas-fg: var(--foreground);
+		--fx-canvas-surface: var(--surface);
 	}
 }
 
-/* React Flow's control toolbar styling. */
-.fx-canvas .react-flow__controls {
-	box-shadow: 0 8px 20px -4px rgba(0, 0, 0, 0.5) !important;
-	border-radius: 0.75rem !important;
-	border: 1px solid #161820 !important;
-	background: #141720 !important;
-	backdrop-filter: blur(12px) !important;
-	padding: 3px !important;
-	display: flex !important;
-	flex-direction: column !important;
-	gap: 2px !important;
-	overflow: hidden !important;
+/* Product-owned canvas toolbar. It deliberately does not inherit React Flow's
+   default controls, while every surface and state still resolves through the
+   shared component theme tokens. */
+.fx-canvas-toolbar {
+	--fx-toolbar-bg: var(--overlay, var(--surface));
+	--fx-toolbar-fg: var(--foreground);
+	--fx-toolbar-border: var(--border);
+
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	padding: 4px;
+	border: 1px solid var(--fx-toolbar-border);
+	border-radius: calc(var(--radius) + 4px);
+	/* Opaque by design: a translucent surface can blend to white through the
+	   React Flow viewport, even when the application theme is dark. */
+	background: var(--fx-toolbar-bg);
+	backdrop-filter: blur(14px);
+	color: var(--fx-toolbar-fg);
 }
 
-.fx-canvas .react-flow__controls-button {
-	width: 28px !important;
-	height: 28px !important;
-	padding: 5px !important;
-	border: none !important;
-	border-bottom: none !important;
-	border-radius: 0.5rem !important;
-	background: transparent !important;
-	color: #D0F237 !important;
-	fill: #D0F237 !important;
-	display: flex !important;
-	align-items: center !important;
-	justify-content: center !important;
-	transition: background-color 0.15s ease, opacity 0.15s ease !important;
+/* The design-system theme class may be on html or any app shell ancestor.
+   Keep the portal's control surface deterministic in every supported form. */
+html.dark .fx-canvas-toolbar,
+html[data-theme="dark"] .fx-canvas-toolbar,
+.dark .fx-canvas-toolbar,
+[data-theme="dark"] .fx-canvas-toolbar {
+	--fx-toolbar-bg: #141416;
+	--fx-toolbar-fg: #fafafa;
+	--fx-toolbar-border: #232326;
 }
 
-.fx-canvas .react-flow__controls-button:hover {
-	background: rgba(208, 242, 55, 0.12) !important;
-	color: #D0F237 !important;
+.fx-canvas-toolbar__group {
+	display: flex;
+	align-items: center;
+	gap: 2px;
 }
 
-.fx-canvas .react-flow__controls-button:active {
-	background: rgba(208, 242, 55, 0.22) !important;
+.fx-canvas-toolbar__divider {
+	width: 1px;
+	height: 20px;
+	margin: 0 2px;
+	background: var(--fx-toolbar-border);
 }
 
-.fx-canvas .react-flow__controls-button:disabled {
-	opacity: 0.3 !important;
-	background: transparent !important;
-	color: #71717a !important;
-	fill: #71717a !important;
-	cursor: not-allowed !important;
+.fx-canvas-toolbar__button,
+.fx-canvas-toolbar__zoom {
+	display: inline-flex;
+	width: 30px;
+	height: 30px;
+	align-items: center;
+	justify-content: center;
+	padding: 0;
+	border: 0;
+	border-radius: var(--radius);
+	background: transparent;
+	color: var(--fx-toolbar-fg);
+	cursor: pointer;
+	transition: background-color 150ms ease, color 150ms ease, opacity 150ms ease;
 }
 
-.fx-canvas .react-flow__controls-button svg {
-	width: 15px !important;
-	height: 15px !important;
-	max-width: 15px !important;
-	max-height: 15px !important;
-	stroke: currentColor !important;
-	stroke-width: 2 !important;
+.fx-canvas-toolbar__button:hover:not(:disabled),
+.fx-canvas-toolbar__zoom:hover {
+	background: color-mix(in srgb, var(--accent) 13%, transparent);
+	color: var(--accent);
+}
+
+.fx-canvas-toolbar__button[aria-pressed="true"] {
+	background: color-mix(in srgb, var(--accent) 18%, transparent);
+	color: var(--accent);
+}
+
+.fx-canvas-toolbar__button:focus-visible,
+.fx-canvas-toolbar__zoom:focus-visible {
+	outline: 2px solid var(--focus);
+	outline-offset: 1px;
+}
+
+.fx-canvas-toolbar__button:disabled {
+	cursor: not-allowed;
+	opacity: 0.35;
+}
+
+.fx-canvas-toolbar__button svg {
+	width: 15px;
+	height: 15px;
+}
+
+.fx-canvas-toolbar__zoom {
+	width: 44px;
+	font-size: 11px;
+	font-variant-numeric: tabular-nums;
+}
+
+@media (max-width: 640px) {
+	.fx-canvas-toolbar {
+		gap: 2px;
+	}
+
+	.fx-canvas-toolbar__divider {
+		display: none;
+	}
 }
 
 .fx-canvas .react-flow__minimap {
@@ -109,6 +156,22 @@
 	pointer-events: none;
 	font-size: 0.875rem;
 	color: var(--fx-canvas-muted);
+}
+
+.fx-canvas__quick-actions {
+	position: absolute;
+	top: 1rem;
+	right: 1rem;
+	z-index: 5;
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+}
+
+.fx-canvas__quick-action {
+	background: transparent;
+	border: 1px solid var(--border);
+	box-shadow: 0 0.25rem 0.75rem color-mix(in srgb, var(--foreground) 14%, transparent);
 }
 
 /* The shell wraps the canvas and its settings panel. Without a height of its

--- a/apps/portal/src/components/canvas/types.ts
+++ b/apps/portal/src/components/canvas/types.ts
@@ -59,6 +59,12 @@ export type BlockCanvasProps = {
 	/** Block settings side panel, opened by double click or the block's open
 	 *  action. Default `true`; available in `readonly` too (it only reads). */
 	enablePanel?: boolean;
+	/**
+	 * Composable canvas features must default to disabled. Enable them explicitly
+	 * from their owning route so embeds do not gain controls unintentionally.
+	 * Core block picker and canvas quick actions. Default `false`; off in readonly.
+	 */
+	enableBlockPicker?: boolean;
 	/** Copy/paste/duplicate of blocks and the edges between them. Default `true`;
 	 *  always off in `readonly`. Also hides the copy/duplicate block actions. */
 	enableClipboard?: boolean;

--- a/apps/portal/src/components/canvas/useBlockPicker.ts
+++ b/apps/portal/src/components/canvas/useBlockPicker.ts
@@ -1,0 +1,11 @@
+import { useCallback, useState } from "react";
+
+/** Shared picker controls for buttons, keyboard shortcuts, and other triggers. */
+export function useBlockPicker() {
+	const [isOpen, setIsOpen] = useState(false);
+	const open = useCallback(() => setIsOpen(true), []);
+	const close = useCallback(() => setIsOpen(false), []);
+	const onOpenChange = useCallback((nextOpen: boolean) => setIsOpen(nextOpen), []);
+
+	return { isOpen, open, close, onOpenChange };
+}

--- a/apps/portal/src/routes/_authed/$projectId_.canvas.$routeId.tsx
+++ b/apps/portal/src/routes/_authed/$projectId_.canvas.$routeId.tsx
@@ -16,6 +16,7 @@ function RouteCanvasPage() {
 	return (
 		<CanvasWorkbench
 			title="Route canvas"
+			enableBlockPicker
 			items={routesQuery.canvasItems.useQuery(routeId)}
 			reload={() => routesService.getCanvasItems(routeId)}
 			save={(payload) => save.mutateAsync(payload)}

--- a/packages/blocks/builtin/stickyNote.ts
+++ b/packages/blocks/builtin/stickyNote.ts
@@ -7,8 +7,8 @@ export const stickyNotesSchema = z
     notes: z.string(),
     color: z.enum(["red", "blue", "green", "yellow"]).default("yellow"),
     size: z.object({
-      width: z.number().min(75).max(200).default(100),
-      height: z.number().min(75).max(200).default(100),
+      width: z.number().min(50).default(100),
+      height: z.number().min(50).default(100),
     }),
   })
   .extend(baseBlockDataSchema.shape);

--- a/packages/components/index.ts
+++ b/packages/components/index.ts
@@ -15,6 +15,7 @@ export * from "./src/ArrayEditor";
 export * from "./src/JoinsEditor";
 export * from "./src/MultiSelect";
 export * from "./src/CustomSelect";
+export * from "./src/Sidebar";
 export { LazyLoader } from "./src/LazyLoader/LazyLoader";
 export {
 	Checkbox,

--- a/packages/components/src/Sidebar/Sidebar.tsx
+++ b/packages/components/src/Sidebar/Sidebar.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useState, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+import "./sidebar.css";
+
+export type SidebarPlacement = "left" | "right";
+
+export type SidebarProps = {
+	children: ReactNode;
+	isOpen: boolean;
+	onOpenChange: (isOpen: boolean) => void;
+	placement?: SidebarPlacement;
+	className?: string;
+	"aria-label"?: string;
+};
+
+/** Portal-backed sidebar with backdrop, Escape, and outside-click dismissal. */
+export function Sidebar({
+	children,
+	isOpen,
+	onOpenChange,
+	placement = "right",
+	className,
+	"aria-label": ariaLabel = "Sidebar",
+}: SidebarProps) {
+	const [mounted, setMounted] = useState(false);
+
+	useEffect(() => setMounted(true), []);
+
+	useEffect(() => {
+		if (!isOpen) return;
+
+		const closeOnEscape = (event: KeyboardEvent) => {
+			if (event.key === "Escape") onOpenChange(false);
+		};
+		const previousOverflow = document.body.style.overflow;
+		document.addEventListener("keydown", closeOnEscape);
+		document.body.style.overflow = "hidden";
+
+		return () => {
+			document.removeEventListener("keydown", closeOnEscape);
+			document.body.style.overflow = previousOverflow;
+		};
+	}, [isOpen, onOpenChange]);
+
+	if (!mounted || !isOpen) return null;
+
+	return createPortal(
+		<div
+			className="fx-sidebar-backdrop"
+			onMouseDown={(event) => {
+				if (event.target === event.currentTarget) onOpenChange(false);
+			}}
+		>
+			<aside
+				aria-label={ariaLabel}
+				aria-modal="true"
+				className={["fx-sidebar", `fx-sidebar--${placement}`, className]
+					.filter(Boolean)
+					.join(" ")}
+				role="dialog"
+			>
+				{children}
+			</aside>
+		</div>,
+		document.body,
+	);
+}

--- a/packages/components/src/Sidebar/index.ts
+++ b/packages/components/src/Sidebar/index.ts
@@ -1,0 +1,1 @@
+export * from "./Sidebar";

--- a/packages/components/src/Sidebar/sidebar.css
+++ b/packages/components/src/Sidebar/sidebar.css
@@ -1,0 +1,39 @@
+.fx-sidebar-backdrop {
+	position: fixed;
+	inset: 0;
+	z-index: 1000;
+	display: flex;
+	background: color-mix(in srgb, var(--foreground) 32%, transparent);
+}
+
+.fx-sidebar {
+	display: flex;
+	width: min(100%, 26rem);
+	height: 100dvh;
+	flex-direction: column;
+	background: var(--overlay);
+	box-shadow: 0 0 2rem color-mix(in srgb, var(--foreground) 24%, transparent);
+	animation: fx-sidebar-enter 160ms ease-out;
+}
+
+.fx-sidebar--right {
+	margin-left: auto;
+	border-left: 1px solid var(--border);
+}
+
+.fx-sidebar--left {
+	margin-right: auto;
+	border-right: 1px solid var(--border);
+	--fx-sidebar-enter-offset: -1rem;
+}
+
+@keyframes fx-sidebar-enter {
+	from {
+		opacity: 0;
+		transform: translateX(var(--fx-sidebar-enter-offset, 1rem));
+	}
+	to {
+		opacity: 1;
+		transform: translateX(0);
+	}
+}

--- a/packages/components/src/css.d.ts
+++ b/packages/components/src/css.d.ts
@@ -1,0 +1,1 @@
+declare module "*.css";

--- a/packages/components/src/styles.css
+++ b/packages/components/src/styles.css
@@ -34,7 +34,7 @@
 .light,
 [data-theme="light"],
 [data-theme="default"] {
-	--accent: oklch(0.9 0.19 122);
+	--accent: oklch(0.72 0.17 122);
 	/* lime green */
 }
 


### PR DESCRIPTION
## Summary
- add themed canvas toolbar, block picker sidebar, zoom, fit, formatting, undo/redo, and layout locking controls
- improve sticky notes with safe 50px minimum sizing, unbounded resizing, edit-only elevation, color/delete controls, and theme-aligned styling
- protect route-owned entrypoint and error-handler blocks from copy, duplicate, and every deletion path, with an error notification
- add shared sidebar component and CSS type declaration support

## Validation
- un run lint (workspace pre-commit suite)
- 734 tests passed (2 skipped)