### PR TITLE
feat(custom-blocks): app config selector input param

### DIFF
--- a/apps/portal/src/components/appConfig/AppConfigField.tsx
+++ b/apps/portal/src/components/appConfig/AppConfigField.tsx
@@ -1,0 +1,116 @@
+import { useState } from "react";
+import { Button, CloseButton, Label, cn } from "@fluxify/components";
+import { TbKey, TbVariable } from "react-icons/tb";
+import {
+	type AppConfigExtraItem,
+	AppConfigSelectorModal,
+} from "@/components/integrations/AppConfigSelectorModal";
+
+export type AppConfigFieldProps = {
+	projectId: string;
+	/** A bare app config key, or `param:<name>` when deferred to the caller. */
+	value: string;
+	label?: string;
+	description?: string;
+	placeholder?: string;
+	isDisabled?: boolean;
+	/** Input params of the enclosing custom block, offered as `param:` entries. */
+	extraItems?: AppConfigExtraItem[];
+	onChange: (value: string) => void;
+};
+
+/**
+ * Picks an app config *key*. Unlike `integrations/AppConfigSelector`, this field
+ * has no literal mode — a literal is exactly what an app config reference exists
+ * to remove — so it stores the bare key with no `cfg:` marker to disambiguate.
+ */
+export function AppConfigField({
+	projectId,
+	value,
+	label,
+	description,
+	placeholder = "None selected",
+	isDisabled,
+	extraItems,
+	onChange,
+}: AppConfigFieldProps) {
+	const [pickerOpen, setPickerOpen] = useState(false);
+
+	const isParam = value.startsWith("param:");
+	const extra = isParam ? extraItems?.find((e) => e.value === value) : undefined;
+
+	return (
+		<div className="flex flex-col gap-1.5 py-2">
+			{label && <Label>{label}</Label>}
+			{description && (
+				<p className="text-xs leading-normal text-muted-foreground">
+					{description}
+				</p>
+			)}
+
+			<div className="flex h-10 w-full items-center justify-between gap-3 rounded-[var(--radius)] border border-border bg-surface px-3 shadow-sm">
+				<div className="flex min-w-0 flex-1 items-center gap-2.5">
+					{value ? (
+						<>
+							{isParam ? (
+								<TbVariable size={16} className="shrink-0 text-accent" />
+							) : (
+								<TbKey size={16} className="shrink-0 text-muted-foreground" />
+							)}
+							<span
+								className={cn(
+									"truncate font-mono text-sm font-medium",
+									isParam ? "text-accent" : "text-foreground",
+								)}
+							>
+								{isParam ? (extra?.label ?? value.slice(6)) : value}
+							</span>
+							{isParam && (
+								<span className="shrink-0 rounded-full border border-border bg-surface-secondary px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+									Input parameter
+								</span>
+							)}
+						</>
+					) : (
+						<span className="text-sm text-muted-foreground">{placeholder}</span>
+					)}
+				</div>
+
+				<div className="flex shrink-0 items-center gap-1.5">
+					{value && !isDisabled && (
+						<>
+							<CloseButton
+								aria-label="Clear app config key"
+								onPress={() => onChange("")}
+								className="text-muted-foreground hover:text-foreground"
+							/>
+							<span className="mx-1 h-5 w-px shrink-0 bg-border" />
+						</>
+					)}
+					<Button
+						variant="primary"
+						size="sm"
+						isDisabled={isDisabled}
+						onPress={() => setPickerOpen(true)}
+					>
+						{value ? "Change" : "Select"}
+					</Button>
+				</div>
+			</div>
+
+			{isParam && extra?.hint && (
+				<p className="text-xs leading-normal text-accent">{extra.hint}</p>
+			)}
+
+			<AppConfigSelectorModal
+				projectId={projectId}
+				isOpen={pickerOpen}
+				onOpenChange={setPickerOpen}
+				selectedValue={value}
+				extraItems={extraItems}
+				onSelect={onChange}
+				onClear={() => onChange("")}
+			/>
+		</div>
+	);
+}

--- a/apps/portal/src/components/canvas/panel/blocks/CustomBlockSettings.tsx
+++ b/apps/portal/src/components/canvas/panel/blocks/CustomBlockSettings.tsx
@@ -6,6 +6,7 @@ import { withBasePath } from "@/constants/routes";
 import { customBlocksQuery } from "@/query/customBlocksQuery";
 import { BlockSettings } from "../BlockSettings";
 import {
+	BlockAppConfigField,
 	BlockArrayEditorField,
 	BlockCheckboxField,
 	BlockIntegrationField,
@@ -18,7 +19,13 @@ import type { BlockNode } from "../../types";
 export type CustomBlockInputParam = {
 	name: string;
 	label: string;
-	type: "text_input" | "checkbox" | "dropdown" | "array_editor" | "integration_selector";
+	type:
+		| "text_input"
+		| "checkbox"
+		| "dropdown"
+		| "array_editor"
+		| "integration_selector"
+		| "app_config_selector";
 	options?: (string | { label: string; value: string })[];
 	group?: string;
 	tags?: string[];
@@ -150,6 +157,17 @@ export function CustomBlockSettingsPanel({ block }: { block: BlockNode }) {
 									label={param.label}
 									description={param.description}
 									group={param.group}
+								/>
+							);
+						case "app_config_selector":
+							return (
+								<BlockAppConfigField
+									key={param.name}
+									blockId={block.id}
+									data={block.data}
+									name={param.name}
+									label={param.label}
+									description={param.description}
 								/>
 							);
 						default:

--- a/apps/portal/src/components/canvas/panel/fields.tsx
+++ b/apps/portal/src/components/canvas/panel/fields.tsx
@@ -17,6 +17,8 @@ import { useReactFlow } from "@xyflow/react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { ReactNode } from "react";
 import { withBasePath } from "@/constants/routes";
+import { AppConfigField } from "@/components/appConfig/AppConfigField";
+import type { AppConfigExtraItem } from "@/components/integrations/AppConfigSelectorModal";
 import { integrationService } from "@/services/integrations";
 import { customBlocksQuery } from "@/query/customBlocksQuery";
 import type { CustomBlockInputParam } from "./blocks/CustomBlockSettings";
@@ -348,6 +350,76 @@ export function BlockIntegrationField({
 						)
 					: undefined
 			}
+		/>
+	);
+}
+
+/**
+ * The app config counterpart of `useCustomBlockParamIntegrations`: on a custom
+ * block's own canvas, that block's `app_config_selector` input params are
+ * offered next to the project's real keys. Picking one writes `param:<name>`,
+ * so the key is chosen by whoever places the block — and it chains, an authz
+ * block can hand its own secret key down to the jwt block it calls.
+ */
+function useCustomBlockParamConfigs(
+	projectId: string,
+	customBlockId: string | undefined,
+): AppConfigExtraItem[] | undefined {
+	const { data: blocks } = customBlocksQuery.getAll.useQuery(projectId);
+
+	return useMemo(() => {
+		if (!customBlockId) return undefined;
+		const block = blocks?.find((b) => b.id === customBlockId);
+		const params = Array.isArray(block?.inputParams)
+			? (block.inputParams as CustomBlockInputParam[])
+			: [];
+		const matching = params.filter((p) => p.type === "app_config_selector");
+		if (matching.length === 0) return undefined;
+		return matching.map((param) => ({
+			value: `param:${param.name}`,
+			label: param.label || param.name,
+			hint: `Set by whoever places this block — the “${param.label || param.name}” input.`,
+		}));
+	}, [blocks, customBlockId]);
+}
+
+export type BlockAppConfigFieldProps = {
+	blockId: string;
+	data: BlockData;
+	name: string;
+	label?: string;
+	description?: string;
+};
+
+/**
+ * An app config key setting field backed by AppConfigField.
+ */
+export function BlockAppConfigField({
+	blockId,
+	data,
+	name,
+	label,
+	description,
+}: BlockAppConfigFieldProps) {
+	const { updateNodeData } = useReactFlow();
+	const { enabled: editable } = useCanvasChanges();
+	const params = useParams({ strict: false }) as {
+		projectId?: string;
+		blockId?: string;
+	};
+	const projectId = params?.projectId ?? "";
+	const value = typeof data[name] === "string" ? (data[name] as string) : "";
+	const extraItems = useCustomBlockParamConfigs(projectId, params?.blockId);
+
+	return (
+		<AppConfigField
+			projectId={projectId}
+			value={value}
+			label={label}
+			description={description}
+			isDisabled={!editable}
+			extraItems={extraItems}
+			onChange={(next) => updateNodeData(blockId, { [name]: next })}
 		/>
 	);
 }

--- a/apps/portal/src/components/customBlocks/InputParamsEditor.tsx
+++ b/apps/portal/src/components/customBlocks/InputParamsEditor.tsx
@@ -17,6 +17,7 @@ const PARAM_TYPE_OPTIONS = [
 	{ value: "dropdown", label: "Dropdown" },
 	{ value: "array_editor", label: "Array editor" },
 	{ value: "integration_selector", label: "Integration selector" },
+	{ value: "app_config_selector", label: "App config selector" },
 ];
 
 const NAME_REGEX = /^[a-z0-9_]+$/;
@@ -206,6 +207,13 @@ function ParamRow({
 					isDisabled={isDisabled}
 					onChange={(options) => onChange({ options })}
 				/>
+			)}
+
+			{param.type === "app_config_selector" && (
+				<p className="text-xs text-muted">
+					Holds an app config <em>key</em>, not its value — read it with{" "}
+					<code className="font-mono">getConfig(params.{param.name || "name"})</code>.
+				</p>
 			)}
 
 			{param.type === "integration_selector" && (

--- a/apps/portal/src/components/integrations/AppConfigSelector.tsx
+++ b/apps/portal/src/components/integrations/AppConfigSelector.tsx
@@ -81,6 +81,10 @@ export function AppConfigSelector({
 				isOpen={modalOpen}
 				onOpenChange={setModalOpen}
 				selectedValue={local}
+				// The modal hands back a bare key and the caller decides how to store
+				// it: this field is a hybrid — a literal or a reference — so it needs
+				// the `cfg:` marker to tell them apart. Fields with no literal mode
+				// (AppConfigField) store the bare key instead.
 				onSelect={(keyName) => set(`cfg:${keyName}`)}
 				onClear={() => set("")}
 			/>

--- a/apps/portal/src/components/integrations/AppConfigSelectorModal.tsx
+++ b/apps/portal/src/components/integrations/AppConfigSelectorModal.tsx
@@ -6,15 +6,28 @@ import {
 	TbLock,
 	TbRefresh,
 	TbSearch,
+	TbVariable,
 	TbX,
 } from "react-icons/tb";
 import { appConfigQuery } from "@/query/appConfigQuery";
+
+/**
+ * An entry offered alongside the project's real keys — used by a custom block's
+ * canvas to offer its own `app_config_selector` input params as `param:<name>`.
+ */
+export type AppConfigExtraItem = {
+	/** What `onSelect` receives, e.g. `param:jwt_secret`. */
+	value: string;
+	label: string;
+	hint?: string;
+};
 
 export type AppConfigSelectorModalProps = {
 	projectId: string;
 	isOpen: boolean;
 	onOpenChange: (isOpen: boolean) => void;
 	selectedValue?: string;
+	extraItems?: AppConfigExtraItem[];
 	onSelect: (keyName: string) => void;
 	onClear?: () => void;
 };
@@ -24,6 +37,7 @@ export function AppConfigSelectorModal({
 	isOpen,
 	onOpenChange,
 	selectedValue = "",
+	extraItems,
 	onSelect,
 	onClear,
 }: AppConfigSelectorModalProps) {
@@ -76,6 +90,16 @@ export function AppConfigSelectorModal({
 		if (!data?.pages) return [];
 		return data.pages.flatMap((page) => page.data);
 	}, [data?.pages]);
+
+	const filteredExtras = useMemo(() => {
+		const q = debouncedSearch.trim().toLowerCase();
+		const all = extraItems ?? [];
+		if (!q) return all;
+		return all.filter(
+			(e) =>
+				e.label.toLowerCase().includes(q) || e.value.toLowerCase().includes(q),
+		);
+	}, [extraItems, debouncedSearch]);
 
 	const activeKey = selectedValue.startsWith("cfg:")
 		? selectedValue.slice(4)
@@ -156,7 +180,7 @@ export function AppConfigSelectorModal({
 									<Spinner />
 									<span className="mt-2 text-xs text-muted">Loading configuration keys…</span>
 								</div>
-							) : items.length === 0 ? (
+							) : items.length === 0 && filteredExtras.length === 0 ? (
 								debouncedSearch ? (
 									<div className="flex flex-col items-center justify-center py-12 text-center">
 										<TbSearch size={26} className="text-muted/60 mb-2" />
@@ -188,6 +212,63 @@ export function AppConfigSelectorModal({
 								)
 							) : (
 								<div className="flex max-h-[440px] min-h-[260px] flex-col gap-2 overflow-y-auto pr-1">
+									{filteredExtras.map((extra) => {
+										const isSelected = activeKey === extra.value;
+										return (
+											<button
+												key={extra.value}
+												type="button"
+												onClick={() => handleSelect(extra.value)}
+												className={cn(
+													"group flex w-full items-center justify-between gap-3 rounded-xl border border-dashed px-3.5 py-2.5 text-left transition-all duration-150",
+													isSelected
+														? "border-accent bg-accent/10 shadow-sm ring-1 ring-accent"
+														: "border-border bg-surface hover:border-accent hover:bg-surface-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus",
+												)}
+											>
+												<div className="flex min-w-0 flex-1 items-center gap-2.5">
+													<span
+														className={cn(
+															"flex size-8 shrink-0 items-center justify-center rounded-lg transition-colors",
+															isSelected
+																? "bg-accent text-accent-foreground"
+																: "bg-surface-secondary text-foreground group-hover:bg-accent group-hover:text-accent-foreground",
+														)}
+													>
+														<TbVariable size={15} />
+													</span>
+													<span className="flex min-w-0 flex-col">
+														<span className="truncate text-xs font-semibold text-foreground">
+															{extra.label}
+														</span>
+														{extra.hint && (
+															<span className="truncate text-[11px] text-muted">
+																{extra.hint}
+															</span>
+														)}
+													</span>
+													<Chip
+														size="sm"
+														color="accent"
+														className="text-[11px] font-medium shrink-0"
+													>
+														Input parameter
+													</Chip>
+												</div>
+												<div className="shrink-0">
+													{isSelected ? (
+														<span className="flex size-6 items-center justify-center rounded-full bg-accent text-accent-foreground">
+															<TbCheck size={13} strokeWidth={3} />
+														</span>
+													) : (
+														<span className="text-xs font-medium text-muted transition-colors group-hover:text-foreground">
+															Select
+														</span>
+													)}
+												</div>
+											</button>
+										);
+									})}
 									{items.map((item) => {
 										const isSelected = activeKey === item.keyName;
 										return (

--- a/apps/server/src/api/v1/custom-blocks/create/dto.ts
+++ b/apps/server/src/api/v1/custom-blocks/create/dto.ts
@@ -28,6 +28,15 @@ export const inputParamSchema = z.discriminatedUnion("type", [
     tags: z.array(z.string()).default([]),
     description: z.string().optional(),
   }),
+  // The param carries an app config *key*, not the resolved value: `param:`
+  // placeholders are substituted at compile time, so a resolved value would be
+  // baked into the compiled worker source. The block reads `getConfig(params.x)`.
+  z.object({
+    type: z.literal("app_config_selector"),
+    name: z.string().regex(/^[a-z0-9_]+$/),
+    label: z.string(),
+    description: z.string().optional(),
+  }),
   z.object({
     type: z.literal("dropdown"),
     name: z.string().regex(/^[a-z0-9_]+$/),

--- a/packages/blocks/builtin/tests/compilerCustomBlock.spec.ts
+++ b/packages/blocks/builtin/tests/compilerCustomBlock.spec.ts
@@ -419,4 +419,42 @@ describe("compiled cloud logs", () => {
 
 		expect(asked).toEqual([{ integrationId: "obs-42", type: "observability" }]);
 	});
+
+	it("chains an app config key param down through a nested custom block", async () => {
+		// the app config selector param carries the *key*: `authz` hands its own
+		// key to the `jwt` block it calls, and only the callee resolves it
+		registerCustomBlock(
+			"jwt",
+			[
+				block("c1", BlockTypes.entrypoint),
+				block("c2", BlockTypes.jsrunner, {
+					value: "return { signedWith: getConfig(params.secret_key) };",
+				}),
+			],
+			[edge("c1", "c2")],
+		);
+		registerCustomBlock(
+			"authz",
+			[
+				block("d1", BlockTypes.entrypoint),
+				block("d2", "jwt", { secret_key: "param:signing_key" }),
+			],
+			[edge("d1", "d2")],
+		);
+
+		const { run } = compileGraph(
+			[
+				block("1", BlockTypes.entrypoint),
+				block("2", "authz", { signing_key: "JWT_SECRET" }),
+				block("3", BlockTypes.response, { httpCode: "200" }),
+			],
+			[edge("1", "2"), edge("2", "3")],
+		);
+
+		const ctx = createContext();
+		ctx.vars.getConfig = (key: string) => `resolved:${key}`;
+		const result = await run(ctx, null);
+
+		expect(result.output.body).toEqual({ signedWith: "resolved:JWT_SECRET" });
+	});
 });

--- a/testing/e2e/blocks/jwt-ops.json
+++ b/testing/e2e/blocks/jwt-ops.json
@@ -1,6 +1,6 @@
 {
 	"name": "jwt_ops",
-	"description": "Signs or verifies a JWT, chosen by the `operation` input param. With `failOnInvalid` set, a bad token ends the block on a 401 response instead of returning a result. The secret is baked in until custom blocks can read app config.",
+	"description": "Signs or verifies a JWT, chosen by the `operation` input param. With `failOnInvalid` set, a bad token ends the block on a 401 response instead of returning a result. The signing secret is an app config key the caller picks, so the block carries no secret of its own.",
 	"inputParams": [
 		{
 			"name": "operation",
@@ -14,6 +14,12 @@
 			"label": "Reject invalid tokens",
 			"type": "checkbox",
 			"description": "End the block with a 401 instead of returning { valid: false }."
+		},
+		{
+			"name": "secret_key",
+			"label": "Signing secret",
+			"type": "app_config_selector",
+			"description": "App config key holding the HMAC secret. The block reads the key, never the value."
 		}
 	],
 	"blocks": [
@@ -46,7 +52,7 @@
 			"position": { "x": 480, "y": -120 },
 			"data": {
 				"blockName": "Sign a token",
-				"value": "return {\n\ttoken: jwt.sign(input ?? {}, \"e2e-custom-block-secret\", {\n\t\texpiresIn: \"1h\",\n\t\tissuer: \"fluxify-e2e-block\",\n\t}),\n};"
+				"value": "return {\n\ttoken: jwt.sign(input ?? {}, getConfig(params.secret_key), {\n\t\texpiresIn: \"1h\",\n\t\tissuer: \"fluxify-e2e-block\",\n\t}),\n};"
 			}
 		},
 		{
@@ -55,7 +61,7 @@
 			"position": { "x": 480, "y": 120 },
 			"data": {
 				"blockName": "Verify the token",
-				"value": "const result = jwt.verify(input?.token ?? \"\", \"e2e-custom-block-secret\");\nreturn result.success\n\t? { valid: true, payload: result.payload }\n\t: { valid: false, error: \"invalid_token\" };"
+				"value": "const result = jwt.verify(input?.token ?? \"\", getConfig(params.secret_key));\nreturn result.success\n\t? { valid: true, payload: result.payload }\n\t: { valid: false, error: \"invalid_token\" };"
 			}
 		},
 		{

--- a/testing/e2e/graphs/custom-blocks/jwt-sign.json
+++ b/testing/e2e/graphs/custom-blocks/jwt-sign.json
@@ -37,7 +37,8 @@
 				"blockName": "Sign it",
 				"invoke": "sync",
 				"operation": "sign",
-				"failOnInvalid": false
+				"failOnInvalid": false,
+				"secret_key": "JWT_SIGNING_SECRET"
 			}
 		},
 		{

--- a/testing/e2e/graphs/custom-blocks/jwt-verify-strict.json
+++ b/testing/e2e/graphs/custom-blocks/jwt-verify-strict.json
@@ -37,7 +37,8 @@
 				"blockName": "Verify it",
 				"invoke": "sync",
 				"operation": "verify",
-				"failOnInvalid": true
+				"failOnInvalid": true,
+				"secret_key": "JWT_SIGNING_SECRET"
 			}
 		},
 		{

--- a/testing/e2e/graphs/custom-blocks/jwt-verify.json
+++ b/testing/e2e/graphs/custom-blocks/jwt-verify.json
@@ -37,7 +37,8 @@
 				"blockName": "Verify it",
 				"invoke": "sync",
 				"operation": "verify",
-				"failOnInvalid": false
+				"failOnInvalid": false,
+				"secret_key": "JWT_SIGNING_SECRET"
 			}
 		},
 		{

--- a/testing/e2e/src/runner.ts
+++ b/testing/e2e/src/runner.ts
@@ -3,7 +3,7 @@ import {
 	hydrateIntegrations,
 	OWNER_KEY,
 } from "@fluxify/server/src/loaders/integrationsLoader";
-import { hydrateAppConfig } from "@fluxify/server/src/loaders/appConfigLoader";
+import { hydrateAppConfig } from "@fluxify/server/src/loaders/appconfigLoader";
 import { setBlocksExecutor } from "@fluxify/server/src/modules/requestRouter/executor";
 import { executeRouteInternal } from "@fluxify/server/src/modules/requestRouter/service";
 import { connectionFor } from "./engines";

--- a/testing/e2e/src/runner.ts
+++ b/testing/e2e/src/runner.ts
@@ -3,6 +3,8 @@ import {
 	hydrateIntegrations,
 	OWNER_KEY,
 } from "@fluxify/server/src/loaders/integrationsLoader";
+// `appconfigLoader`, not `appConfigLoader` — the file is lowercase and CI runs
+// on a case-sensitive filesystem, so the camelCase spelling only resolves locally
 import { hydrateAppConfig } from "@fluxify/server/src/loaders/appconfigLoader";
 import { setBlocksExecutor } from "@fluxify/server/src/modules/requestRouter/executor";
 import { executeRouteInternal } from "@fluxify/server/src/modules/requestRouter/service";

--- a/testing/e2e/src/runner.ts
+++ b/testing/e2e/src/runner.ts
@@ -3,6 +3,7 @@ import {
 	hydrateIntegrations,
 	OWNER_KEY,
 } from "@fluxify/server/src/loaders/integrationsLoader";
+import { hydrateAppConfig } from "@fluxify/server/src/loaders/appConfigLoader";
 import { setBlocksExecutor } from "@fluxify/server/src/modules/requestRouter/executor";
 import { executeRouteInternal } from "@fluxify/server/src/modules/requestRouter/service";
 import { connectionFor } from "./engines";
@@ -26,6 +27,14 @@ import type { GraphFixture } from "./graph";
 export const PROJECT_ID = "e2e-project";
 /** the integration id every fixture points its db blocks at */
 export const DB_CONNECTION = "primary";
+/**
+ * The project's app config, as the worker would receive it over KV — a fixture
+ * reaches it through `getConfig`, and a custom block through an
+ * `app_config_selector` param naming the key.
+ */
+export const APP_CONFIG: Record<string, string | number | boolean> = {
+	JWT_SIGNING_SECRET: "e2e-custom-block-secret",
+};
 
 export type GraphRequest = {
 	method?: string;
@@ -63,6 +72,7 @@ export async function runGraph(
 	fixture: GraphFixture,
 	request: GraphRequest = {},
 ): Promise<GraphRun> {
+	hydrateAppConfig(PROJECT_ID, APP_CONFIG);
 	await hydrateDatabase(fixture);
 	const disposeBlocks = await registerFixtureBlocks(fixture);
 

--- a/testing/e2e/tests/jwtCustomBlock.test.ts
+++ b/testing/e2e/tests/jwtCustomBlock.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { loadGraph } from "../src/graph";
-import { runGraph } from "../src/runner";
+import { APP_CONFIG, runGraph } from "../src/runner";
 
 /**
  * One custom block, three routes, three configurations. What this covers that a
@@ -90,7 +90,8 @@ describe("jwt_ops custom block", () => {
 	});
 
 	it("rejects a token signed with a different secret", async () => {
-		// the secret lives inside the block; nothing the caller passes can change it
+		// the block signs with whatever app config key the caller picked, and all
+		// three routes pick the same one — a foreign signature cannot verify
 		const foreign = [
 			Buffer.from(JSON.stringify({ alg: "HS256", typ: "JWT" })).toString(
 				"base64url",
@@ -115,6 +116,15 @@ describe("jwt_ops custom block", () => {
 
 		expect(run.source).toContain('lib.invoke(ctx, "jwt_ops"');
 		// the callee's body is compiled once, into the library — not here
-		expect(run.source).not.toContain("e2e-custom-block-secret");
+		expect(run.source).not.toContain("getConfig(params.secret_key)");
+	});
+
+	it("carries the app config key into the block, never the secret itself", async () => {
+		const run = await runGraph(sign, { body: { sub: "user-42" } });
+
+		// the caller passes the key, so the secret is resolved at call time and
+		// never reaches the compiled artifact — the whole point of the param type
+		expect(run.source).toContain("JWT_SIGNING_SECRET");
+		expect(run.source).not.toContain(APP_CONFIG.JWT_SIGNING_SECRET);
 	});
 });


### PR DESCRIPTION
Closes #260.

## What

Adds an `app_config_selector` custom block input param: a param whose value is an app config key, chosen by whoever places the block. The app-config half of the `integration_selector` from #259.

## The key, not the value

The issue left this open. It resolves itself once you follow the compiler: `param:` placeholders are substituted at **compile** time (`compiler.ts:485` emits `$state.params[...]`, `blockFactory.ts:384` inlines caller data into the graph). Resolving eagerly would write the app config value into the compiled worker source — which `testing/e2e/tests/jwtCustomBlock.test.ts` already asserts against. So the param carries the key and the block reads `getConfig(params.<name>)`, keeping resolution project-scoped and at call time.

## Runtime: nothing

`params` is already a real function argument of every JS block (`compiler.ts:363`, `:544`) and `getConfig` is already project-scoped (`requestRouter/service.ts:602`). No engine change, no new plumbing.

## Chaining

An `app_config_selector` param is offered on a custom block's own canvas as a `param:<name>` entry, exactly like `useCustomBlockParamIntegrations` does for integrations. That is what lets an `authz` block pass its signing key down to the `jwt` block it calls — the `param:` hop resolves per level, so the key travels and the secret never does. Covered by a compiler test.

## Changes

| | |
|---|---|
| `apps/server/.../custom-blocks/create/dto.ts` | new union member on `inputParamSchema` |
| `apps/portal/src/components/appConfig/AppConfigField.tsx` | **new** — dedicated key picker, `h-10` to match a HeroUI input, no literal mode |
| `apps/portal/.../integrations/AppConfigSelectorModal.tsx` | optional `extraItems`, for the injected `param:` entries |
| `apps/portal/.../integrations/AppConfigSelector.tsx` | comment on why the hybrid field owns the `cfg:` prefix and the modal stays bare-key |
| `apps/portal/.../canvas/panel/fields.tsx` | `BlockAppConfigField` + `useCustomBlockParamConfigs` |
| `apps/portal/.../CustomBlockSettings.tsx`, `customBlocks/InputParamsEditor.tsx` | render + author the new type |
| `testing/e2e/**` | jwt-ops drops its hardcoded secret; the runner seeds app config via `hydrateAppConfig` |

The new field is deliberately separate from `integrations/AppConfigSelector`: that one is a hybrid (literal *or* `cfg:` reference) and needs the prefix to tell them apart. This field has no literal mode — a literal is the thing the param type exists to remove — so it stores the bare key.

On a route canvas there is no caller to defer to, so the picker shows the project's real keys only, same rule as the integration selector.

## Not in scope

The AI harness still doesn't know the type exists — filed as #261, with a note on #232 about which of the two should land first.

## Checks

- `turbo run lint` clean across all 9 packages (pre-commit)
- `packages/blocks` `compilerCustomBlock.spec.ts` — 15/15, including the nested-chain test
- `testing/e2e` `jwtCustomBlock.test.ts` 10/10, `fixtures.test.ts` 13/13

🤖 Generated with [Claude Code](https://claude.com/claude-code)
