### PR TITLE
fix(harness): reject fan-out canvases, pre-load the JS API docs

### DIFF
--- a/apps/ai-gateway/src/db/vector.ts
+++ b/apps/ai-gateway/src/db/vector.ts
@@ -29,3 +29,26 @@ export async function queryDocs(query: string, limit: number = 5) {
 
 	return results.hits.map((hit) => hit.document as Document);
 }
+
+/**
+ * Fetch specific docs by their exact frontmatter title. Used to pre-load the
+ * handful of pages an agent always ends up searching for anyway — one lookup at
+ * prompt-build time instead of several tool round-trips mid-run.
+ */
+const byTitleCache = new Map<string, Document | null>();
+
+export async function getDocsByTitle(titles: string[]): Promise<Document[]> {
+	const docs: Document[] = [];
+	for (const title of titles) {
+		if (!byTitleCache.has(title)) {
+			const hits = await queryDocs(title, 5);
+			byTitleCache.set(
+				title,
+				hits.find((h) => h.title.toLowerCase() === title.toLowerCase()) ?? null,
+			);
+		}
+		const doc = byTitleCache.get(title);
+		if (doc) docs.push(doc);
+	}
+	return docs;
+}

--- a/apps/ai-gateway/src/harness/agents/discussion.ts
+++ b/apps/ai-gateway/src/harness/agents/discussion.ts
@@ -31,7 +31,7 @@ About Fluxify:
 - **Flexible Deployments**: Can be deployed as a Docker container, or in Kubernetes.
 
 Capabilities & Tools:
-1. "search_docs": Use this tool whenever the user asks about platform features, how a specific block works, or best practices. Pass a highly relevant keyword search query to retrieve documentation chunks.
+1. "search_docs": Use this tool whenever the user asks about platform features, how a specific block works, or best practices. Pass ALL the topics you need as one array of keyword queries ('searchQueries') in a SINGLE call — do not call it once per topic.
 2. "get_route_details": Use this tool *only when necessary* if the user asks about the current route (the graph in canvas) they are viewing or working on — skip it if the "Current context" block below already gives you the details you need.
 3. "find_resource": Use this tool to find tables, databases, or API blocks within the workspace when the user queries about them. It also returns a route's or custom block's current canvas (its live block graph) when you pass its id. If you already hold a resource's exact id, pass \`searchBy: "id"\` — the default keyword search matches names and descriptions and will never find an id. Skip it for the resource already named in "Current context" below.
 4. "get_artifact": Use this tool whenever the user asks what you built, changed, or implemented in an earlier run of this conversation ("what did you do in that route?", "why did you add that block?"). It returns the exact stored output of a past build.

--- a/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/agent.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/agent.ts
@@ -15,7 +15,9 @@ import {
 	createBlocksTable,
 	createSystemPrompt,
 	createUserQuery,
+	PREFETCH_DOC_TITLES,
 } from "./promptHelpers";
+import { getDocsByTitle } from "../../../../db/vector";
 
 export class BlockBuilderAgent extends BaseAgent {
 	constructor(state: GlobalGraphState) {
@@ -57,6 +59,25 @@ export class BlockBuilderAgent extends BaseAgent {
 			actual: plannedRouteIds[0],
 		});
 		return { ...result, targetId: plannedRouteIds[0] };
+	}
+
+	/**
+	 * Models like to echo `blockName`/`blockDescription` back inside `data`,
+	 * where they mean nothing to the block schemas and just double the tokens
+	 * on every canvas round-trip. Drop them — the real ones live on the block.
+	 */
+	private stripEchoedMetadata(response: z.infer<typeof blockBuilderSchema>) {
+		const clean = (block: { data?: Record<string, unknown> | null }) => {
+			if (!block?.data) return;
+			delete block.data.blockName;
+			delete block.data.blockDescription;
+			delete block.data.blockType;
+		};
+		response.blocks?.forEach(clean);
+		for (const change of response.canvasChanges ?? []) {
+			if (change.type === "block_change") change.data.blocksInfo.forEach(clean);
+		}
+		return response;
 	}
 
 	private replaceShortIds<T>(value: T, shortIdMap: Map<string, string>): T {
@@ -128,7 +149,10 @@ export class BlockBuilderAgent extends BaseAgent {
 		const projectId = this.state.internal?.metadata?.projectId || "NONE";
 		const customBlocksTable = await this.getCustomBlocksInfo(projectId);
 		const contextBlock = this.state.internal?.metadata?.contextBlock;
-		const systemPrompt = createSystemPrompt(customBlocksTable);
+		const prefetchedDocs = (await getDocsByTitle(PREFETCH_DOC_TITLES))
+			.map((doc) => doc.content)
+			.join("\n\n---\n\n");
+		const systemPrompt = createSystemPrompt(customBlocksTable, prefetchedDocs);
 		const userQuery = createUserQuery(activeTask);
 
 		const tools = [
@@ -164,7 +188,7 @@ export class BlockBuilderAgent extends BaseAgent {
 				.map((block) => [block.id, generateID()]),
 		);
 		const processedResponse = await this.reconcileRouteTarget(
-			this.replaceShortIds(response, shortIdMap),
+			this.replaceShortIds(this.stripEchoedMetadata(response), shortIdMap),
 			projectId,
 		);
 

--- a/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/graphRules.spec.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/graphRules.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "bun:test";
+import { validateGraphRules } from "./graphRules";
+
+const block = (
+	id: string,
+	blockType: string,
+	connections: Array<{ blockId: string; handle?: string }> = [],
+) => ({ id, blockType, connections });
+
+describe("validateGraphRules", () => {
+	it("rejects two edges hanging off one handle", () => {
+		const errors = validateGraphRules([
+			block("a", "entrypoint", [{ blockId: "b" }, { blockId: "c" }]),
+		]);
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain("fans out");
+	});
+
+	it("allows an if block's two branch handles", () => {
+		expect(
+			validateGraphRules([
+				block("a", "if", [
+					{ blockId: "b", handle: "success" },
+					{ blockId: "c", handle: "failure" },
+				]),
+			]),
+		).toEqual([]);
+	});
+
+	it("allows a loop's source and executor", () => {
+		expect(
+			validateGraphRules([
+				block("a", "forloop", [
+					{ blockId: "b", handle: "source" },
+					{ blockId: "c", handle: "executor" },
+				]),
+			]),
+		).toEqual([]);
+	});
+
+	it("rejects a handle the block type does not have", () => {
+		const errors = validateGraphRules([
+			block("a", "httprequest", [{ blockId: "b", handle: "success" }]),
+		]);
+		expect(errors[0]).toContain('has no "success" handle');
+	});
+
+	it("rejects an outgoing edge on a terminal block", () => {
+		const errors = validateGraphRules([
+			block("a", "response", [{ blockId: "b" }]),
+		]);
+		expect(errors[0]).toContain("terminal block");
+	});
+
+	it("rejects duplicate entrypoints and duplicate block ids", () => {
+		const errors = validateGraphRules([
+			block("a", "entrypoint"),
+			block("b", "entrypoint"),
+			block("b", "setvar"),
+		]);
+		expect(errors.some((e) => e.includes("defined more than once"))).toBe(true);
+		expect(errors.some((e) => e.includes('exactly one "entrypoint"'))).toBe(true);
+	});
+
+	it("treats custom blocks as a single source handle", () => {
+		expect(
+			validateGraphRules([block("a", "custom:send_email", [{ blockId: "b" }])]),
+		).toEqual([]);
+		expect(
+			validateGraphRules([
+				block("a", "custom:send_email", [
+					{ blockId: "b", handle: "executor" },
+				]),
+			])[0],
+		).toContain('has no "executor" handle');
+	});
+});

--- a/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/graphRules.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/graphRules.ts
@@ -1,0 +1,82 @@
+import { BlockTypes, getOutputHandles } from "@fluxify/blocks";
+import type { ValidatableBlock } from "./schemas";
+
+const SINGLETON_TYPES = [BlockTypes.entrypoint, BlockTypes.errorHandler];
+
+/**
+ * The runtime resolves an edge with `findEdge(block, handle)`, which takes the
+ * first match and drops the rest — so two edges on one handle is a silently
+ * halved workflow, not a parallel branch. It also never asks for a handle a
+ * block type does not have, so an edge on an invented handle is simply never
+ * traversed. Neither shows up as an error at apply time; both show up as a
+ * route that quietly does less than the user asked for.
+ */
+export function validateGraphRules(blocks: ValidatableBlock[]): string[] {
+	const errors: string[] = [];
+	const seenIds = new Set<string>();
+	const singletonCounts = new Map<string, string[]>();
+
+	for (const block of blocks) {
+		if (!block?.id) continue;
+
+		if (seenIds.has(block.id)) {
+			errors.push(
+				`Block "${block.id}" is defined more than once. Each block must appear exactly once, either in "blocks" or in a "block_change", never both.`,
+			);
+			continue;
+		}
+		seenIds.add(block.id);
+
+		const rawType = block.blockType || "";
+		if (SINGLETON_TYPES.includes(rawType as BlockTypes)) {
+			singletonCounts.set(rawType, [
+				...(singletonCounts.get(rawType) ?? []),
+				block.id,
+			]);
+		}
+
+		const isCustom =
+			rawType.startsWith("custom:") ||
+			!Object.values(BlockTypes).includes(rawType as BlockTypes);
+		// custom blocks are a plain pass-through: one `source` handle
+		const allowed = isCustom ? ["source"] : getOutputHandles(rawType);
+		const usedHandles = new Map<string, string[]>();
+
+		for (const conn of block.connections ?? []) {
+			if (!conn?.blockId) continue;
+			const handle = conn.handle || "source";
+
+			if (!allowed.includes(handle)) {
+				errors.push(
+					allowed.length === 0
+						? `Block "${block.id}" of type "${rawType}" is a terminal block and has no output handles, but it connects to "${conn.blockId}". Remove the connection.`
+						: `Block "${block.id}" of type "${rawType}" has no "${handle}" handle. Its only output handle(s): ${allowed.map((h) => `"${h}"`).join(", ")}.`,
+				);
+				continue;
+			}
+
+			usedHandles.set(handle, [
+				...(usedHandles.get(handle) ?? []),
+				conn.blockId,
+			]);
+		}
+
+		for (const [handle, targets] of usedHandles) {
+			if (targets.length > 1) {
+				errors.push(
+					`Block "${block.id}" fans out: its "${handle}" handle connects to ${targets.length} blocks (${targets.map((t) => `"${t}"`).join(", ")}). The runtime follows only the first and silently drops the rest. Each handle must have at most ONE outgoing connection — chain the blocks in sequence instead, or use an "if" block whose "success"/"failure" handles are the branches.`,
+				);
+			}
+		}
+	}
+
+	for (const [type, ids] of singletonCounts) {
+		if (ids.length > 1) {
+			errors.push(
+				`A canvas may contain exactly one "${type}" block, but ${ids.length} were provided (${ids.map((i) => `"${i}"`).join(", ")}). Keep one and remove the rest.`,
+			);
+		}
+	}
+
+	return errors;
+}

--- a/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/promptHelpers.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/promptHelpers.ts
@@ -24,7 +24,23 @@ export const BUILTIN_BLOCKS_TABLE = createBlocksTable(
 	})),
 );
 
-export function createSystemPrompt(customBlocksTable: string): string {
+/**
+ * Docs the block builder searched for on nearly every run \u2014 the JS API it has
+ * to write against, and the execution model that decides what a legal edge is.
+ * Pre-loading them costs a fixed ~3k prompt tokens and removes several
+ * sequential tool round-trips per run, which is where the wall-clock went.
+ */
+export const PREFETCH_DOC_TITLES = [
+	"How Blocks Work",
+	"JavaScript API Reference",
+	"Scripting Context",
+	"Key Considerations & Common Pitfalls",
+];
+
+export function createSystemPrompt(
+	customBlocksTable: string,
+	prefetchedDocs: string,
+): string {
 	return `You are the Block Builder Agent for Fluxify \u2014 an Agentic Low Code Backend Development Platform.
 Your responsibility is to build and modify the canvas of a workflow DAG, which consists of various blocks (nodes) connected by edges. You are capable of building the canvas for both Routes and Custom Blocks. The task description will define what you are editing.
 
@@ -57,16 +73,26 @@ ${customBlocksTable}
    - Vertical spacing between parallel/branching blocks: ~72 units (48 height + 24 gap).
    - Start new nodes to the right of the rightmost existing node in the canvas.
 
-4. **Connections**:
-   - Use the 'connections' array to define edges.
-   - Standard blocks use handle type: 'source' (right side) connecting to 'target' (left side of the next block).
-   - Control blocks with a body/loop (ForLoop, ForEach, Transaction) additionally have an 'executor' handle (top side) for their inner block chain.
-   - The 'if' block additionally has 'success' and 'failure' handles (right side) instead of 'source'.
-   - Connect new blocks to the existing canvas logic.
+4. **Connections — how the runtime actually walks the graph**:
+   At request time the engine resolves each step by asking a block for the single edge on a named handle. It takes the FIRST edge it finds on that handle and ignores every other edge on it. There is no parallel execution and no fan-out.
+
+   - **ONE outgoing edge per handle. No exceptions.** If you put two connections on a block's 'source' handle, only one branch ever runs and the other is silently discarded — the route will quietly do less than the user asked for. This is the single most common way this agent produces a broken canvas.
+   - **Never converge two branches by pointing them at the same block and expecting them to merge.** Each branch runs to its own terminal block.
+   - Handles available per block type — using any other handle name means the edge is never traversed:
+     | Block type | Output handles |
+     | --- | --- |
+     | 'if' | 'success', 'failure' (NO 'source') |
+     | 'forloop', 'foreachloop', 'db_transaction' | 'source' (continues after the loop) and 'executor' (the inner chain, one edge) |
+     | 'response', 'sticky_note' | none — terminal, must have \`"connections": []\` |
+     | every other built-in block, and all custom blocks | 'source' only |
+   - **Branching is only ever expressed with an 'if' block**, whose 'success' and 'failure' handles are the two branches. If you need to do two things, chain them one after the other — blocks pass their output forward, so sequential is almost always what the user meant.
+   - The graph must be acyclic: never connect a block back to itself or to any upstream block.
+   - Connect new blocks to the existing canvas logic; every non-terminal block you add must be reachable from the entrypoint.
 
 5. **Data Filling**:
    - Use available Integrations/Configs for authentication fields.
-   - For JavaScript expressions, use the following syntax: js:expression. Search docs for more info about js expressions. Previous block's output is available in 'input' global variable.
+   - For JavaScript expressions, use the syntax \`js:<expression>\`. The previous block's output is in the \`input\` global. The full JavaScript API is pre-loaded below under "Platform Reference" — write your JS against it and do NOT search the docs for it.
+   - Never put \`blockName\`, \`blockDescription\` or \`blockType\` inside \`data\`. They belong on the block object itself; repeating them in \`data\` is invalid.
 
 6. **Canvas Modifications (canvasChanges)**:
    When modifying an existing canvas (non-empty), use the 'canvasChanges' array to express changes to **existing** items.
@@ -88,7 +114,7 @@ ${customBlocksTable}
    - Specify whether the canvas belongs to a \`route\` or \`custom_block\` in the \`targetType\` field.
    - Provide the exact ID in the \`targetId\` field.
 
-8. **Tools**: Use the 'search_docs' tool to understand specific block capabilities and how to write Javascript expressions. Use 'find_resource' to lookup integrations and existing route/custom block canvas (metadata.isNewRoute=true for new routes) — skip this for the canvas already summarized in "Current context" below. When the task description already gives you a resource's exact ID, pass \`searchBy: "id"\`; the default keyword search will not find an ID. Use 'get_block_schemas' to fetch configuration schemas for any blocks you plan to use. Use 'get_agent_output' to fetch the configuration of a newly created route or custom block from a previous agent's output if it's not yet saved in the DB (the task description will provide the task IDs).
+8. **Tools**: Everything about the execution model and the JavaScript API is already in "Platform Reference" below — do NOT call 'search_docs' for scripting, \`js:\` expressions, \`input\`, variables, or how blocks execute. Use 'search_docs' only for a platform feature not covered there, and when you do, pass ALL your topics in ONE call ('searchQueries' is an array) rather than calling it repeatedly. Use 'find_resource' to lookup integrations and existing route/custom block canvas (metadata.isNewRoute=true for new routes) — skip this for the canvas already summarized in "Current context" below. When the task description already gives you a resource's exact ID, pass \`searchBy: "id"\`; the default keyword search will not find an ID. Use 'get_block_schemas' to fetch configuration schemas for any blocks you plan to use. Use 'get_agent_output' to fetch the configuration of a newly created route or custom block from a previous agent's output if it's not yet saved in the DB (the task description will provide the task IDs).
 
 ### Output Contract
 
@@ -116,6 +142,10 @@ Use these exact property names — do not rename or omit them:
 - The block's type goes in \`blockType\` (NOT \`type\`).
 - \`connections\` and \`canvasChanges\` are always present — use \`[]\` when empty.
 - Set \`status\` to 'impossible' (with a short \`reasoning\`) only when the canvas genuinely cannot be built.
+
+### Platform Reference (pre-loaded — do not search for any of this)
+
+${prefetchedDocs}
 
 The orchestrator will apply the configuration after supervisor approval. Keep your reasoning concise.`;
 }

--- a/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/schemas.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/schemas.ts
@@ -27,7 +27,9 @@ export const BlockSchema = z.object({
 	data: z
 		.record(z.string(), z.unknown())
 		.nullish()
-		.describe("Configuration payload specific to the block type."),
+		.describe(
+			"Configuration payload specific to the block type, matching that block's schema exactly. Do NOT repeat blockName, blockDescription or blockType in here — they belong on the block itself.",
+		),
 	position: z
 		.object({
 			x: z.number().describe("Horizontal coordinate on the canvas."),
@@ -38,7 +40,7 @@ export const BlockSchema = z.object({
 		.array(ConnectionSchema)
 		.default([])
 		.describe(
-			"List of downstream connections from this block (empty for terminal blocks).",
+			"Downstream connections from this block, at most ONE per handle. Empty for terminal blocks. Never connect the same handle to two blocks: the runtime follows only the first and drops the rest. Branch with an 'if' block instead.",
 		),
 });
 

--- a/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/validator.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/validator.ts
@@ -1,6 +1,7 @@
 import { builtinBlockSchemas, BlockTypes } from "@fluxify/blocks";
 import type { AgentOutputValidator } from "../../../types";
 import { detectCycles } from "./cycleDetector";
+import { validateGraphRules } from "./graphRules";
 import type { BlockBuilderResult, ValidatableBlock } from "./schemas";
 
 /** Storage stores these exact strings — anything else is a broken canvas. */
@@ -206,7 +207,7 @@ export const validateBlockBuilderOutput: AgentOutputValidator = async (
 			);
 	}
 
-	const errors: string[] = [];
+	const errors: string[] = validateGraphRules(blocksToValidate);
 	for (const block of blocksToValidate) {
 		errors.push(...validateBlockAgainstSchemas(block, customBlockSchemasMap));
 	}

--- a/apps/ai-gateway/src/harness/agents/sub-agents/routeConfig.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/routeConfig.ts
@@ -131,7 +131,7 @@ Fluxify uses a specific JSON format for schemas. DO NOT output standard JSON Sch
 
 ## Instructions
 1. Analyze the assigned task to understand the exact route modifications required.
-2. If you need to search for documentation about Javascript APIs, Scripting, or other Fluxify concepts, use the \`search_docs\` tool provided to you.
+2. If you need to search for documentation about Javascript APIs, Scripting, or other Fluxify concepts, use the \`search_docs\` tool provided to you — pass every topic you need as one array of queries in a SINGLE call, not one call per topic.
 3. If you need to know the details of an existing route configuration to perform an update or deletion, use the \`get_route_details\` tool provided to you — unless the "Current context" block below already describes that exact route.
 4. Determine if the action is \`create\`, \`delete\`, or \`update-partial\`.
 5. If creating or updating a route, define the \`name\`, \`method\`, \`path\`, and relevant schemas in the \`data\` object.

--- a/apps/ai-gateway/src/harness/tools/searchDocs.ts
+++ b/apps/ai-gateway/src/harness/tools/searchDocs.ts
@@ -3,6 +3,9 @@ import { z } from "zod";
 import { logger } from "@fluxify/common";
 import { queryDocs } from "../../db/vector";
 
+/** ponytail: flat cap — one agent turn never legitimately needs more topics. */
+const MAX_QUERIES_PER_CALL = 5;
+
 async function performDocsSearch(
 	searchQuery: string,
 	limit: number = 3,
@@ -17,18 +20,34 @@ async function performDocsSearch(
 }
 
 export const searchDocsTool = fencedTool(
-	async ({ searchQuery }) => {
-		logger.info(`[Tools] Searching docs for: ${searchQuery}`);
-		return await performDocsSearch(searchQuery);
+	async ({ searchQueries }) => {
+		// One tool call per keyword meant one model round-trip per keyword, and
+		// the agents reliably needed four or five. Batching collapses that into
+		// a single round-trip.
+		const queries = [...new Set(searchQueries)].slice(0, MAX_QUERIES_PER_CALL);
+		logger.info(`[Tools] Searching docs for: ${queries.join(" | ")}`);
+
+		const sections = await Promise.all(
+			queries.map(async (query) => {
+				const seen = new Set<string>();
+				const content = await performDocsSearch(query);
+				return seen.has(content) ? "" : `## Results for "${query}"\n\n${content}`;
+			}),
+		);
+
+		return sections.filter(Boolean).join("\n\n===\n\n");
 	},
 	{
 		name: "search_docs",
 		description:
-			"Search the platform documentation using keywords. Use relevant terms for e.g. if user asks about filters, use keyword filter/filters.",
+			`Search the platform documentation. Pass ALL the topics you need in one call — batching is far cheaper than calling this repeatedly. Use relevant keywords, e.g. for filters use "filter". At most ${MAX_QUERIES_PER_CALL} queries per call.`,
 		schema: z.object({
-			searchQuery: z
-				.string()
-				.describe("The keywords to find relevant documentation."),
+			searchQueries: z
+				.array(z.string())
+				.min(1)
+				.describe(
+					`Keywords to look up, one entry per topic (e.g. ["js expressions", "http request block"]). At most ${MAX_QUERIES_PER_CALL}.`,
+				),
 		}),
 	},
 );

--- a/packages/blocks/blockHandles.ts
+++ b/packages/blocks/blockHandles.ts
@@ -1,0 +1,24 @@
+import { BlockTypes } from "./blockTypes";
+
+/**
+ * Which output handles each block type actually exposes.
+ *
+ * Mirrors the `findEdge(block, <handle>, edgesMap)` calls in `blockFactory.ts`.
+ * `findEdge` takes the FIRST edge matching a handle and silently discards the
+ * rest, so a handle carrying two edges is not a parallel branch — it is one
+ * branch plus a dropped one. Anything building a graph must treat a handle as
+ * holding at most one edge, and must not invent handles a block does not have.
+ */
+export const BLOCK_OUTPUT_HANDLES: Record<string, readonly string[]> = {
+	[BlockTypes.if]: ["success", "failure"],
+	[BlockTypes.forloop]: ["source", "executor"],
+	[BlockTypes.foreachloop]: ["source", "executor"],
+	[BlockTypes.db_transaction]: ["source", "executor"],
+	// terminal — the runtime never looks for an outgoing edge
+	[BlockTypes.response]: [],
+	[BlockTypes.sticky_note]: [],
+};
+
+/** Handles for a block type; everything not listed above is a plain `source`. */
+export const getOutputHandles = (blockType: string): readonly string[] =>
+	BLOCK_OUTPUT_HANDLES[blockType] ?? ["source"];

--- a/packages/blocks/index.ts
+++ b/packages/blocks/index.ts
@@ -13,6 +13,7 @@ export * from "./compiler";
 export * from "./builtin/customBlock";
 export * from "./jobs";
 export * from "./blockTypes";
+export * from "./blockHandles";
 export * from "./baseBlock";
 export * from "./categories";
 export * from "./builtin/getVar";


### PR DESCRIPTION
Closes #236.

## Why

The runtime resolves each step with `findEdge(block, handle)` in `blockFactory.ts`, which takes the **first** edge on a handle and silently discards the rest. So when the block builder hangs two edges off one `source` handle, it is not building a parallel branch — it is building one branch plus a dropped one, and the run still reports success. The verifier never inspected handles at all, so it went straight to the artifact as valid.

Two related problems shipped in the same canvas: the agent guessed at the JS runtime API because nothing it could read documented it, and it burned several sequential `search_docs` round-trips per run rediscovering the same four pages.

## What

**Fan-out (#236.1, #236.2)**
- `packages/blocks/blockHandles.ts` — the handle registry, living next to `blockFactory.ts` so the two stay in sync: `if` → `success`/`failure`, loops and transactions → `source`/`executor`, `response`/`sticky_note` → terminal, everything else → `source`.
- `blockBuilder/graphRules.ts` — rejects a handle carrying more than one edge, a handle the block type does not have, an outgoing edge on a terminal block, a block id defined twice across `blocks` and `block_change`, and a second `entrypoint`/`error_handler`. Runs in the existing validator alongside the cycle check.
- Prompt rule 4 replaced with the actual execution model plus a per-type handle table; the `connections` schema description carries the one-edge rule as well, so the constraint reaches the model through both channels.

**JS API documentation (#236.3)**
- The block builder now pre-loads *How Blocks Work*, *JavaScript API Reference*, *Scripting Context* and *Key Considerations & Common Pitfalls* into its system prompt via `getDocsByTitle` (cached per process), and is explicitly told not to search for scripting topics.

**Round-trips**
- `search_docs` takes `searchQueries: string[]` instead of a single string — the agents reliably needed four or five topics and were paying a full model round-trip for each. All three prompts that mention the tool were updated.

**Token waste**
- `stripEchoedMetadata` drops `blockName`/`blockDescription`/`blockType` echoed back inside `data`, where they mean nothing to the block schemas and double the payload on every canvas round-trip. The schema `describe()` also now tells the model not to emit them.

## Testing

`graphRules.spec.ts` covers each new rule (fan-out rejected, `if`/loop handles allowed, invented handle rejected, terminal-block edge rejected, duplicate ids and duplicate entrypoints rejected, custom blocks treated as single-`source`). `bun test src/harness` — 127 pass, 0 fail. `turbo run lint` clean.

## Note

This fix is "do not fan out". #237 is where fan-out becomes something an agent is allowed to build, with a declared branch count and one join point — `blockHandles.ts` is the registry that work will extend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)