### PR TITLE
feat(projects): multi-step project creation wizard

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -58,6 +58,22 @@ When creating branches or Pull Requests via the `gh` CLI:
 
 ## Known Issues & Fixes
 
+### ⚠️ CRITICAL — Never Hardcode Colors in Portal UI
+**Issue:** New portal pages render unthemed — wrong background, invisible text, borders that vanish — because the markup carries literal hex values (`bg-[#12151D]`, `border-[#1E232F]`, `text-[#D0F237]`, `bg-[#ccff00]`) or Tailwind's default palette (`text-zinc-400`, `text-white`, `text-black`, `bg-white/[0.04]`). These are frozen dark-theme values: they ignore `--accent`, do not flip under `.light` / `[data-theme="light"]`, and drift from the design system the moment a token changes.
+**Cause:** Copying an existing page as a starting point. Several older files still contain hardcoded hex, so the wrong pattern looks like the house style. **A hex value in a neighbouring file is NOT precedent — it is unconverted debt.**
+**Fix & Best Practices:**
+1. **Always use the semantic utility classes.** The theme is defined in `packages/components/src/styles.css` as CSS variables; the Tailwind utilities built on them are the only supported way to colour portal UI:
+   - Surfaces: `bg-background`, `bg-background-secondary`, `bg-surface`, `bg-surface-secondary`, `bg-overlay`
+   - Text: `text-foreground`, `text-muted`, `text-muted-foreground`, `text-accent`, `text-accent-foreground`
+   - Lines & rings: `border-border`, `border-accent`, `ring-accent`, `ring-focus`
+   - Status: `text-danger`, `text-success`, `bg-warning` (and their `border-*` / `bg-*` forms)
+2. **Never write `text-white` / `text-black` / `text-zinc-*` / `bg-white/[0.04]`.** Map them: primary text → `text-foreground`, secondary text → `text-muted`, hover wash → `hover:bg-surface-secondary`, selected wash → `bg-accent/10`, hairline ring → `ring-border`.
+3. **The lime accent is `--accent`, never a literal.** `#ccff00` / `#D0F237` → `bg-accent` with `text-accent-foreground` (the accent needs dark text for contrast; `text-accent-foreground` already encodes that).
+4. **Prefer the component over restyling a native element.** A lime CTA is `<Button variant="primary">`, not a `<button>` with an accent background pasted on — the variant already tracks the theme.
+5. **Opacity modifiers on a token are fine** (`bg-accent/10`, `text-muted/50`); they stay theme-aware. Literal rgba/hex overlays are not.
+6. **Check before committing any portal UI:**
+   `grep -nE "(bg|text|border|ring)-\[#|zinc-[0-9]|text-(white|black)" <changed files>` — this must return nothing.
+
 ### Monorepo Server to Frontend Package Bleed
 **Issue:** "Module not found: Can't resolve 'child_process'" or similar Node.js built-in errors in Next.js client code.
 **Cause:** Importing utilities (like `canAccess`) or types directly from the root of a server module (e.g., `@fluxify/server`) forces the Next.js bundler to evaluate the server's main barrel file (`index.ts`). This barrel file exports modules that rely on Node.js built-ins (like database schemas, ORMs, and `pg`), breaking the frontend build.

--- a/apps/portal/src/components/common/RoleSelector.tsx
+++ b/apps/portal/src/components/common/RoleSelector.tsx
@@ -1,6 +1,6 @@
 import { TbCheck } from "react-icons/tb";
 
-const ROLES = [
+export const ROLES = [
 	{ id: "viewer", title: "Viewer", description: "Can read and run" },
 	{ id: "creator", title: "Creator", description: "Can build and deploy" },
 	{ id: "project_admin", title: "Project Admin", description: "Full project control" },

--- a/apps/portal/src/components/home/ProjectsTab.tsx
+++ b/apps/portal/src/components/home/ProjectsTab.tsx
@@ -1,20 +1,8 @@
-import { useState } from "react";
-import {
-	Button,
-	Card,
-	Modal,
-	Spinner,
-	TextField,
-	Label,
-	Input,
-	FieldError,
-	toast,
-} from "@fluxify/components";
+import { Button, Spinner } from "@fluxify/components";
 import { TbPlus } from "react-icons/tb";
+import { useNavigate } from "@tanstack/react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import { projectsQuery } from "@/query/projectsQuery";
-import { projectsService } from "@/services/projects";
-import { showErrorNotification } from "@/lib/errorNotifier";
 import { useAuthStore } from "@/store/auth";
 import { ProjectCard } from "./ProjectCard";
 
@@ -74,76 +62,12 @@ export function ProjectsTab() {
 }
 
 function NewProjectButton() {
-	const client = useQueryClient();
-	const [open, setOpen] = useState(false);
-	const [name, setName] = useState("");
-	const [error, setError] = useState<string>();
-	const [saving, setSaving] = useState(false);
-
-	async function onSubmit(e: React.FormEvent) {
-		e.preventDefault();
-		setSaving(true);
-		setError(undefined);
-		try {
-			await projectsService.create({ name });
-			projectsQuery.invalidateAll(client);
-			setOpen(false);
-			setName("");
-			toast.success("Project created");
-		} catch (err) {
-			showErrorNotification(err as Error);
-			setError((err as Error).message);
-		} finally {
-			setSaving(false);
-		}
-	}
+	const navigate = useNavigate();
 
 	return (
-		<Modal isOpen={open} onOpenChange={setOpen}>
-			<Modal.Trigger>
-				<button className="flex items-center gap-2 rounded-md bg-[#ccff00] px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-[#b3e600]">
-					<TbPlus className="h-4 w-4" />
-					New Project
-				</button>
-			</Modal.Trigger>
-			<Modal.Backdrop>
-				<Modal.Container placement="center" size="sm">
-					<Modal.Dialog>
-						<Modal.Header>
-							<Modal.Heading>Create a project</Modal.Heading>
-							<p className="mt-1 text-sm text-muted">
-								Give it a name to get started — you can rename it later.
-							</p>
-						</Modal.Header>
-						<form onSubmit={onSubmit}>
-							<Modal.Body>
-								<TextField
-									isRequired
-									value={name}
-									onChange={setName}
-									isInvalid={!!error}
-								>
-									<Label>Project name</Label>
-									<Input placeholder="My API project" autoFocus />
-									<FieldError>{error}</FieldError>
-								</TextField>
-							</Modal.Body>
-							<Modal.Footer>
-								<Button
-									type="button"
-									variant="ghost"
-									onPress={() => setOpen(false)}
-								>
-									Cancel
-								</Button>
-								<Button type="submit" variant="primary" isPending={saving}>
-									Create project
-								</Button>
-							</Modal.Footer>
-						</form>
-					</Modal.Dialog>
-				</Modal.Container>
-			</Modal.Backdrop>
-		</Modal>
+		<Button variant="primary" onPress={() => navigate({ to: "/projects/new" })}>
+			<TbPlus className="h-4 w-4" />
+			New Project
+		</Button>
 	);
 }

--- a/apps/portal/src/query/projectsQuery.ts
+++ b/apps/portal/src/query/projectsQuery.ts
@@ -2,9 +2,26 @@ import {
 	type GetAllProjectsQueryParams,
 	projectsService,
 } from "@/services/projects";
-import { type QueryClient, useQuery } from "@tanstack/react-query";
+import {
+	type QueryClient,
+	useMutation,
+	useQuery,
+	useQueryClient,
+} from "@tanstack/react-query";
+import type { z } from "zod";
 
 export const projectsQuery = {
+	create: {
+		mutation() {
+			const qc = useQueryClient();
+			return useMutation({
+				mutationFn: (
+					body: z.infer<typeof projectsService.createRequestBodySchema>,
+				) => projectsService.create(body),
+				onSuccess: () => qc.invalidateQueries({ queryKey: ["projects", "list"] }),
+			});
+		},
+	},
 	getAll: {
 		useQuery(query: GetAllProjectsQueryParams) {
 			return useQuery({

--- a/apps/portal/src/routes/_authed/projects.new.tsx
+++ b/apps/portal/src/routes/_authed/projects.new.tsx
@@ -1,0 +1,557 @@
+import { useMemo, useState } from "react";
+import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router";
+import {
+	Button,
+	Checkbox,
+	Input,
+	Label,
+	LazyLoader,
+	ListBox,
+	Select,
+	TextArea,
+	TextField,
+	cn,
+	toast,
+} from "@fluxify/components";
+import {
+	TbArrowLeft,
+	TbArrowRight,
+	TbCheck,
+	TbChevronLeft,
+	TbChevronRight,
+	TbSearch,
+} from "react-icons/tb";
+import { authClient } from "@/lib/auth";
+import { authQuery } from "@/query/authQuery";
+import { projectsQuery } from "@/query/projectsQuery";
+import { showErrorNotification } from "@/lib/errorNotifier";
+import { createRouteHead } from "@/lib/seo";
+import { ROLES, type Role } from "@/components/common/RoleSelector";
+
+// Same roles the project settings member list offers, shown as a dropdown here
+// because each row already carries a name and a remove action.
+const ROLE_OPTIONS = ROLES.map((role) => ({ id: role.id, label: role.title }));
+
+export const Route = createFileRoute("/_authed/projects/new")({
+	head: createRouteHead(
+		"New Project",
+		"Create a project: name it, invite members and set its configuration.",
+	),
+	// Same gate the New Project button honours on the home page — reaching this
+	// route by URL must not get further than clicking would.
+	beforeLoad: async () => {
+		const session = await authClient.getSession();
+		if (!(session.data?.user as { isSystemAdmin?: boolean })?.isSystemAdmin) {
+			throw redirect({ to: "/", search: { tab: "projects" } });
+		}
+	},
+	component: CreateProjectPage,
+});
+
+type UserRow = { id: string; name: string | null; email: string };
+type Member = { userId: string; role: Role; label: string };
+
+const STEPS = [
+	{ key: "basics", label: "Basics" },
+	{ key: "members", label: "Members" },
+	{ key: "config", label: "Configuration" },
+] as const;
+
+const STEP_COPY: Record<
+	(typeof STEPS)[number]["key"],
+	{ title: string; description: string }
+> = {
+	basics: {
+		title: "Name the project",
+		description: "How it appears in the project list. You can rename it later.",
+	},
+	members: {
+		title: "Who can work on it",
+		description:
+			"Optional. Members and their roles are saved with the project — you can change them any time in project settings.",
+	},
+	config: {
+		title: "Set the project's configuration",
+		description:
+			"Optional. Integrations, app configs and routes are set up inside the project once it exists.",
+	},
+};
+
+function initialsOf(name: string | null, email: string) {
+	if (!name) return email.substring(0, 2).toUpperCase();
+	const parts = name.trim().split(" ");
+	if (parts.length > 1) return (parts[0][0] + parts[1][0]).toUpperCase();
+	return name.substring(0, 2).toUpperCase();
+}
+
+function CreateProjectPage() {
+	const navigate = useNavigate();
+	const create = projectsQuery.create.mutation();
+
+	const [step, setStep] = useState(0);
+	const [name, setName] = useState("");
+	const [description, setDescription] = useState("");
+	const [members, setMembers] = useState<Member[]>([]);
+	const [workerTimeouts, setWorkerTimeouts] = useState(false);
+
+	// `projects.name` is varchar(50) and the API rejects anything longer, so the
+	// field has to stop the user rather than let the request fail.
+	const basicsValid = name.trim().length >= 2 && name.trim().length <= 50;
+
+	const isLast = step === STEPS.length - 1;
+	const currentKey = STEPS[step].key;
+
+	function submit() {
+		create.mutate(
+			{
+				name: name.trim(),
+				description: description.trim() || undefined,
+				members: members.length
+					? members.map(({ userId, role }) => ({ userId, role }))
+					: undefined,
+				settings: {
+					"experimental.workerTimeouts.enabled": workerTimeouts
+						? "true"
+						: "false",
+				},
+			},
+			{
+				onSuccess: (created) => {
+					toast.success("Project created");
+					navigate({ to: "/$projectId", params: { projectId: created.id } });
+				},
+				onError: (error) => showErrorNotification(error as Error),
+			},
+		);
+	}
+
+	return (
+		<div className="mx-auto flex w-full max-w-4xl flex-col gap-5 px-6 py-8">
+			<div className="flex items-center gap-3">
+				<Button
+					isIconOnly
+					variant="ghost"
+					aria-label="Back to projects"
+					onPress={() => navigate({ to: "/", search: { tab: "projects" } })}
+				>
+					<TbArrowLeft size={18} />
+				</Button>
+				<div>
+					<h1 className="text-xl font-semibold tracking-tight">
+						Create a project
+					</h1>
+					<p className="text-xs text-muted">
+						Name it, pick who works on it, and set how it runs.
+					</p>
+				</div>
+			</div>
+
+			<nav
+				aria-label="Project setup steps"
+				className="border-b border-border pb-3"
+			>
+				<ol className="flex flex-wrap gap-2">
+					{STEPS.map((item, index) => {
+						const reachable = index === 0 || basicsValid;
+						const complete = index < step;
+						return (
+							<li key={item.key} className="flex-1">
+								<button
+									type="button"
+									disabled={!reachable}
+									onClick={() => setStep(index)}
+									aria-current={index === step ? "step" : undefined}
+									className={cn(
+										"flex w-full items-center gap-2 rounded-lg px-2 py-1 text-left text-xs font-medium transition-colors",
+										reachable
+											? index === step
+												? "text-foreground"
+												: "text-muted hover:bg-surface-secondary hover:text-foreground"
+											: "cursor-not-allowed text-muted/50",
+									)}
+								>
+									<span
+										className={cn(
+											"flex size-5 shrink-0 items-center justify-center rounded-full border text-[10px] font-semibold transition-all",
+											complete || index === step
+												? "border-accent bg-accent text-accent-foreground"
+												: "border-border bg-surface text-muted",
+										)}
+									>
+										{complete ? <TbCheck size={12} strokeWidth={3} /> : index + 1}
+									</span>
+									<span className="hidden truncate sm:inline">{item.label}</span>
+								</button>
+							</li>
+						);
+					})}
+				</ol>
+			</nav>
+
+			<div className="min-h-[340px]">
+				<div>
+					<p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-accent">
+						Step {step + 1} of {STEPS.length}
+					</p>
+					<h2 className="mt-1 text-lg font-semibold tracking-tight text-foreground">
+						{STEP_COPY[currentKey].title}
+					</h2>
+					<p className="mt-0.5 text-xs text-muted">
+						{STEP_COPY[currentKey].description}
+					</p>
+				</div>
+
+				<div className="mt-4">
+					{currentKey === "basics" && (
+						<div className="flex flex-col gap-5">
+							<TextField
+								isRequired
+								value={name}
+								onChange={setName}
+								isInvalid={name.length > 50}
+							>
+								<Label>Name</Label>
+								<Input placeholder="Billing API" autoFocus maxLength={50} />
+								<p className="text-xs text-muted">
+									2 to 50 characters. Must be unique across the instance.
+								</p>
+							</TextField>
+
+							<TextField value={description} onChange={setDescription}>
+								<Label>Description</Label>
+								<TextArea
+									rows={3}
+									placeholder="What this project is for"
+									maxLength={1000}
+								/>
+							</TextField>
+						</div>
+					)}
+
+					{currentKey === "members" && (
+						<MembersStep members={members} onChange={setMembers} />
+					)}
+
+					{currentKey === "config" && (
+						<div className="flex flex-col gap-5">
+							<Checkbox
+								isSelected={workerTimeouts}
+								onChange={setWorkerTimeouts}
+								label="Enable worker timeouts (experimental)"
+								description="Routes in this project can define a timeout, and a request running past it is aborted. Leave off to let requests run to completion."
+							/>
+
+							<dl className="grid gap-px overflow-hidden rounded-xl border border-border bg-border sm:grid-cols-2">
+								<SummaryItem label="Name" value={name.trim()} />
+								<SummaryItem
+									label="Description"
+									value={description.trim() || "—"}
+								/>
+								<SummaryItem
+									label="Members"
+									value={
+										members.length
+											? `${members.length} invited`
+											: "None — you can add them later"
+									}
+								/>
+								<SummaryItem
+									label="Worker timeouts"
+									value={workerTimeouts ? "Enabled" : "Disabled"}
+								/>
+							</dl>
+						</div>
+					)}
+				</div>
+			</div>
+
+			<div className="flex items-center justify-between border-t border-border pt-3.5">
+				<Button
+					variant="ghost"
+					size="sm"
+					isDisabled={step === 0}
+					onPress={() => setStep(step - 1)}
+				>
+					<TbArrowLeft size={16} /> Back
+				</Button>
+				{isLast ? (
+					<Button
+						variant="primary"
+						size="sm"
+						isPending={create.isPending}
+						isDisabled={!basicsValid}
+						onPress={submit}
+					>
+						Create project
+					</Button>
+				) : (
+					<Button
+						variant="primary"
+						size="sm"
+						isDisabled={!basicsValid}
+						onPress={() => setStep(step + 1)}
+					>
+						Next <TbArrowRight size={16} />
+					</Button>
+				)}
+			</div>
+		</div>
+	);
+}
+
+/** Two-column transfer panel: available users on the left, project members on
+ *  the right, moved across with the buttons between them. Highlighting is
+ *  multi-select, so a batch of users crosses in one press. */
+function MembersStep({
+	members,
+	onChange,
+}: {
+	members: Member[];
+	onChange: (next: Member[]) => void;
+}) {
+	const [search, setSearch] = useState("");
+	const [availableHighlight, setAvailableHighlight] = useState<string[]>([]);
+	const [memberHighlight, setMemberHighlight] = useState<string[]>([]);
+
+	const { data, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } =
+		authQuery.listUsers.useInfiniteQuery({ perPage: 50 });
+
+	const added = useMemo(() => members.map((m) => m.userId), [members]);
+
+	const available = useMemo(() => {
+		const all = (data?.pages.flatMap((page) => page.data) ?? []) as UserRow[];
+		const term = search.toLowerCase();
+		return all.filter(
+			(user) =>
+				!added.includes(user.id) &&
+				((user.name?.toLowerCase() ?? "").includes(term) ||
+					user.email.toLowerCase().includes(term)),
+		);
+	}, [data, search, added]);
+
+	function toggle(list: string[], id: string) {
+		return list.includes(id) ? list.filter((x) => x !== id) : [...list, id];
+	}
+
+	function addHighlighted() {
+		const moving = available.filter((user) =>
+			availableHighlight.includes(user.id),
+		);
+		onChange([
+			...members,
+			...moving.map((user) => ({
+				userId: user.id,
+				role: "viewer" as Role,
+				label: user.name || user.email,
+			})),
+		]);
+		setAvailableHighlight([]);
+	}
+
+	function removeHighlighted() {
+		onChange(members.filter((m) => !memberHighlight.includes(m.userId)));
+		setMemberHighlight([]);
+	}
+
+	return (
+		<div className="grid grid-cols-1 gap-3 sm:grid-cols-[1fr_auto_1fr]">
+			<section className="flex min-w-0 flex-col rounded-xl border border-border">
+				<header className="flex items-center justify-between border-b border-border px-3 py-2">
+					<h3 className="text-xs font-semibold uppercase tracking-wide text-muted">
+						Available
+					</h3>
+					<span className="text-[11px] text-muted">
+						{available.length} user{available.length === 1 ? "" : "s"}
+					</span>
+				</header>
+
+				<div className="relative border-b border-border p-2">
+					<TbSearch
+						size={15}
+						className="pointer-events-none absolute left-5 top-1/2 -translate-y-1/2 text-muted"
+					/>
+					<Input
+						aria-label="Search users"
+						placeholder="Search by name or email"
+						value={search}
+						onChange={(e) => setSearch(e.target.value)}
+						className="pl-9"
+					/>
+				</div>
+
+				<div className="flex h-[280px] flex-col overflow-y-auto p-2">
+					<LazyLoader
+						items={available}
+						isLoading={isLoading}
+						isFetchingNextPage={isFetchingNextPage}
+						hasNextPage={!!hasNextPage}
+						fetchNextPage={fetchNextPage}
+						className="flex flex-col gap-1"
+						emptyMessage="No users found."
+						renderItem={(user: UserRow) => (
+							<UserRowButton
+								key={user.id}
+								label={user.name || user.email}
+								sublabel={user.email}
+								initials={initialsOf(user.name, user.email)}
+								highlighted={availableHighlight.includes(user.id)}
+								onToggle={() =>
+									setAvailableHighlight(toggle(availableHighlight, user.id))
+								}
+							/>
+						)}
+					/>
+				</div>
+			</section>
+
+			<div className="flex flex-row items-center justify-center gap-2 sm:flex-col">
+				<Button
+					isIconOnly
+					variant="outline"
+					size="sm"
+					aria-label="Add selected users to the project"
+					isDisabled={availableHighlight.length === 0}
+					onPress={addHighlighted}
+				>
+					<TbChevronRight size={16} />
+				</Button>
+				<Button
+					isIconOnly
+					variant="outline"
+					size="sm"
+					aria-label="Remove selected members from the project"
+					isDisabled={memberHighlight.length === 0}
+					onPress={removeHighlighted}
+				>
+					<TbChevronLeft size={16} />
+				</Button>
+			</div>
+
+			<section className="flex min-w-0 flex-col rounded-xl border border-border">
+				<header className="flex items-center justify-between border-b border-border px-3 py-2">
+					<h3 className="text-xs font-semibold uppercase tracking-wide text-muted">
+						Members
+					</h3>
+					<span className="text-[11px] text-muted">
+						{members.length} added
+					</span>
+				</header>
+
+				<div className="flex h-[336px] flex-col gap-1 overflow-y-auto p-2">
+					{members.length === 0 ? (
+						<p className="m-auto px-4 text-center text-xs text-muted">
+							No members yet. Highlight users on the left and press the arrow to
+							add them.
+						</p>
+					) : (
+						members.map((member) => (
+							<div
+								key={member.userId}
+								className={cn(
+									"flex items-center gap-2 rounded-lg border p-2 transition-colors",
+									memberHighlight.includes(member.userId)
+										? "border-accent bg-accent/10"
+										: "border-transparent",
+								)}
+							>
+								<button
+									type="button"
+									aria-pressed={memberHighlight.includes(member.userId)}
+									onClick={() =>
+										setMemberHighlight(toggle(memberHighlight, member.userId))
+									}
+									className="min-w-0 flex-1 truncate text-left text-sm text-foreground"
+								>
+									{member.label}
+								</button>
+								<Select
+									aria-label={`Role for ${member.label}`}
+									selectedKey={member.role}
+									onSelectionChange={(key) =>
+										onChange(
+											members.map((m) =>
+												m.userId === member.userId
+													? { ...m, role: key as Role }
+													: m,
+											),
+										)
+									}
+								>
+									<Select.Trigger className="w-[8.5rem] shrink-0">
+										<Select.Value />
+										<Select.Indicator />
+									</Select.Trigger>
+									<Select.Popover>
+										<ListBox>
+											{ROLE_OPTIONS.map((option) => (
+												<ListBox.Item
+													key={option.id}
+													id={option.id}
+													textValue={option.label}
+												>
+													{option.label}
+													<ListBox.ItemIndicator />
+												</ListBox.Item>
+											))}
+										</ListBox>
+									</Select.Popover>
+								</Select>
+							</div>
+						))
+					)}
+				</div>
+			</section>
+		</div>
+	);
+}
+
+function UserRowButton({
+	label,
+	sublabel,
+	initials,
+	highlighted,
+	onToggle,
+}: {
+	label: string;
+	sublabel: string;
+	initials: string;
+	highlighted: boolean;
+	onToggle: () => void;
+}) {
+	return (
+		<button
+			type="button"
+			aria-pressed={highlighted}
+			onClick={onToggle}
+			className={cn(
+				"flex items-center gap-3 rounded-lg border p-2 text-left transition-colors",
+				highlighted
+					? "border-accent bg-accent/10"
+					: "border-transparent hover:bg-surface-secondary",
+			)}
+		>
+			<div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-surface-secondary text-xs font-semibold text-muted-foreground ring-1 ring-border">
+				{initials}
+			</div>
+			<div className="flex min-w-0 flex-col">
+				<span className="truncate text-sm font-medium text-foreground">
+					{label}
+				</span>
+				<span className="truncate text-xs text-muted-foreground">
+					{sublabel}
+				</span>
+			</div>
+		</button>
+	);
+}
+
+function SummaryItem({ label, value }: { label: string; value: string }) {
+	return (
+		<div className="bg-surface px-3 py-2">
+			<dt className="text-[11px] uppercase tracking-wide text-muted">
+				{label}
+			</dt>
+			<dd className="mt-0.5 text-sm text-foreground">{value || "—"}</dd>
+		</div>
+	);
+}

--- a/apps/server/src/api/v1/projects/create/dto.ts
+++ b/apps/server/src/api/v1/projects/create/dto.ts
@@ -1,8 +1,52 @@
 import { z } from "zod";
+import { projectSettingsKeySchemaMap } from "../settings/keys/keySchemaMap";
+
+/** Settings a project can be given at creation time.
+ *
+ *  Deliberately NOT every key in `projectSettingsKeySchemaMap`: the connection-id
+ *  keys (AI agent, telemetry destinations) need integration wiring — a live
+ *  connection test and the harness opt-in — that only `settings/keys/upsert`
+ *  performs. Those are configured inside the project, once integrations exist.
+ *  A new non-connection config key becomes available to the creation wizard by
+ *  adding it to the map and to this list; nothing else changes. */
+export const CREATE_TIME_SETTING_KEYS = [
+	"experimental.workerTimeouts.enabled",
+] as const;
+
+export type CreateTimeSettingKey = (typeof CREATE_TIME_SETTING_KEYS)[number];
+
+const settingsSchema = z.object(
+	Object.fromEntries(
+		CREATE_TIME_SETTING_KEYS.map((key) => [
+			key,
+			projectSettingsKeySchemaMap[key].schema.optional(),
+		]),
+	) as {
+		[K in CreateTimeSettingKey]: z.ZodOptional<
+			(typeof projectSettingsKeySchemaMap)[K]["schema"]
+		>;
+	},
+);
+
+const memberSchema = z.object({
+	userId: z.string().min(1),
+	role: z.enum(["viewer", "creator", "project_admin"]),
+});
 
 export const requestBodySchema = z.object({
-  name: z.string().min(2).max(100),
-  description: z.string().max(1000).optional(),
+	// 50, not 100: `projects.name` is varchar(50), so a longer name passed
+	// validation and then died on the insert.
+	name: z.string().min(2).max(50),
+	description: z.string().max(1000).optional(),
+	members: z
+		.array(memberSchema)
+		.optional()
+		.refine(
+			(members) =>
+				!members || new Set(members.map((m) => m.userId)).size === members.length,
+			{ message: "A user can only be added to the project once" },
+		),
+	settings: settingsSchema.optional(),
 });
 
 export const responseSchema = z.object({ id: z.string() });

--- a/apps/server/src/api/v1/projects/create/service.ts
+++ b/apps/server/src/api/v1/projects/create/service.ts
@@ -1,23 +1,46 @@
 import { z } from "zod";
 import { requestBodySchema, responseSchema } from "./dto";
 import { db } from "../../../../db";
-import { checkProjectExist } from "../../routes/create/repository";
 import { ConflictError } from "../../../../errors/conflictError";
-import { createProject } from "./repository";
+import { checkProjectExists, createProject } from "./repository";
+import { addProjectMember } from "../settings/members/repository";
+import { upsertProjectSettingKey } from "../settings/keys/upsert/repository";
 import { ServerError } from "../../../../errors/serverError";
 import { generateID } from "@fluxify/lib";
 
 export default async function handleRequest(
-  data: z.infer<typeof requestBodySchema>
+	data: z.infer<typeof requestBodySchema>,
 ): Promise<z.infer<typeof responseSchema>> {
-  const id = await db.transaction(async (tx) => {
-    const exist = await checkProjectExist(data.name, tx);
-    if (exist)
-      throw new ConflictError(
-        `Project already exists with '${data.name}' name`
-      );
-    return await createProject({ ...data, id: generateID() }, tx);
-  });
-  if (!id) throw new ServerError("Something went wrong while creating project");
-  return { id };
+	const { members, settings, ...project } = data;
+
+	// Members and settings ride in the same transaction as the insert: a project
+	// that exists but is missing the access grants it was created with is worse
+	// than no project at all, since only a system admin could then repair it.
+	const id = await db.transaction(async (tx) => {
+		const exist = await checkProjectExists(project.name, tx);
+		if (exist)
+			throw new ConflictError(
+				`Project already exists with '${project.name}' name`,
+			);
+
+		const projectId = await createProject(
+			{ ...project, id: generateID() },
+			tx,
+		);
+		if (!projectId) return "";
+
+		for (const member of members ?? []) {
+			await addProjectMember(projectId, member.userId, member.role, tx);
+		}
+
+		for (const [key, value] of Object.entries(settings ?? {})) {
+			if (value === undefined) continue;
+			await upsertProjectSettingKey(projectId, key, value, tx);
+		}
+
+		return projectId;
+	});
+
+	if (!id) throw new ServerError("Something went wrong while creating project");
+	return { id };
 }

--- a/apps/server/src/api/v1/projects/create/tests/create.spec.ts
+++ b/apps/server/src/api/v1/projects/create/tests/create.spec.ts
@@ -1,5 +1,87 @@
-import { describe, it, mock, spyOn, type Mock } from "bun:test";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import handleRequest from "../service";
+import * as repository from "../repository";
+import * as membersRepository from "../../settings/members/repository";
+import * as settingsRepository from "../../settings/keys/upsert/repository";
+import { ConflictError } from "../../../../../errors/conflictError";
 
-describe("unit tests for get-all", () => {
-  it("test 01", () => {});
+mock.module("../repository", () => ({
+	createProject: mock(),
+	checkProjectExists: mock(),
+}));
+
+mock.module("../../settings/members/repository", () => ({
+	addProjectMember: mock(),
+}));
+
+mock.module("../../settings/keys/upsert/repository", () => ({
+	upsertProjectSettingKey: mock(),
+}));
+
+const tx = { __tx: true };
+mock.module("../../../../../db", () => ({
+	db: { transaction: (fn: (t: unknown) => unknown) => fn(tx) },
+}));
+
+describe("create project service", () => {
+	beforeEach(() => {
+		(repository.createProject as any).mockClear();
+		(repository.checkProjectExists as any).mockClear();
+		(membersRepository.addProjectMember as any).mockClear();
+		(settingsRepository.upsertProjectSettingKey as any).mockClear();
+		(repository.checkProjectExists as any).mockResolvedValue(false);
+		(repository.createProject as any).mockResolvedValue("proj-1");
+	});
+
+	it("rejects a duplicate name by name, not by id", async () => {
+		(repository.checkProjectExists as any).mockResolvedValue(true);
+
+		expect(handleRequest({ name: "Billing" } as any)).rejects.toThrow(
+			ConflictError,
+		);
+		expect(repository.checkProjectExists).toHaveBeenCalledWith("Billing", tx);
+	});
+
+	it("writes members and settings in the creating transaction", async () => {
+		const result = await handleRequest({
+			name: "Billing",
+			members: [
+				{ userId: "u1", role: "viewer" },
+				{ userId: "u2", role: "project_admin" },
+			],
+			settings: { "experimental.workerTimeouts.enabled": "true" },
+		} as any);
+
+		expect(result).toEqual({ id: "proj-1" });
+		// Same `tx` as the insert — a failure anywhere rolls the project back.
+		expect(membersRepository.addProjectMember).toHaveBeenCalledWith(
+			"proj-1",
+			"u1",
+			"viewer",
+			tx,
+		);
+		expect(membersRepository.addProjectMember).toHaveBeenCalledWith(
+			"proj-1",
+			"u2",
+			"project_admin",
+			tx,
+		);
+		expect(settingsRepository.upsertProjectSettingKey).toHaveBeenCalledWith(
+			"proj-1",
+			"experimental.workerTimeouts.enabled",
+			"true",
+			tx,
+		);
+	});
+
+	it("creates a bare project when members and settings are omitted", async () => {
+		await handleRequest({ name: "Billing" } as any);
+
+		expect(membersRepository.addProjectMember).not.toHaveBeenCalled();
+		expect(settingsRepository.upsertProjectSettingKey).not.toHaveBeenCalled();
+		// `members`/`settings` must not reach the insert — they are not columns.
+		const [inserted] = (repository.createProject as any).mock.calls[0];
+		expect(inserted).not.toHaveProperty("members");
+		expect(inserted).not.toHaveProperty("settings");
+	});
 });

--- a/apps/server/src/api/v1/projects/update/dto.ts
+++ b/apps/server/src/api/v1/projects/update/dto.ts
@@ -5,7 +5,9 @@ export const requestRouteSchema = z.object({
 });
 
 export const requestBodySchema = z.object({
-  name: z.string().min(1).max(255).optional(),
+  // 50, not 255: `projects.name` is varchar(50), so a longer name passed
+  // validation and then died on the update.
+  name: z.string().min(1).max(50).optional(),
   description: z.string().max(1000).optional(),
   hidden: z.boolean().optional(),
 });


### PR DESCRIPTION
## What

Replaces the single-field "new project" modal with a dedicated 3-step wizard, and extends the create endpoint to accept what the wizard collects.

### Server — `POST /v1/projects`

- Accepts `{ name, description?, members[], settings{} }`. Members and settings are written inside the **existing** `db.transaction` alongside the insert — all three repository functions already took an optional `tx`, so this is atomic without new plumbing. A project that exists but is missing the access grants it was created with can only be repaired by a system admin, so partial creation isn't an acceptable state.
- `CREATE_TIME_SETTING_KEYS` in `create/dto.ts` is the single source shared by the request schema and the wizard. Connection-id keys (AI agent, telemetry) are deliberately excluded — they need the live connection test that only `settings/keys/upsert` performs. Adding a future non-connection key is a one-line change there.

### Server — bugs found on the way

- **Duplicate-name check never fired.** `create/service.ts` imported `checkProjectExist` from `routes/create/repository`, whose signature is `(id: string)` and which matches `eq(projectsEntity.id, id)`. It was querying `id = <the project name>`, always returned false, and the 409 was dead code — duplicate project names were silently allowed. The correct `checkProjectExists(name)` was sitting unused in `projects/create/repository.ts`. Now used, and covered by a test asserting it's called with the name.
- **`varchar(50)` vs zod.** `projects.name` is `varchar({ length: 50 })` but `create/dto.ts` allowed `max(100)` and `update/dto.ts` allowed `max(255)`, so a 51+ character name passed validation and then failed at the DB. Both DTOs now cap at 50.
- `create/tests/create.spec.ts` was a copy-pasted `get-all` stub (`it("test 01", () => {})`). Replaced with real tests.

### Portal

- New route `/projects/new` (`_authed/projects.new.tsx`), behind the same `isSystemAdmin` gate as the old modal. Three steps — basics, members, config — split this way so future config keys have a home rather than crowding the name field.
- Members step is a two-column transfer panel: searchable available users on the left, chosen members on the right with a per-row role dropdown reusing `ROLES` from `RoleSelector` rather than retyping the three roles.
- `ProjectsTab` loses the modal and navigates to the wizard.

## Notes

- No new DB columns and no migration. Future project metadata goes to the existing project-settings key/value table.
- `hidden` is untouched — it's the live archive flag used by `get-all` and `update`, not something to set at creation.
- All new styling uses design-system tokens. `AGENT.md` gains a rule documenting this, after a first pass copied literal hex from a neighbouring file.

## Testing

- `bun run lint` — clean across all 10 packages (also runs on pre-commit).
- Server project tests: 19/19 pass. Portal tests: 71/71 pass.
- `vite build` succeeds; `routeTree.gen.ts` picks up the new route (it's gitignored and generated at build time, so it doesn't appear in the diff).
- Not yet manually clicked through in a running portal — worth a look at the wizard before merge, particularly the transfer panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
