### PR TITLE
feat(components): port the Schema Editor to HeroUI

### DIFF
--- a/apps/portal/src/routes/playground.tsx
+++ b/apps/portal/src/routes/playground.tsx
@@ -2,6 +2,7 @@ import { useState, type ReactNode } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import {
 	Card,
+	Checkbox,
 	ConditionsBuilder,
 	type Condition,
 	FieldMapEditor,
@@ -12,6 +13,8 @@ import {
 	JsTextField,
 	Label,
 	ListBox,
+	SchemaEditor,
+	type ValidationSchema,
 	Select,
 } from "@fluxify/components";
 
@@ -217,7 +220,96 @@ function IntegrationSelectorDemo() {
 	);
 }
 
+const INITIAL_SCHEMA: ValidationSchema = {
+	dataType: "object",
+	properties: [
+		{
+			id: "p1",
+			key: "email",
+			dataType: "str",
+			required: true,
+			rules: [
+				{ type: "minLength", value: 5 },
+				{ type: "contains", value: "@" },
+			],
+		},
+		{ id: "p2", key: "age", dataType: "int", required: false, rules: [{ type: "min", value: 18 }] },
+		{
+			id: "p3",
+			key: "role",
+			dataType: "enum",
+			required: true,
+			rules: [{ type: "values", value: ["admin", "editor", "viewer"] }],
+		},
+		{
+			id: "p4",
+			key: "address",
+			dataType: "object",
+			required: false,
+			properties: [
+				{ id: "p4a", key: "city", dataType: "str", required: true, rules: [] },
+				{ id: "p4b", key: "zip", dataType: "str", required: false, rules: [{ type: "regex", value: "^\\d{6}$" }] },
+			],
+		},
+		{
+			id: "p5",
+			key: "tags",
+			dataType: "arr",
+			required: false,
+			rules: [{ type: "maxItems", value: 5 }],
+			items: { key: "", dataType: "str", rules: [] },
+		},
+		{ id: "p6", key: "avatar", dataType: "file", required: false, rules: [{ type: "maxSize", value: 2097152 }] },
+	],
+};
+
+/**
+ * Exercises the props that change what the editor allows, not just how it
+ * looks — a locked editor with a per-field type override is the shape the
+ * route settings panel actually needs.
+ */
+function SchemaEditorDemo() {
+	const [schema, setSchema] = useState<ValidationSchema>(INITIAL_SCHEMA);
+	const [isReadOnly, setIsReadOnly] = useState(false);
+	const [disableJs, setDisableJs] = useState(false);
+	const [limitTypes, setLimitTypes] = useState(false);
+	const [limitDepth, setLimitDepth] = useState(false);
+
+	return (
+		<div className="flex flex-col gap-4">
+			<div className="flex flex-wrap gap-5 rounded-[var(--radius)] border border-border bg-surface p-3">
+				<Checkbox isSelected={isReadOnly} label="Read only" onChange={setIsReadOnly} />
+				<Checkbox isSelected={disableJs} label="Disable JS" onChange={setDisableJs} />
+				<Checkbox
+					isSelected={limitTypes}
+					label="Only str / int / bool"
+					onChange={setLimitTypes}
+				/>
+				<Checkbox isSelected={limitDepth} label="Max depth 1" onChange={setLimitDepth} />
+			</div>
+
+			<SchemaEditor
+				allowedDataTypes={limitTypes ? ["str", "int", "bool"] : undefined}
+				description="Builds the validation schema the server compiles to Zod."
+				disableJs={disableJs}
+				isReadOnly={isReadOnly}
+				label="Request body schema"
+				maxDepth={limitDepth ? 1 : undefined}
+				onChange={setSchema}
+				// Locked everywhere else, but this one field still offers a choice.
+				typeOverrides={{ "address.zip": ["str", "int"] }}
+				value={schema}
+			/>
+
+			<pre className="max-h-96 overflow-auto rounded-[var(--radius)] border border-border bg-background p-3 font-mono text-xs text-foreground">
+				{JSON.stringify(schema, null, 2)}
+			</pre>
+		</div>
+	);
+}
+
 const DEMOS: { name: string; render: () => ReactNode }[] = [
+	{ name: "SchemaEditor", render: () => <SchemaEditorDemo /> },
 	{ name: "JsonEditor", render: () => <JsonEditorDemo /> },
 	{ name: "JsTextField", render: () => <JsTextFieldDemo /> },
 	{ name: "ConditionsBuilder", render: () => <ConditionsBuilderDemo /> },

--- a/packages/components/index.ts
+++ b/packages/components/index.ts
@@ -13,6 +13,7 @@ export * from "./src/IntegrationSelector";
 export * from "./src/JsonEditor";
 export * from "./src/ArrayEditor";
 export * from "./src/JoinsEditor";
+export * from "./src/SchemaEditor";
 export * from "./src/MultiSelect";
 export * from "./src/CustomSelect";
 export * from "./src/Sidebar";

--- a/packages/components/src/SchemaEditor/ConfigurationDrawer.tsx
+++ b/packages/components/src/SchemaEditor/ConfigurationDrawer.tsx
@@ -1,0 +1,81 @@
+import { Button, Drawer } from "@heroui/react";
+import { TbX } from "react-icons/tb";
+import { useSchemaEditorContext } from "./context";
+import type { SchemaProperty } from "./types";
+import { getAtPath } from "./utils";
+
+/**
+ * Rules live in a drawer rather than inline: a string has seven of them, and
+ * putting that on every row would bury the shape the editor exists to show.
+ */
+export function ConfigurationDrawer() {
+	const {
+		schema,
+		drawerPath,
+		closeDrawer,
+		updateProperty,
+		isReadOnly,
+		jsEditorRows,
+		ruleEditors,
+		labelFor,
+	} = useSchemaEditorContext();
+
+	const node = drawerPath ? getAtPath(schema, drawerPath) : undefined;
+	const RuleEditor = node ? ruleEditors[node.dataType] : undefined;
+	const title = node
+		? `Configure ${(node as SchemaProperty).key ? `"${(node as SchemaProperty).key}"` : "field"}`
+		: "Configure field";
+
+	return (
+		<Drawer.Backdrop
+			isOpen={drawerPath !== null}
+			onOpenChange={(isOpen) => {
+				if (!isOpen) closeDrawer();
+			}}
+		>
+			<Drawer.Content placement="right">
+				<Drawer.Dialog
+					aria-label={title}
+					className="flex w-full max-w-xl flex-col"
+				>
+					<Drawer.Header className="flex items-center gap-2">
+						<Drawer.Heading className="min-w-0 flex-1 truncate text-sm font-medium">
+							{title}
+						</Drawer.Heading>
+						{node && (
+							<span className="shrink-0 rounded-full border border-border bg-surface px-2 py-0.5 font-mono text-[10px] text-muted-foreground">
+								{labelFor(node.dataType)}
+							</span>
+						)}
+						<Button
+							aria-label="Close configuration"
+							isIconOnly
+							onPress={closeDrawer}
+							size="sm"
+							variant="ghost"
+						>
+							<TbX className="size-4" />
+						</Button>
+					</Drawer.Header>
+
+					<Drawer.Body className="flex-1 overflow-auto">
+						{RuleEditor && node ? (
+							<RuleEditor
+								isReadOnly={isReadOnly}
+								jsEditorRows={jsEditorRows}
+								node={node}
+								onUpdate={(updates) =>
+									drawerPath && updateProperty(drawerPath, updates)
+								}
+							/>
+						) : (
+							<p className="text-sm text-muted">
+								No configuration is available for this type.
+							</p>
+						)}
+					</Drawer.Body>
+				</Drawer.Dialog>
+			</Drawer.Content>
+		</Drawer.Backdrop>
+	);
+}

--- a/packages/components/src/SchemaEditor/DataTypeSelect.tsx
+++ b/packages/components/src/SchemaEditor/DataTypeSelect.tsx
@@ -1,0 +1,50 @@
+import { ListBox, Select } from "@heroui/react";
+import type { DataType, DataTypeOption } from "./types";
+
+/** The single type dropdown, shared by the root, every property and array items. */
+export function DataTypeSelect({
+	value,
+	options,
+	onChange,
+	isDisabled,
+	label,
+	className,
+}: {
+	value: DataType;
+	options: DataTypeOption[];
+	onChange: (next: DataType) => void;
+	isDisabled?: boolean;
+	label: string;
+	className?: string;
+}) {
+	return (
+		<Select
+			aria-label={label}
+			className={className}
+			fullWidth
+			isDisabled={isDisabled}
+			onSelectionChange={(key) => key && onChange(key as DataType)}
+			selectedKey={value}
+			variant="secondary"
+		>
+			<Select.Trigger>
+				<Select.Value />
+				<Select.Indicator />
+			</Select.Trigger>
+			<Select.Popover>
+				<ListBox>
+					{options.map((option) => (
+						<ListBox.Item
+							id={option.value}
+							key={option.value}
+							textValue={option.label}
+						>
+							{option.label}
+							<ListBox.ItemIndicator />
+						</ListBox.Item>
+					))}
+				</ListBox>
+			</Select.Popover>
+		</Select>
+	);
+}

--- a/packages/components/src/SchemaEditor/InfoNote.tsx
+++ b/packages/components/src/SchemaEditor/InfoNote.tsx
@@ -1,0 +1,26 @@
+import clsx from "clsx";
+import type { ReactNode } from "react";
+import { TbInfoCircle } from "react-icons/tb";
+
+/** The one callout style used across the editor's tabs, drawer and panels. */
+export function InfoNote({
+	children,
+	className,
+}: {
+	children: ReactNode;
+	className?: string;
+}) {
+	return (
+		<div
+			className={clsx(
+				"flex gap-2 rounded-[var(--radius)] border border-border bg-surface p-3",
+				className,
+			)}
+		>
+			<TbInfoCircle aria-hidden className="mt-0.5 size-4 shrink-0 text-accent" />
+			<div className="text-xs leading-relaxed text-muted-foreground">
+				{children}
+			</div>
+		</div>
+	);
+}

--- a/packages/components/src/SchemaEditor/PropertyRow.tsx
+++ b/packages/components/src/SchemaEditor/PropertyRow.tsx
@@ -1,0 +1,127 @@
+import { Button, InputGroup, TextField, Tooltip } from "@heroui/react";
+import { IoLogoJavascript } from "react-icons/io5";
+import { TbChevronRight, TbSettings, TbTrash } from "react-icons/tb";
+import { Checkbox } from "../Checkbox";
+import { CONTAINER_TYPES } from "./constants";
+import { useSchemaEditorContext } from "./context";
+import { DataTypeSelect } from "./DataTypeSelect";
+import type { SchemaPath, SchemaProperty } from "./types";
+
+interface PropertyRowProps {
+	property: SchemaProperty;
+	/** Full path to this property, used for overrides and mutations. */
+	path: SchemaPath;
+}
+
+/** One `key : type` line. Containers navigate; everything else opens the drawer. */
+export function PropertyRow({ property, path }: PropertyRowProps) {
+	const {
+		isReadOnly,
+		removeProperty,
+		updateProperty,
+		openDrawer,
+		goToPath,
+		typeOptionsFor,
+		hasTypeOverride,
+		ruleEditors,
+	} = useSchemaEditorContext();
+
+	const isContainer = CONTAINER_TYPES.includes(property.dataType);
+	const isJs = property.dataType === "js";
+	// A type with no registered editor has nothing to open — `bool` today.
+	const isConfigurable = isContainer || Boolean(ruleEditors[property.dataType]);
+
+	// An override names the choices for this one field, so it stays live even
+	// when the rest of the editor is locked.
+	const typeIsEditable = !isReadOnly || hasTypeOverride(path);
+
+	const update = (updates: Partial<SchemaProperty>) =>
+		updateProperty(path, updates);
+
+	const handleConfigure = () => {
+		if (isContainer) goToPath(path);
+		else openDrawer(path);
+	};
+
+	return (
+		<div className="flex w-full flex-col gap-2 rounded-[var(--radius)] border border-border bg-surface p-2 sm:flex-row sm:items-center">
+			<div className="min-w-0 flex-[2]">
+				<TextField fullWidth isDisabled={isReadOnly} variant="secondary">
+					<InputGroup fullWidth variant="secondary">
+						<InputGroup.Input
+							aria-label="Property key"
+							onChange={(event) => update({ key: event.currentTarget.value })}
+							placeholder="Property key"
+							value={property.key}
+						/>
+					</InputGroup>
+				</TextField>
+			</div>
+
+			<div className="min-w-0 flex-[2]">
+				<DataTypeSelect
+					isDisabled={!typeIsEditable}
+					label={`Data type for ${property.key || "property"}`}
+					onChange={(dataType) => update({ dataType })}
+					options={typeOptionsFor(path)}
+					value={property.dataType}
+				/>
+			</div>
+
+			<div className="flex shrink-0 items-center gap-2 sm:w-40 sm:justify-end">
+				<Checkbox
+					isDisabled={isReadOnly}
+					isSelected={property.required ?? true}
+					label="Required"
+					onChange={(next) => update({ required: next })}
+				/>
+
+				{isConfigurable ? (
+					<Tooltip>
+						<Button
+							aria-label={
+								isContainer
+									? `Open ${property.key || "property"}`
+									: `Configure ${property.key || "property"}`
+							}
+							isIconOnly
+							onPress={handleConfigure}
+							size="sm"
+							variant="ghost"
+						>
+							{isContainer ? (
+								<TbChevronRight className="size-4 text-accent" />
+							) : isJs ? (
+								<IoLogoJavascript className="size-4 text-accent" />
+							) : (
+								<TbSettings className="size-4 text-accent" />
+							)}
+						</Button>
+						<Tooltip.Content>
+							{isContainer
+								? "Open this field to edit its shape"
+								: isJs
+									? "Write custom JavaScript validation"
+									: "Configure validation rules"}
+						</Tooltip.Content>
+					</Tooltip>
+				) : (
+					// Keeps the action column aligned across rows.
+					<span aria-hidden className="inline-block size-8" />
+				)}
+
+				{!isReadOnly && (
+					<Button
+						aria-label={`Remove ${property.key || "property"}`}
+						isIconOnly
+						onPress={() => removeProperty(path)}
+						size="sm"
+						variant="ghost"
+					>
+						<TbTrash className="size-4 text-danger" />
+					</Button>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/packages/components/src/SchemaEditor/SchemaEditor.tsx
+++ b/packages/components/src/SchemaEditor/SchemaEditor.tsx
@@ -1,0 +1,157 @@
+import { Tabs } from "@heroui/react";
+import clsx from "clsx";
+import { forwardRef, useImperativeHandle, useState } from "react";
+import { IoLogoJavascript } from "react-icons/io5";
+import { TbEye, TbLayoutDashboard } from "react-icons/tb";
+import { JavaScriptTextArea } from "../JavaScriptTextArea";
+import { ConfigurationDrawer } from "./ConfigurationDrawer";
+import { DEFAULT_JS } from "./constants";
+import { SchemaEditorProvider, useSchemaEditorContext } from "./context";
+import { InfoNote } from "./InfoNote";
+import { SchemaNavigator } from "./SchemaNavigator";
+import { SchemaPreview } from "./SchemaPreview";
+import type { SchemaEditorProps, SchemaEditorRef } from "./types";
+
+type TabKey = "editor" | "js" | "preview";
+
+const SchemaEditorContent = forwardRef<
+	SchemaEditorRef,
+	{
+		onSave?: SchemaEditorProps["onSave"];
+		showPreview: boolean;
+		showRootTypeSelector: boolean;
+	}
+>(({ onSave, showPreview, showRootTypeSelector }, ref) => {
+	const { schema, setSchema, isReadOnly, disableJs, jsEditorRows } =
+		useSchemaEditorContext();
+
+	const isRootJs = schema.dataType === "js";
+	const [selectedTab, setSelectedTab] = useState<TabKey>(
+		isRootJs ? "js" : "editor",
+	);
+
+	useImperativeHandle(ref, () => ({
+		save: () => onSave?.(schema),
+		getSchema: () => schema,
+	}));
+
+	/**
+	 * The tab *is* the root's type: "Custom JS" means `dataType: "js"`, which is
+	 * what makes the server run the validator instead of building a shape. A
+	 * read-only editor still browses both, it just does not rewrite the schema.
+	 */
+	const handleTabChange = (next: TabKey) => {
+		setSelectedTab(next);
+		if (isReadOnly) return;
+		if (next === "js" && !isRootJs) {
+			setSchema({ ...schema, dataType: "js", js: schema.js ?? DEFAULT_JS });
+		} else if (next === "editor" && isRootJs) {
+			setSchema({ ...schema, dataType: "object" });
+		}
+	};
+
+	return (
+		<Tabs
+			onSelectionChange={(key) => handleTabChange(key as TabKey)}
+			selectedKey={selectedTab}
+			variant="secondary"
+		>
+			<Tabs.ListContainer>
+				<Tabs.List aria-label="Schema editor mode">
+					<Tabs.Tab id="editor">
+						<TbLayoutDashboard aria-hidden className="mr-1.5 size-4" />
+						Schema editor
+						<Tabs.Indicator />
+					</Tabs.Tab>
+					{!disableJs && (
+						<Tabs.Tab id="js">
+							<IoLogoJavascript aria-hidden className="mr-1.5 size-4" />
+							Custom JS
+							<Tabs.Indicator />
+						</Tabs.Tab>
+					)}
+					{showPreview && !isRootJs && (
+						<Tabs.Tab id="preview">
+							<TbEye aria-hidden className="mr-1.5 size-4" />
+							Preview
+							<Tabs.Indicator />
+						</Tabs.Tab>
+					)}
+				</Tabs.List>
+			</Tabs.ListContainer>
+
+			<Tabs.Panel className="pt-4" id="editor">
+				<div className="rounded-[var(--radius)] border border-border p-4">
+					<SchemaNavigator showRootTypeSelector={showRootTypeSelector} />
+				</div>
+				<ConfigurationDrawer />
+			</Tabs.Panel>
+
+			{!disableJs && (
+				<Tabs.Panel className="pt-4" id="js">
+					<div className="flex flex-col gap-3 rounded-[var(--radius)] border border-border p-4">
+						<InfoNote>
+							Validate the entire request in JavaScript. Return a boolean to
+							pass or fail. To return a custom error body, throw:{" "}
+							<code className="font-mono">
+								{'throw new ValidationError({ your: "error" })'}
+							</code>
+							.
+						</InfoNote>
+						<JavaScriptTextArea
+							aria-label="Root custom JavaScript validation"
+							onChange={(next) => setSchema({ ...schema, js: next })}
+							readOnly={isReadOnly}
+							rows={jsEditorRows + 8}
+							value={schema.js ?? DEFAULT_JS}
+						/>
+					</div>
+				</Tabs.Panel>
+			)}
+
+			{showPreview && !isRootJs && (
+				<Tabs.Panel className="pt-4" id="preview">
+					<div className="rounded-[var(--radius)] border border-border p-4">
+						<SchemaPreview schema={schema} />
+					</div>
+				</Tabs.Panel>
+			)}
+		</Tabs>
+	);
+});
+
+SchemaEditorContent.displayName = "SchemaEditorContent";
+
+/**
+ * Low-code builder for the validation schema the server compiles to Zod. Works
+ * controlled (`value` + `onChange`) or uncontrolled (`defaultValue` + a `ref`).
+ */
+export const SchemaEditor = forwardRef<SchemaEditorRef, SchemaEditorProps>(
+	function SchemaEditor(props, ref) {
+		const {
+			onSave,
+			label,
+			description,
+			className,
+			showPreview = true,
+			showRootTypeSelector = true,
+		} = props;
+
+		return (
+			<div className={clsx("flex w-full flex-col gap-3", className)}>
+				{label && (
+					<span className="text-sm font-medium text-foreground">{label}</span>
+				)}
+				{description && <p className="text-xs text-muted">{description}</p>}
+				<SchemaEditorProvider {...props}>
+					<SchemaEditorContent
+						onSave={onSave}
+						ref={ref}
+						showPreview={showPreview}
+						showRootTypeSelector={showRootTypeSelector}
+					/>
+				</SchemaEditorProvider>
+			</div>
+		);
+	},
+);

--- a/packages/components/src/SchemaEditor/SchemaNavigator.tsx
+++ b/packages/components/src/SchemaEditor/SchemaNavigator.tsx
@@ -1,0 +1,209 @@
+import { Breadcrumbs, Button } from "@heroui/react";
+import { useMemo } from "react";
+import { TbPlus, TbSettings } from "react-icons/tb";
+import { CONTAINER_TYPES } from "./constants";
+import { useSchemaEditorContext } from "./context";
+import { DataTypeSelect } from "./DataTypeSelect";
+import { InfoNote } from "./InfoNote";
+import { PropertyRow } from "./PropertyRow";
+import type { SchemaNode, SchemaPath, SchemaProperty } from "./types";
+import { buildBreadcrumbs, getAtPath } from "./utils";
+
+/**
+ * The one level of the schema currently in view. Objects list their properties,
+ * arrays configure their item schema, and a primitive just points at the rules
+ * drawer. Nesting is navigation rather than indentation, so a deep schema stays
+ * readable at any depth.
+ */
+export function SchemaNavigator({
+	showRootTypeSelector = true,
+}: {
+	showRootTypeSelector?: boolean;
+}) {
+	const {
+		schema,
+		path,
+		goToLevel,
+		updateProperty,
+		openDrawer,
+		isReadOnly,
+		typeOptionsFor,
+		ruleEditors,
+	} = useSchemaEditorContext();
+
+	// A path can outlive the node it pointed at (the property was deleted); fall
+	// back to the root rather than rendering nothing.
+	const node = (getAtPath(schema, path) ?? schema) as SchemaNode;
+	const crumbs = useMemo(() => buildBreadcrumbs(schema, path), [schema, path]);
+
+	const rootTypeOptions = typeOptionsFor([], true);
+	const showRootTypes =
+		showRootTypeSelector &&
+		!isReadOnly &&
+		path.length === 0 &&
+		rootTypeOptions.length > 1;
+
+	return (
+		<div className="flex flex-col gap-4">
+			<Breadcrumbs>
+				{crumbs.map((crumb) => (
+					<Breadcrumbs.Item
+						key={crumb.level}
+						onPress={() => goToLevel(crumb.level)}
+					>
+						{crumb.title}
+					</Breadcrumbs.Item>
+				))}
+			</Breadcrumbs>
+
+			{showRootTypes && (
+				<div className="flex items-center gap-3">
+					<span className="shrink-0 text-sm font-medium text-foreground">
+						Root schema type
+					</span>
+					<DataTypeSelect
+						className="w-48"
+						label="Root schema type"
+						onChange={(dataType) => updateProperty([], { dataType })}
+						options={rootTypeOptions}
+						value={schema.dataType}
+					/>
+				</div>
+			)}
+
+			{node.dataType === "arr" ? (
+				<ArrayLevel node={node} path={path} />
+			) : node.dataType === "object" ? (
+				<ObjectLevel node={node} path={path} />
+			) : (
+				<div className="flex flex-col items-start gap-3">
+					<p className="text-sm text-muted-foreground">
+						{ruleEditors[node.dataType]
+							? "This level is a primitive. Configure its validation rules below."
+							: "This level is a primitive with no rules to configure."}
+					</p>
+					{ruleEditors[node.dataType] && (
+						<Button
+							onPress={() => openDrawer(path)}
+							size="sm"
+							variant="secondary"
+						>
+							<TbSettings className="mr-1 size-4" />
+							Configure rules
+						</Button>
+					)}
+				</div>
+			)}
+		</div>
+	);
+}
+
+function ObjectLevel({ node, path }: { node: SchemaNode; path: SchemaPath }) {
+	const { addProperty, isReadOnly } = useSchemaEditorContext();
+	const properties = node.properties ?? [];
+
+	return (
+		<div className="flex flex-col gap-3">
+			{!isReadOnly && (
+				<InfoNote>
+					Recursive schemas are not expressible in this UI. For a cyclic shape,
+					set the field's type to{" "}
+					<span className="font-medium">Write JavaScript</span> and validate it
+					in code.
+				</InfoNote>
+			)}
+
+			{properties.length === 0 ? (
+				<p className="py-1 text-sm italic text-muted">
+					No properties added yet.
+				</p>
+			) : (
+				<div className="flex flex-col gap-2">
+					{properties.map((property, index) => (
+						<PropertyRow
+							key={property.id ?? `${index}-${property.key}`}
+							path={[...path, index]}
+							property={property}
+						/>
+					))}
+				</div>
+			)}
+
+			{!isReadOnly && (
+				<div>
+					<Button
+						onPress={() => addProperty(path)}
+						size="sm"
+						variant="secondary"
+					>
+						<TbPlus className="mr-1 size-4" />
+						Add property
+					</Button>
+				</div>
+			)}
+		</div>
+	);
+}
+
+const DEFAULT_ITEMS: SchemaProperty = { key: "", dataType: "str", rules: [] };
+
+function ArrayLevel({ node, path }: { node: SchemaNode; path: SchemaPath }) {
+	const {
+		goToPath,
+		openDrawer,
+		updateProperty,
+		isReadOnly,
+		typeOptionsFor,
+		ruleEditors,
+	} = useSchemaEditorContext();
+
+	const items = node.items ?? DEFAULT_ITEMS;
+	const itemsPath: SchemaPath = [...path, "items"];
+	const ArrayRuleEditor = ruleEditors.arr;
+	const itemsAreContainer = CONTAINER_TYPES.includes(items.dataType);
+	const itemsAreConfigurable =
+		itemsAreContainer || Boolean(ruleEditors[items.dataType]);
+
+	return (
+		<div className="flex flex-col gap-4">
+			{ArrayRuleEditor && (
+				<ArrayRuleEditor
+					isReadOnly={isReadOnly}
+					node={node}
+					onUpdate={(updates) => updateProperty(path, updates)}
+				/>
+			)}
+
+			<div className="h-px w-full bg-border" />
+
+			<div className="flex flex-col gap-2">
+				<span className="text-sm font-medium text-foreground">
+					Array items data type
+				</span>
+				<div className="flex items-center gap-2">
+					<DataTypeSelect
+						className="flex-1"
+						isDisabled={isReadOnly}
+						label="Array items data type"
+						onChange={(dataType) => updateProperty(itemsPath, { dataType })}
+						options={typeOptionsFor(itemsPath)}
+						value={items.dataType}
+					/>
+					{itemsAreConfigurable && (
+						<Button
+							aria-label="Configure array items"
+							isIconOnly
+							onPress={() =>
+								itemsAreContainer ? goToPath(itemsPath) : openDrawer(itemsPath)
+							}
+							size="sm"
+							variant="ghost"
+						>
+							<TbSettings className="size-4 text-accent" />
+						</Button>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/packages/components/src/SchemaEditor/SchemaPreview.tsx
+++ b/packages/components/src/SchemaEditor/SchemaPreview.tsx
@@ -1,0 +1,123 @@
+import { Button } from "@heroui/react";
+import { useState } from "react";
+import { TbChevronDown, TbChevronRight } from "react-icons/tb";
+import type { Rule, SchemaNode, SchemaProperty, ValidationSchema } from "./types";
+
+/** `minLength: 3, regex: ^a+$` — the rules, inline, in authoring order. */
+function summariseRules(rules?: Rule[]): string {
+	if (!rules?.length) return "";
+	const parts = rules
+		.filter((rule) => rule.value !== undefined && rule.value !== "")
+		.map((rule) => {
+			const value = Array.isArray(rule.value)
+				? rule.value.join(" | ")
+				: String(rule.value);
+			return `${rule.type}: ${value}`;
+		});
+	return parts.length ? ` (${parts.join(", ")})` : "";
+}
+
+function PreviewNode({
+	label,
+	node,
+	isRequired,
+}: {
+	label: string;
+	node: SchemaNode;
+	isRequired?: boolean;
+}) {
+	const [isOpen, setIsOpen] = useState(true);
+	const children = node.dataType === "object" ? (node.properties ?? []) : [];
+	const items = node.dataType === "arr" ? node.items : undefined;
+	const hasChildren = children.length > 0 || Boolean(items);
+
+	return (
+		<div className="ml-3 mt-1">
+			<div className="flex items-start gap-1">
+				{hasChildren ? (
+					<Button
+						aria-label={isOpen ? `Collapse ${label}` : `Expand ${label}`}
+						className="mt-0.5 h-4 w-4 min-w-4 p-0"
+						isIconOnly
+						onPress={() => setIsOpen((prev) => !prev)}
+						size="sm"
+						variant="ghost"
+					>
+						{isOpen ? (
+							<TbChevronDown className="size-3.5" />
+						) : (
+							<TbChevronRight className="size-3.5" />
+						)}
+					</Button>
+				) : (
+					<span aria-hidden className="inline-block w-4" />
+				)}
+
+				<div className="min-w-0 flex-1">
+					<p className="font-mono text-xs">
+						<span className="font-semibold text-accent">{label}</span>
+						<span className="text-muted-foreground">
+							{": "}
+							{node.dataType}
+							{isRequired && <span className="text-danger"> *</span>}
+							{summariseRules(node.rules)}
+							{node.dataType === "js" && !node.js && " (no code)"}
+						</span>
+					</p>
+
+					{hasChildren && isOpen && (
+						<div className="border-l border-border">
+							{children.map((child, index) => (
+								<PreviewNode
+									isRequired={child.required ?? true}
+									key={child.id ?? `${index}-${child.key}`}
+									label={child.key || "<unnamed>"}
+									node={child}
+								/>
+							))}
+							{items && <PreviewNode label="[item]" node={items} />}
+						</div>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}
+
+/** Read-only outline of the whole schema — the shape, not the form. */
+export function SchemaPreview({ schema }: { schema: ValidationSchema }) {
+	if (schema.dataType === "js") {
+		return (
+			<p className="text-sm text-muted">
+				This schema is validated entirely by custom JavaScript.
+			</p>
+		);
+	}
+
+	const properties: SchemaProperty[] = schema.properties ?? [];
+	const isEmpty =
+		schema.dataType === "object"
+			? properties.length === 0
+			: schema.dataType === "arr" && !schema.items;
+
+	if (isEmpty) {
+		return <p className="text-sm italic text-muted">Nothing defined yet.</p>;
+	}
+
+	return (
+		<div className="rounded-[var(--radius)] border border-border bg-surface py-3">
+			{schema.dataType === "object" ? (
+				properties.map((property, index) => (
+					<PreviewNode
+						isRequired={property.required ?? true}
+						key={property.id ?? `${index}-${property.key}`}
+						label={property.key || "<unnamed>"}
+						node={property}
+					/>
+				))
+			) : (
+				<PreviewNode label="<root>" node={schema} />
+			)}
+		</div>
+	);
+}

--- a/packages/components/src/SchemaEditor/constants.ts
+++ b/packages/components/src/SchemaEditor/constants.ts
@@ -1,0 +1,41 @@
+import type { DataType, ValidationSchema } from "./types";
+
+export const DATA_TYPE_LABELS: Record<DataType, string> = {
+	str: "String",
+	int: "Integer",
+	float: "Float",
+	bool: "Boolean",
+	arr: "Array",
+	object: "Object",
+	enum: "Enum",
+	file: "File",
+	blob: "Binary (Blob)",
+	js: "Write JavaScript",
+};
+
+/** Dropdown order. Also the default `allowedDataTypes`. */
+export const ALL_DATA_TYPES: DataType[] = [
+	"str",
+	"int",
+	"float",
+	"bool",
+	"arr",
+	"object",
+	"enum",
+	"file",
+	"blob",
+	"js",
+];
+
+/** Types that can hold children, and so consume a level of `maxDepth`. */
+export const CONTAINER_TYPES: DataType[] = ["object", "arr"];
+
+/** A root schema is a shape to validate; `js` at the root is its own tab. */
+export const ROOT_EXCLUDED_TYPES: DataType[] = ["js"];
+
+export const DEFAULT_JS = "return true;";
+
+export const DEFAULT_SCHEMA: ValidationSchema = {
+	dataType: "object",
+	properties: [],
+};

--- a/packages/components/src/SchemaEditor/context.tsx
+++ b/packages/components/src/SchemaEditor/context.tsx
@@ -1,0 +1,238 @@
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useMemo,
+	useState,
+	type ComponentType,
+} from "react";
+import {
+	ALL_DATA_TYPES,
+	CONTAINER_TYPES,
+	DATA_TYPE_LABELS,
+	DEFAULT_SCHEMA,
+	ROOT_EXCLUDED_TYPES,
+} from "./constants";
+import { DEFAULT_RULE_EDITORS } from "./rules";
+import type {
+	DataType,
+	DataTypeOption,
+	RuleEditorProps,
+	SchemaEditorProps,
+	SchemaPath,
+	ValidationSchema,
+} from "./types";
+import {
+	addPropertyAtPath,
+	mergeAtPath,
+	pathToKeyString,
+	removeAtPath,
+} from "./utils";
+
+interface SchemaEditorContextValue {
+	schema: ValidationSchema;
+	setSchema: (schema: ValidationSchema) => void;
+	/** Path of the sub-schema currently being shown. */
+	path: SchemaPath;
+	/** Navigates into the sub-schema at an absolute path. */
+	goToPath: (path: SchemaPath) => void;
+	/** Truncates the current path — used by the breadcrumbs. */
+	goToLevel: (level: number) => void;
+	/** Path whose rules the drawer is editing, or `null` when it is closed. */
+	drawerPath: SchemaPath | null;
+	openDrawer: (path: SchemaPath) => void;
+	closeDrawer: () => void;
+
+	addProperty: (path: SchemaPath) => void;
+	removeProperty: (path: SchemaPath) => void;
+	updateProperty: (
+		path: SchemaPath,
+		updates: Partial<ValidationSchema>,
+	) => void;
+
+	isReadOnly: boolean;
+	disableJs: boolean;
+	jsEditorRows: number;
+	ruleEditors: Partial<Record<DataType, ComponentType<RuleEditorProps>>>;
+	/** Type choices for the node at `path`, honouring overrides and depth. */
+	typeOptionsFor: (path: SchemaPath, isRoot?: boolean) => DataTypeOption[];
+	/** True when this one dropdown stays editable despite `isReadOnly`. */
+	hasTypeOverride: (path: SchemaPath) => boolean;
+	labelFor: (type: DataType) => string;
+}
+
+const SchemaEditorContext = createContext<SchemaEditorContextValue | null>(null);
+
+export function useSchemaEditorContext() {
+	const context = useContext(SchemaEditorContext);
+	if (!context) {
+		throw new Error("SchemaEditor components must be used inside <SchemaEditor>");
+	}
+	return context;
+}
+
+type ProviderProps = SchemaEditorProps & { children: React.ReactNode };
+
+export function SchemaEditorProvider({
+	value,
+	defaultValue,
+	initialData,
+	onChange,
+	isReadOnly,
+	readOnly,
+	locked,
+	allowedDataTypes = ALL_DATA_TYPES,
+	allowedRootTypes,
+	typeOverrides,
+	disableJs = false,
+	maxDepth = Number.POSITIVE_INFINITY,
+	ruleEditors,
+	jsEditorRows = 12,
+	dataTypeLabels,
+	children,
+}: ProviderProps) {
+	const [uncontrolled, setUncontrolled] = useState<ValidationSchema>(
+		() => value ?? defaultValue ?? initialData ?? DEFAULT_SCHEMA,
+	);
+	const schema = value ?? uncontrolled;
+
+	const [path, setPath] = useState<SchemaPath>([]);
+	const [drawerPath, setDrawerPath] = useState<SchemaPath | null>(null);
+
+	const readOnlyResolved = Boolean(isReadOnly ?? readOnly ?? locked ?? false);
+
+	const setSchema = useCallback(
+		(next: ValidationSchema) => {
+			if (value === undefined) setUncontrolled(next);
+			onChange?.(next);
+		},
+		[onChange, value],
+	);
+
+	// Every mutation reads the schema through a ref-free closure over `schema`,
+	// which is fine because each one is invoked from an event handler that
+	// re-renders before the next can fire.
+	const updateProperty = useCallback(
+		(target: SchemaPath, updates: Partial<ValidationSchema>) => {
+			setSchema(mergeAtPath(schema, target, updates));
+		},
+		[schema, setSchema],
+	);
+
+	const addProperty = useCallback(
+		(target: SchemaPath) => setSchema(addPropertyAtPath(schema, target)),
+		[schema, setSchema],
+	);
+
+	const removeProperty = useCallback(
+		(target: SchemaPath) => setSchema(removeAtPath(schema, target)),
+		[schema, setSchema],
+	);
+
+	const goToPath = useCallback((next: SchemaPath) => setPath(next), []);
+
+	const goToLevel = useCallback(
+		(level: number) => setPath((prev) => prev.slice(0, level)),
+		[],
+	);
+
+	const openDrawer = useCallback((target: SchemaPath) => setDrawerPath(target), []);
+	const closeDrawer = useCallback(() => setDrawerPath(null), []);
+
+	const labelFor = useCallback(
+		(type: DataType) => dataTypeLabels?.[type] ?? DATA_TYPE_LABELS[type],
+		[dataTypeLabels],
+	);
+
+	const hasTypeOverride = useCallback(
+		(target: SchemaPath) =>
+			Boolean(typeOverrides?.[pathToKeyString(schema, target)]),
+		[schema, typeOverrides],
+	);
+
+	const typeOptionsFor = useCallback(
+		(target: SchemaPath, isRoot = false): DataTypeOption[] => {
+			const override = typeOverrides?.[pathToKeyString(schema, target)];
+			const base =
+				override ??
+				(isRoot ? (allowedRootTypes ?? allowedDataTypes) : allowedDataTypes);
+
+			// The node's own path length is how deep its *children* would sit, so
+			// a container is offered only while there is room for one more level.
+			const atDepthLimit = target.length >= maxDepth;
+
+			return base
+				.filter((type) => {
+					if (override) return true; // an explicit override is the last word
+					if (disableJs && type === "js") return false;
+					if (isRoot && ROOT_EXCLUDED_TYPES.includes(type)) return false;
+					if (atDepthLimit && CONTAINER_TYPES.includes(type)) return false;
+					return true;
+				})
+				.map((type) => ({ value: type, label: labelFor(type) }));
+		},
+		[
+			allowedDataTypes,
+			allowedRootTypes,
+			disableJs,
+			labelFor,
+			maxDepth,
+			schema,
+			typeOverrides,
+		],
+	);
+
+	const resolvedRuleEditors = useMemo(
+		() => ({ ...DEFAULT_RULE_EDITORS, ...ruleEditors }),
+		[ruleEditors],
+	);
+
+	const contextValue = useMemo<SchemaEditorContextValue>(
+		() => ({
+			schema,
+			setSchema,
+			path,
+			goToPath,
+			goToLevel,
+			drawerPath,
+			openDrawer,
+			closeDrawer,
+			addProperty,
+			removeProperty,
+			updateProperty,
+			isReadOnly: readOnlyResolved,
+			disableJs,
+			jsEditorRows,
+			ruleEditors: resolvedRuleEditors,
+			typeOptionsFor,
+			hasTypeOverride,
+			labelFor,
+		}),
+		[
+			addProperty,
+			closeDrawer,
+			disableJs,
+			drawerPath,
+			goToLevel,
+			goToPath,
+			hasTypeOverride,
+			jsEditorRows,
+			labelFor,
+			openDrawer,
+			path,
+			readOnlyResolved,
+			removeProperty,
+			resolvedRuleEditors,
+			schema,
+			setSchema,
+			typeOptionsFor,
+			updateProperty,
+		],
+	);
+
+	return (
+		<SchemaEditorContext.Provider value={contextValue}>
+			{children}
+		</SchemaEditorContext.Provider>
+	);
+}

--- a/packages/components/src/SchemaEditor/index.ts
+++ b/packages/components/src/SchemaEditor/index.ts
@@ -1,0 +1,38 @@
+export {
+	ALL_DATA_TYPES,
+	DATA_TYPE_LABELS,
+	DEFAULT_JS,
+	DEFAULT_SCHEMA,
+} from "./constants";
+export { ConfigurationDrawer } from "./ConfigurationDrawer";
+export { useSchemaEditorContext } from "./context";
+export { DataTypeSelect } from "./DataTypeSelect";
+export { DEFAULT_RULE_EDITORS } from "./rules";
+export { SchemaEditor } from "./SchemaEditor";
+export { SchemaNavigator } from "./SchemaNavigator";
+export { SchemaPreview } from "./SchemaPreview";
+export type {
+	ChainType,
+	DataType,
+	DataTypeOption,
+	Rule,
+	RuleEditorProps,
+	SchemaChain,
+	SchemaEditorProps,
+	SchemaEditorRef,
+	SchemaNode,
+	SchemaPath,
+	SchemaProperty,
+	ValidationSchema,
+} from "./types";
+export {
+	addPropertyAtPath,
+	buildBreadcrumbs,
+	getAtPath,
+	getRuleValue,
+	mergeAtPath,
+	pathToKeyString,
+	removeAtPath,
+	updateAtPath,
+	updateRule,
+} from "./utils";

--- a/packages/components/src/SchemaEditor/rules/ArrayRules.tsx
+++ b/packages/components/src/SchemaEditor/rules/ArrayRules.tsx
@@ -1,0 +1,43 @@
+import type { RuleEditorProps } from "../types";
+import { getRuleValue, updateRule } from "../utils";
+import { RuleNumberField, RuleSectionTitle } from "./fields";
+
+/**
+ * Length only. An array's element schema is a real sub-schema (`items`), edited
+ * by navigating into it — not a rule, which is why there is no item-type
+ * dropdown here.
+ */
+export function ArrayRules({ node, onUpdate, isReadOnly }: RuleEditorProps) {
+	const set = (type: string, value: unknown) =>
+		onUpdate({ rules: updateRule(node.rules, type, value) });
+
+	return (
+		<div className="flex flex-col gap-4">
+			<RuleSectionTitle>Array validation rules</RuleSectionTitle>
+
+			<div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+				<RuleNumberField
+					isReadOnly={isReadOnly}
+					label="Minimum items"
+					min={0}
+					onChange={(next) => set("minItems", next)}
+					placeholder="e.g. 1"
+					value={getRuleValue<number | "">(node.rules, "minItems", "")}
+				/>
+				<RuleNumberField
+					isReadOnly={isReadOnly}
+					label="Maximum items"
+					min={0}
+					onChange={(next) => set("maxItems", next)}
+					placeholder="e.g. 10"
+					value={getRuleValue<number | "">(node.rules, "maxItems", "")}
+				/>
+			</div>
+
+			<p className="text-xs text-muted">
+				Open this array from the editor to configure the schema its items must
+				match.
+			</p>
+		</div>
+	);
+}

--- a/packages/components/src/SchemaEditor/rules/EnumRules.tsx
+++ b/packages/components/src/SchemaEditor/rules/EnumRules.tsx
@@ -1,0 +1,139 @@
+import { Button, InputGroup, ListBox, Select, TextField } from "@heroui/react";
+import { useState } from "react";
+import { TbPlus, TbTrash } from "react-icons/tb";
+import type { RuleEditorProps } from "../types";
+import { getRuleValue, updateRule } from "../utils";
+import { RuleSectionTitle } from "./fields";
+
+type EnumValue = string | number;
+type ValueKind = "string" | "number";
+
+/** The parser infers the enum's kind from the values, so it is never persisted. */
+function inferKind(values: EnumValue[]): ValueKind {
+	return values.length > 0 && values.every((v) => typeof v === "number")
+		? "number"
+		: "string";
+}
+
+/**
+ * Writes the `values` rule — the one shape `schemaParser` reads to build
+ * `z.enum(...)`. Values are stored as their real type: a numeric enum built as
+ * strings would reject every number the client sends.
+ */
+export function EnumRules({ node, onUpdate, isReadOnly }: RuleEditorProps) {
+	const values = getRuleValue<EnumValue[]>(node.rules, "values", []);
+	const [kind, setKind] = useState<ValueKind>(() => inferKind(values));
+
+	const commit = (next: EnumValue[]) =>
+		onUpdate({ rules: updateRule(node.rules, "values", next) });
+
+	const handleKindChange = (nextKind: ValueKind) => {
+		setKind(nextKind);
+		commit(
+			values.map((value) =>
+				nextKind === "number" ? (Number(value) || 0) : String(value),
+			),
+		);
+	};
+
+	const handleValueChange = (index: number, raw: string) => {
+		const next = [...values];
+		next[index] = kind === "number" ? (raw === "" ? 0 : Number(raw)) : raw;
+		commit(next);
+	};
+
+	return (
+		<div className="flex flex-col gap-4">
+			<RuleSectionTitle>Enum configuration</RuleSectionTitle>
+
+			<div className="flex w-full flex-col gap-1.5">
+				<span className="text-xs font-medium text-muted-foreground">
+					Value type
+				</span>
+				<Select
+					fullWidth
+					isDisabled={isReadOnly}
+					onSelectionChange={(key) => handleKindChange(key as ValueKind)}
+					selectedKey={kind}
+					variant="secondary"
+				>
+					<Select.Trigger>
+						<Select.Value />
+						<Select.Indicator />
+					</Select.Trigger>
+					<Select.Popover>
+						<ListBox>
+							<ListBox.Item id="string" textValue="String">
+								String
+								<ListBox.ItemIndicator />
+							</ListBox.Item>
+							<ListBox.Item id="number" textValue="Number">
+								Number
+								<ListBox.ItemIndicator />
+							</ListBox.Item>
+						</ListBox>
+					</Select.Popover>
+				</Select>
+			</div>
+
+			<div className="h-px w-full bg-border" />
+
+			<span className="text-xs font-medium text-muted-foreground">
+				Allowed values
+			</span>
+
+			{values.length === 0 && (
+				<p className="text-xs text-muted">
+					No values yet — an enum with no values accepts anything.
+				</p>
+			)}
+
+			<div className="flex flex-col gap-2">
+				{values.map((value, index) => (
+					// Index keys are correct here: the row *is* its position, and the
+					// values themselves are editable and may repeat while typing.
+					// biome-ignore lint/suspicious/noArrayIndexKey: see above
+					<div className="flex items-center gap-2" key={index}>
+						<TextField fullWidth isDisabled={isReadOnly} variant="secondary">
+							<InputGroup fullWidth variant="secondary">
+								<InputGroup.Input
+									aria-label={`Value ${index + 1}`}
+									onChange={(event) =>
+										handleValueChange(index, event.currentTarget.value)
+									}
+									placeholder={`Value ${index + 1}`}
+									type={kind === "number" ? "number" : "text"}
+									value={String(value)}
+								/>
+							</InputGroup>
+						</TextField>
+						{!isReadOnly && (
+							<Button
+								aria-label={`Remove value ${index + 1}`}
+								isIconOnly
+								onPress={() => commit(values.filter((_, i) => i !== index))}
+								size="sm"
+								variant="ghost"
+							>
+								<TbTrash className="size-4 text-danger" />
+							</Button>
+						)}
+					</div>
+				))}
+			</div>
+
+			{!isReadOnly && (
+				<div>
+					<Button
+						onPress={() => commit([...values, kind === "number" ? 0 : ""])}
+						size="sm"
+						variant="secondary"
+					>
+						<TbPlus className="mr-1 size-4" />
+						Add value
+					</Button>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/packages/components/src/SchemaEditor/rules/FileRules.tsx
+++ b/packages/components/src/SchemaEditor/rules/FileRules.tsx
@@ -1,0 +1,53 @@
+import type { RuleEditorProps } from "../types";
+import { getRuleValue, updateRule } from "../utils";
+import { RuleNumberField, RuleSectionTitle, RuleTextField } from "./fields";
+
+/**
+ * `file` is a multipart field, `blob` a raw binary body. Both validate the same
+ * three things server-side, so they share one editor.
+ */
+export function FileRules({ node, onUpdate, isReadOnly }: RuleEditorProps) {
+	const set = (type: string, value: unknown) =>
+		onUpdate({ rules: updateRule(node.rules, type, value) });
+
+	// Stored as a comma-separated string; the parser accepts that or a list.
+	const mimeTypes = getRuleValue<string | string[]>(node.rules, "mimeTypes", "");
+
+	return (
+		<div className="flex flex-col gap-4">
+			<RuleSectionTitle>
+				{node.dataType === "blob" ? "Binary" : "File"} validation rules
+			</RuleSectionTitle>
+
+			<div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+				<RuleNumberField
+					description="In bytes."
+					isReadOnly={isReadOnly}
+					label="Minimum size"
+					min={0}
+					onChange={(next) => set("minSize", next)}
+					placeholder="e.g. 1024"
+					value={getRuleValue<number | "">(node.rules, "minSize", "")}
+				/>
+				<RuleNumberField
+					description="In bytes. 2 MB is 2097152."
+					isReadOnly={isReadOnly}
+					label="Maximum size"
+					min={0}
+					onChange={(next) => set("maxSize", next)}
+					placeholder="e.g. 2097152"
+					value={getRuleValue<number | "">(node.rules, "maxSize", "")}
+				/>
+			</div>
+
+			<RuleTextField
+				description="Comma-separated. Leave empty to accept any type."
+				isReadOnly={isReadOnly}
+				label="Allowed MIME types"
+				onChange={(next) => set("mimeTypes", next)}
+				placeholder="e.g. image/png, image/jpeg"
+				value={Array.isArray(mimeTypes) ? mimeTypes.join(", ") : mimeTypes}
+			/>
+		</div>
+	);
+}

--- a/packages/components/src/SchemaEditor/rules/JsRules.tsx
+++ b/packages/components/src/SchemaEditor/rules/JsRules.tsx
@@ -1,0 +1,41 @@
+import { JavaScriptTextArea } from "../../JavaScriptTextArea";
+import { DEFAULT_JS } from "../constants";
+import { InfoNote } from "../InfoNote";
+import type { RuleEditorProps } from "../types";
+import { RuleSectionTitle } from "./fields";
+
+/**
+ * The validator source lives on the node's `js` field, which is where
+ * `buildZodSchema` reads it. It is deliberately not a rule — a `jsCode` rule
+ * would be written but never executed.
+ */
+export function JsRules({
+	node,
+	onUpdate,
+	isReadOnly,
+	jsEditorRows = 12,
+}: RuleEditorProps) {
+	return (
+		<div className="flex flex-col gap-4">
+			<RuleSectionTitle>Custom JavaScript validation</RuleSectionTitle>
+
+			<InfoNote>
+				Return a boolean to pass or fail. The value under validation is{" "}
+				<code className="font-mono">input</code>. To return a custom error
+				body, throw:{" "}
+				<code className="font-mono">
+					{'throw new ValidationError({ your: "error" })'}
+				</code>
+				.
+			</InfoNote>
+
+			<JavaScriptTextArea
+				aria-label="Custom JavaScript validation"
+				onChange={(next) => onUpdate({ js: next })}
+				readOnly={isReadOnly}
+				rows={jsEditorRows}
+				value={node.js ?? DEFAULT_JS}
+			/>
+		</div>
+	);
+}

--- a/packages/components/src/SchemaEditor/rules/NumberRules.tsx
+++ b/packages/components/src/SchemaEditor/rules/NumberRules.tsx
@@ -1,0 +1,37 @@
+import type { RuleEditorProps } from "../types";
+import { getRuleValue, updateRule } from "../utils";
+import { RuleNumberField, RuleSectionTitle } from "./fields";
+
+export function NumberRules({ node, onUpdate, isReadOnly }: RuleEditorProps) {
+	const set = (type: string, value: unknown) =>
+		onUpdate({ rules: updateRule(node.rules, type, value) });
+
+	const isFloat = node.dataType === "float";
+
+	return (
+		<div className="flex flex-col gap-4">
+			<RuleSectionTitle>
+				{isFloat ? "Float" : "Integer"} validation rules
+			</RuleSectionTitle>
+
+			<div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+				<RuleNumberField
+					isReadOnly={isReadOnly}
+					label="Minimum value"
+					onChange={(next) => set("min", next)}
+					placeholder="e.g. 0"
+					step={isFloat ? 0.01 : 1}
+					value={getRuleValue<number | "">(node.rules, "min", "")}
+				/>
+				<RuleNumberField
+					isReadOnly={isReadOnly}
+					label="Maximum value"
+					onChange={(next) => set("max", next)}
+					placeholder="e.g. 100"
+					step={isFloat ? 0.01 : 1}
+					value={getRuleValue<number | "">(node.rules, "max", "")}
+				/>
+			</div>
+		</div>
+	);
+}

--- a/packages/components/src/SchemaEditor/rules/StringRules.tsx
+++ b/packages/components/src/SchemaEditor/rules/StringRules.tsx
@@ -1,0 +1,75 @@
+import type { RuleEditorProps } from "../types";
+import { getRuleValue, updateRule } from "../utils";
+import { RuleNumberField, RuleSectionTitle, RuleTextField } from "./fields";
+
+/** Every rule here maps 1:1 onto a Zod call in the server's `applyRules`. */
+export function StringRules({ node, onUpdate, isReadOnly }: RuleEditorProps) {
+	const set = (type: string, value: unknown) =>
+		onUpdate({ rules: updateRule(node.rules, type, value) });
+
+	return (
+		<div className="flex flex-col gap-4">
+			<RuleSectionTitle>String validation rules</RuleSectionTitle>
+
+			<div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+				<RuleNumberField
+					isReadOnly={isReadOnly}
+					label="Minimum length"
+					min={0}
+					onChange={(next) => set("minLength", next)}
+					placeholder="e.g. 3"
+					value={getRuleValue<number | "">(node.rules, "minLength", "")}
+				/>
+				<RuleNumberField
+					isReadOnly={isReadOnly}
+					label="Maximum length"
+					min={0}
+					onChange={(next) => set("maxLength", next)}
+					placeholder="e.g. 255"
+					value={getRuleValue<number | "">(node.rules, "maxLength", "")}
+				/>
+			</div>
+
+			<div className="h-px w-full bg-border" />
+
+			<RuleTextField
+				description="A JavaScript regular expression, without delimiters."
+				isReadOnly={isReadOnly}
+				label="Regex pattern"
+				onChange={(next) => set("regex", next)}
+				placeholder="e.g. ^[a-z]+$"
+				value={getRuleValue(node.rules, "regex", "")}
+			/>
+			<div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+				<RuleTextField
+					isReadOnly={isReadOnly}
+					label="Starts with"
+					onChange={(next) => set("startsWith", next)}
+					placeholder="e.g. usr_"
+					value={getRuleValue(node.rules, "startsWith", "")}
+				/>
+				<RuleTextField
+					isReadOnly={isReadOnly}
+					label="Ends with"
+					onChange={(next) => set("endsWith", next)}
+					placeholder="e.g. .com"
+					value={getRuleValue(node.rules, "endsWith", "")}
+				/>
+				<RuleTextField
+					isReadOnly={isReadOnly}
+					label="Contains"
+					onChange={(next) => set("contains", next)}
+					placeholder="e.g. hello"
+					value={getRuleValue(node.rules, "contains", "")}
+				/>
+				<RuleTextField
+					isReadOnly={isReadOnly}
+					label="Does not contain"
+					onChange={(next) => set("notContains", next)}
+					placeholder="e.g. badword"
+					value={getRuleValue(node.rules, "notContains", "")}
+				/>
+			</div>
+		</div>
+	);
+}

--- a/packages/components/src/SchemaEditor/rules/fields.tsx
+++ b/packages/components/src/SchemaEditor/rules/fields.tsx
@@ -1,0 +1,103 @@
+import { InputGroup, Label, TextField } from "@heroui/react";
+import type { ReactNode } from "react";
+
+interface BaseFieldProps {
+	label: string;
+	placeholder?: string;
+	description?: ReactNode;
+	isReadOnly?: boolean;
+}
+
+function FieldShell({
+	label,
+	description,
+	children,
+}: {
+	label: string;
+	description?: ReactNode;
+	children: ReactNode;
+}) {
+	return (
+		<div className="flex w-full flex-col gap-1.5">
+			<Label className="text-xs font-medium text-muted-foreground">{label}</Label>
+			{children}
+			{description && <p className="text-xs text-muted">{description}</p>}
+		</div>
+	);
+}
+
+export function RuleTextField({
+	label,
+	placeholder,
+	description,
+	isReadOnly,
+	value,
+	onChange,
+}: BaseFieldProps & {
+	value: string;
+	onChange: (value: string) => void;
+}) {
+	return (
+		<FieldShell label={label} description={description}>
+			<TextField fullWidth isDisabled={isReadOnly} variant="secondary">
+				<InputGroup fullWidth variant="secondary">
+					<InputGroup.Input
+						aria-label={label}
+						onChange={(event) => onChange(event.currentTarget.value)}
+						placeholder={placeholder}
+						value={value}
+					/>
+				</InputGroup>
+			</TextField>
+		</FieldShell>
+	);
+}
+
+/**
+ * A number rule that can also be *absent*. An empty input clears the rule
+ * rather than writing `0`, which is a real bound the parser would enforce.
+ */
+export function RuleNumberField({
+	label,
+	placeholder,
+	description,
+	isReadOnly,
+	value,
+	onChange,
+	min,
+	step,
+}: BaseFieldProps & {
+	value: number | "";
+	onChange: (value: number | "") => void;
+	min?: number;
+	step?: number;
+}) {
+	return (
+		<FieldShell label={label} description={description}>
+			<TextField fullWidth isDisabled={isReadOnly} variant="secondary">
+				<InputGroup fullWidth variant="secondary">
+					<InputGroup.Input
+						aria-label={label}
+						min={min}
+						onChange={(event) => {
+							const raw = event.currentTarget.value;
+							if (raw === "") return onChange("");
+							const next = Number(raw);
+							if (Number.isFinite(next)) onChange(next);
+						}}
+						placeholder={placeholder}
+						step={step}
+						type="number"
+						value={value === "" ? "" : String(value)}
+					/>
+				</InputGroup>
+			</TextField>
+		</FieldShell>
+	);
+}
+
+export function RuleSectionTitle({ children }: { children: ReactNode }) {
+	return (
+		<p className="text-sm font-semibold text-foreground">{children}</p>
+	);
+}

--- a/packages/components/src/SchemaEditor/rules/index.ts
+++ b/packages/components/src/SchemaEditor/rules/index.ts
@@ -1,0 +1,29 @@
+import type { ComponentType } from "react";
+import type { DataType, RuleEditorProps } from "../types";
+import { ArrayRules } from "./ArrayRules";
+import { EnumRules } from "./EnumRules";
+import { FileRules } from "./FileRules";
+import { JsRules } from "./JsRules";
+import { NumberRules } from "./NumberRules";
+import { StringRules } from "./StringRules";
+
+/**
+ * Which editor configures which type. Consumers override entries through the
+ * `ruleEditors` prop; a type absent from this map simply has nothing to
+ * configure (`bool`, and `object` whose children are edited inline).
+ */
+export const DEFAULT_RULE_EDITORS: Partial<
+	Record<DataType, ComponentType<RuleEditorProps>>
+> = {
+	str: StringRules,
+	int: NumberRules,
+	float: NumberRules,
+	arr: ArrayRules,
+	enum: EnumRules,
+	file: FileRules,
+	blob: FileRules,
+	js: JsRules,
+};
+
+export { ArrayRules, EnumRules, FileRules, JsRules, NumberRules, StringRules };
+export { RuleNumberField, RuleSectionTitle, RuleTextField } from "./fields";

--- a/packages/components/src/SchemaEditor/types.ts
+++ b/packages/components/src/SchemaEditor/types.ts
@@ -1,0 +1,152 @@
+import type { ComponentType, ReactNode } from "react";
+
+/**
+ * The wire format is the one `apps/server/src/lib/validationSchemaZod.ts`
+ * accepts and `schemaParser.ts` compiles to Zod. Anything this editor writes
+ * that the parser does not read is dead weight, so the rule types below are
+ * kept in step with `applyRules`.
+ */
+export type DataType =
+	| "str"
+	| "int"
+	| "float"
+	| "bool"
+	| "object"
+	| "arr"
+	| "js"
+	| "enum"
+	| "file"
+	| "blob";
+
+export type ChainType = "or" | "and";
+
+export interface Rule {
+	type: string;
+	value?: unknown;
+	message?: string;
+	[key: string]: unknown;
+}
+
+export interface SchemaProperty {
+	/** Client-side only, for stable React keys. Round-trips harmlessly. */
+	id?: string;
+	key: string;
+	dataType: DataType;
+	rules?: Rule[];
+	required?: boolean;
+	/** For `object`. */
+	properties?: SchemaProperty[];
+	/** For `arr`. */
+	items?: SchemaProperty;
+	chain?: SchemaChain[];
+	/** For `js` — the validator source. Not a rule; the parser reads it here. */
+	js?: string;
+}
+
+export interface SchemaChain {
+	chainType: ChainType;
+	properties?: SchemaProperty[];
+}
+
+export interface ValidationSchema {
+	dataType: DataType;
+	properties?: SchemaProperty[];
+	items?: SchemaProperty;
+	chain?: SchemaChain[];
+	rules?: Rule[];
+	js?: string;
+}
+
+/**
+ * Address of a node inside the schema tree. A number steps into
+ * `properties[n]`, the literal `"items"` steps into an array's item schema.
+ */
+export type SchemaPath = (number | "items")[];
+
+/** Any node the editor can sit on — the root has no `key`, a property does. */
+export type SchemaNode = ValidationSchema | SchemaProperty;
+
+export interface SchemaEditorRef {
+	/** Fires `onSave` with the current schema. */
+	save: () => void;
+	getSchema: () => ValidationSchema;
+}
+
+/**
+ * What a rule editor gets. Custom editors passed via `ruleEditors` receive the
+ * same contract, so a third type of editor is a drop-in.
+ */
+export interface RuleEditorProps {
+	node: SchemaNode;
+	onUpdate: (updates: Partial<SchemaProperty>) => void;
+	isReadOnly?: boolean;
+	/** Visible lines for any embedded JavaScript editor. */
+	jsEditorRows?: number;
+}
+
+export interface DataTypeOption {
+	value: DataType;
+	label: string;
+}
+
+export interface SchemaEditorProps {
+	/** Controlled schema. Pair with `onChange`. */
+	value?: ValidationSchema;
+	/** Uncontrolled starting schema. */
+	defaultValue?: ValidationSchema;
+	/** Legacy alias for `defaultValue`. */
+	initialData?: ValidationSchema;
+	/** Fires on every edit. Required for controlled use. */
+	onChange?: (schema: ValidationSchema) => void;
+	/** Fires when `ref.save()` is called. */
+	onSave?: (schema: ValidationSchema) => void;
+
+	/** Field label rendered above the tabs. */
+	label?: ReactNode;
+	/** Helper text under the label. */
+	description?: ReactNode;
+
+	/** Everything becomes non-editable; navigation and preview still work. */
+	isReadOnly?: boolean;
+	/** Alias for `isReadOnly`. */
+	readOnly?: boolean;
+	/** Legacy alias for `isReadOnly`. */
+	locked?: boolean;
+
+	/** Restricts the type dropdown everywhere. Defaults to all types. */
+	allowedDataTypes?: DataType[];
+	/** Restricts the root type dropdown. Defaults to `allowedDataTypes`. */
+	allowedRootTypes?: DataType[];
+	/**
+	 * Per-field override of the allowed types, keyed by dotted path
+	 * (`user.address.zip`, `tags[]`). Wins over `allowedDataTypes`, and over
+	 * `isReadOnly` for that one dropdown — the point is to let a locked schema
+	 * still offer a choice where one is meaningful.
+	 */
+	typeOverrides?: Record<string, DataType[]>;
+
+	/** Drops the `js` type and the Custom JS tab. */
+	disableJs?: boolean;
+	/** Show the Preview tab. Default true. */
+	showPreview?: boolean;
+	/** Show the root type dropdown. Default true. */
+	showRootTypeSelector?: boolean;
+	/**
+	 * How deep `object`/`arr` may nest, counting the root as 0. Beyond it those
+	 * types drop out of the dropdown rather than silently allowing a tree the
+	 * consumer cannot handle.
+	 */
+	maxDepth?: number;
+
+	/**
+	 * Replaces or extends the per-type rule editors. Merged over the defaults,
+	 * so `{ str: MyStringRules }` swaps one and keeps the rest.
+	 */
+	ruleEditors?: Partial<Record<DataType, ComponentType<RuleEditorProps>>>;
+	/** Visible lines for embedded JavaScript editors. Default 12. */
+	jsEditorRows?: number;
+	/** Labels for the type dropdown, merged over the defaults. */
+	dataTypeLabels?: Partial<Record<DataType, string>>;
+
+	className?: string;
+}

--- a/packages/components/src/SchemaEditor/utils.test.ts
+++ b/packages/components/src/SchemaEditor/utils.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import type { ValidationSchema } from "./types";
+import {
+	addPropertyAtPath,
+	buildBreadcrumbs,
+	getAtPath,
+	getRuleValue,
+	mergeAtPath,
+	pathToKeyString,
+	removeAtPath,
+	updateRule,
+} from "./utils";
+
+const schema = (): ValidationSchema => ({
+	dataType: "object",
+	properties: [
+		{ id: "a", key: "name", dataType: "str", rules: [] },
+		{
+			id: "b",
+			key: "address",
+			dataType: "object",
+			properties: [{ id: "c", key: "zip", dataType: "str", rules: [] }],
+		},
+		{
+			id: "d",
+			key: "tags",
+			dataType: "arr",
+			items: { key: "", dataType: "str", rules: [] },
+		},
+	],
+});
+
+describe("path navigation", () => {
+	test("reads nested properties and array items", () => {
+		expect(getAtPath(schema(), [1, 0])).toMatchObject({ key: "zip" });
+		expect(getAtPath(schema(), [2, "items"])).toMatchObject({ dataType: "str" });
+		expect(getAtPath(schema(), [9])).toBeUndefined();
+	});
+
+	test("merging leaves untouched subtrees identical", () => {
+		const before = schema();
+		const after = mergeAtPath(before, [1, 0], { key: "postcode" });
+
+		expect(getAtPath(after, [1, 0])).toMatchObject({ key: "postcode" });
+		// The edit must not clone siblings, or memoised rows re-render for nothing.
+		expect(after.properties?.[0]).toBe(before.properties![0]!);
+		expect(before.properties?.[1]?.properties?.[0]?.key).toBe("zip");
+	});
+
+	test("creates the item schema on demand", () => {
+		const bare: ValidationSchema = { dataType: "arr" };
+		expect(mergeAtPath(bare, ["items"], { dataType: "int" }).items).toMatchObject(
+			{ dataType: "int" },
+		);
+	});
+
+	test("adds and removes at any depth", () => {
+		const added = addPropertyAtPath(schema(), [1]);
+		expect(added.properties?.[1]?.properties).toHaveLength(2);
+
+		const removed = removeAtPath(schema(), [1, 0]);
+		expect(removed.properties?.[1]?.properties).toHaveLength(0);
+
+		const noItems = removeAtPath(schema(), [2, "items"]);
+		expect(noItems.properties?.[2]?.items).toBeUndefined();
+	});
+
+	test("builds breadcrumbs and dotted keys", () => {
+		expect(buildBreadcrumbs(schema(), [1, 0]).map((c) => c.title)).toEqual([
+			"Main Schema",
+			"address",
+			"zip",
+		]);
+		expect(pathToKeyString(schema(), [1, 0])).toBe("address.zip");
+		expect(pathToKeyString(schema(), [2, "items"])).toBe("tags[]");
+	});
+});
+
+describe("rules", () => {
+	test("upserts, and keeps falsy-but-real values", () => {
+		let rules = updateRule([], "minLength", 3);
+		expect(rules).toEqual([{ type: "minLength", value: 3 }]);
+
+		rules = updateRule(rules, "minLength", 0);
+		expect(getRuleValue<number | "">(rules, "minLength", "")).toBe(0);
+	});
+
+	test("an empty value deletes the rule rather than storing a blank bound", () => {
+		const rules = updateRule([{ type: "max", value: 10 }], "max", "");
+		expect(rules).toEqual([]);
+		expect(getRuleValue(rules, "max", "unset")).toBe("unset");
+	});
+
+	test("enum values round-trip as a list", () => {
+		const rules = updateRule([], "values", ["a", "b"]);
+		expect(getRuleValue<string[]>(rules, "values", [])).toEqual(["a", "b"]);
+	});
+});

--- a/packages/components/src/SchemaEditor/utils.ts
+++ b/packages/components/src/SchemaEditor/utils.ts
@@ -1,0 +1,193 @@
+import type {
+	Rule,
+	SchemaNode,
+	SchemaPath,
+	SchemaProperty,
+	ValidationSchema,
+} from "./types";
+
+export const newPropertyId = () => Math.random().toString(36).slice(2, 9);
+
+export const newProperty = (): SchemaProperty => ({
+	id: newPropertyId(),
+	key: "",
+	dataType: "str",
+	rules: [],
+	// Explicit, and it matches the legacy editor. The parser treats a missing
+	// `required` as required, so writing `false` is the only way to say optional.
+	required: false,
+});
+
+const DEFAULT_ITEMS: SchemaProperty = { key: "", dataType: "str", rules: [] };
+
+/** The node at `path`, or `undefined` if the path runs off the tree. */
+export function getAtPath(
+	root: SchemaNode,
+	path: SchemaPath,
+): SchemaNode | undefined {
+	let node: SchemaNode | undefined = root;
+	for (const segment of path) {
+		if (!node) return undefined;
+		node =
+			segment === "items" ? node.items : node.properties?.[segment];
+	}
+	return node;
+}
+
+/**
+ * Returns a copy of `root` with `updater` applied at `path`. Only the nodes
+ * along the path are cloned, so untouched subtrees keep their identity and
+ * `React.memo` further down still holds.
+ */
+export function updateAtPath<T extends SchemaNode>(
+	root: T,
+	path: SchemaPath,
+	updater: (node: SchemaNode) => SchemaNode,
+): T {
+	if (path.length === 0) return updater(root) as T;
+
+	const [segment, ...rest] = path;
+	if (segment === "items") {
+		return {
+			...root,
+			items: updateAtPath(root.items ?? DEFAULT_ITEMS, rest, updater),
+		};
+	}
+
+	const properties = [...(root.properties ?? [])];
+	const child = properties[segment as number];
+	if (!child) return root;
+	properties[segment as number] = updateAtPath(child, rest, updater);
+	return { ...root, properties };
+}
+
+/** Shallow-merges `updates` into the node at `path`. */
+export function mergeAtPath<T extends SchemaNode>(
+	root: T,
+	path: SchemaPath,
+	updates: Partial<SchemaProperty>,
+): T {
+	return updateAtPath(root, path, (node) => ({ ...node, ...updates }));
+}
+
+export function addPropertyAtPath<T extends SchemaNode>(
+	root: T,
+	path: SchemaPath,
+): T {
+	return updateAtPath(root, path, (node) => ({
+		...node,
+		properties: [...(node.properties ?? []), newProperty()],
+	}));
+}
+
+export function removeAtPath<T extends SchemaNode>(root: T, path: SchemaPath): T {
+	if (path.length === 0) return root;
+	const last = path[path.length - 1]!;
+	return updateAtPath(root, path.slice(0, -1), (parent) => {
+		if (last === "items") {
+			const { items: _dropped, ...rest } = parent;
+			return rest;
+		}
+		return {
+			...parent,
+			properties: (parent.properties ?? []).filter((_, i) => i !== last),
+		};
+	});
+}
+
+// ── Rules ────────────────────────────────────────────────────────────────────
+
+export function getRuleValue<T = unknown>(
+	rules: Rule[] | undefined,
+	type: string,
+	defaultValue: T,
+): T {
+	const rule = rules?.find((r) => r.type === type);
+	return rule === undefined ? defaultValue : (rule.value as T);
+}
+
+/**
+ * Upserts a rule. An empty value removes the rule rather than persisting a
+ * blank one — `0` and `false` are real values and survive.
+ */
+export function updateRule(
+	rules: Rule[] | undefined,
+	type: string,
+	value: unknown,
+): Rule[] {
+	const next = rules ? [...rules] : [];
+	const index = next.findIndex((r) => r.type === type);
+	const isEmpty =
+		value === "" ||
+		value === undefined ||
+		value === null ||
+		(typeof value === "number" && Number.isNaN(value));
+
+	if (isEmpty) {
+		if (index >= 0) next.splice(index, 1);
+		return next;
+	}
+	if (index >= 0) next[index] = { ...next[index], type, value };
+	else next.push({ type, value });
+	return next;
+}
+
+// ── Paths ────────────────────────────────────────────────────────────────────
+
+/**
+ * Dotted path used to look a field up in `typeOverrides`: `user.address.zip`,
+ * `tags[]` for an array's items.
+ */
+export function pathToKeyString(root: SchemaNode, path: SchemaPath): string {
+	let node: SchemaNode | undefined = root;
+	let out = "";
+	for (const segment of path) {
+		if (!node) break;
+		if (segment === "items") {
+			out += "[]";
+			node = node.items;
+		} else {
+			const child = node.properties?.[segment];
+			out += out ? `.${child?.key ?? ""}` : (child?.key ?? "");
+			node = child;
+		}
+	}
+	return out;
+}
+
+export interface Breadcrumb {
+	title: string;
+	/** Path length to truncate to when this crumb is clicked. */
+	level: number;
+}
+
+export function buildBreadcrumbs(
+	root: SchemaNode,
+	path: SchemaPath,
+	rootTitle = "Main Schema",
+): Breadcrumb[] {
+	const crumbs: Breadcrumb[] = [{ title: rootTitle, level: 0 }];
+	let node: SchemaNode | undefined = root;
+	for (let i = 0; i < path.length; i++) {
+		const segment = path[i]!;
+		if (segment === "items") {
+			crumbs.push({ title: "Array Items [ ]", level: i + 1 });
+			node = node?.items;
+		} else {
+			const child = node?.properties?.[segment];
+			if (!child) break;
+			crumbs.push({
+				title: child.key || `Property ${segment}`,
+				level: i + 1,
+			});
+			node = child;
+		}
+	}
+	return crumbs;
+}
+
+/** How many container levels deep `path` sits. */
+export const depthOf = (path: SchemaPath) => path.length;
+
+export const isEmptySchema = (schema: ValidationSchema) =>
+	!schema.properties?.length && !schema.items && !schema.js;


### PR DESCRIPTION
## Why

`apps/portal` has no way to author a route's validation schema — the low-code
Zod builder only exists in the legacy `apps/web` (Mantine). This ports it to
HeroUI in `packages/components` so the portal can use it, and so there is one
schema editor rather than two.

## What

`@fluxify/components` → `SchemaEditor`. Same interaction model as the legacy
one: one level of the tree in view at a time, breadcrumbs to walk back out,
validation rules in a right-hand drawer, plus the Schema Editor / Custom JS /
Preview tabs.

**Structure** — one folder, small files: `types` / `constants` / `utils` (pure
path + rule helpers), `context` (state + resolved config), `SchemaNavigator`,
`PropertyRow`, `ConfigurationDrawer`, `SchemaPreview`, and `rules/*` — one
editor per data type, registered in a map.

**Props** (everything asked for, plus what the parser made obvious):

| Prop | Effect |
| --- | --- |
| `value` / `defaultValue` / `onChange` | controlled or uncontrolled |
| `isReadOnly` (`readOnly`, `locked`) | disables every control; navigation and preview still work |
| `allowedDataTypes` | restricts the type dropdown everywhere |
| `allowedRootTypes` | restricts the root type dropdown |
| `typeOverrides` | per-field allowed types by dotted path (`address.zip`, `tags[]`); stays live even when the editor is read-only |
| `disableJs` | drops the `js` type and the Custom JS tab |
| `maxDepth` | caps nesting by dropping `object`/`arr` from the dropdown at the limit |
| `showPreview`, `showRootTypeSelector` | hide either surface |
| `ruleEditors` | swap in a custom rule editor for any type; merged over the defaults |
| `dataTypeLabels`, `jsEditorRows`, `label`, `description`, `className` | presentation |
| `onSave` + `ref` | `save()` / `getSchema()`, as before |

## Corrections to the legacy behaviour

Checked every field the editor writes against
`apps/server/src/lib/schemaParser.ts`. Three were never read:

- **Enum was broken.** The UI wrote `enumValues` + `enumType`; the parser reads
  one `values` rule and infers string vs number from the values. A legacy enum
  validated nothing. Now writes `values`, with the values stored in their real
  type.
- **Custom JS had two homes.** The row wrote `property.js`, the drawer wrote a
  `jsCode` rule. Only `js` is executed. One path now.
- **Dead rules dropped**, unsupported by the parser: `itemType`, `equal`,
  `notEqual`. **`file` / `blob` added** — they *are* supported (`minSize`,
  `maxSize`, `mimeTypes`) and had no UI.

## Notes

- No new dependencies. State is a plain immutable path-update helper rather
  than zustand + immer (neither is a dep of this package); only the nodes along
  the edited path are cloned, so sibling rows keep their identity.
- `packages/components/src/SchemaEditor/utils.test.ts` covers the path
  navigation and rule upsert/delete rules (`bun test`, 8 passing).
- Added to `/playground` with toggles for read-only, disabled JS, a restricted
  type list, a depth cap, and a `typeOverrides` entry — with the live JSON
  underneath.

## Testing

- `bun test packages/components/src/SchemaEditor` — passing.
- `bun run --cwd packages/components lint` — clean.
- `bun run --cwd apps/portal lint` — clean for this change.
- Not yet exercised in a browser — the portal dev server boots and the route
  compiles, but the rendered editor still needs a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
