### PR TITLE
feat(harness): custom block builder, plus apply-path and run-durability fixes

### DIFF
--- a/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/applyBatch.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/applyBatch.ts
@@ -1,0 +1,234 @@
+import { NotFoundError } from "@fluxify/server";
+import {
+	canvasChangesFromPayload,
+	type BlockBuilderPayload,
+} from "./normalize";
+import { callerFor } from "./opsClient";
+import {
+	getArtifactSubArtifacts,
+	markSubArtifactsApplied,
+} from "./repository";
+import {
+	announce,
+	applyCanvasRow,
+	applyCustomBlockRow,
+	applyRouteRow,
+	assertParentRoutesReady,
+	customBlockIdOf,
+	describeFailure,
+	EMPTY_CANVAS,
+	parentRouteIdOf,
+	rememberRealRouteId,
+	resolveCanvasTarget,
+	routeIdOf,
+	type ApplyContext,
+	type ApplyFailure,
+	type DependencyRow,
+	type LabelledRow,
+} from "./service";
+
+/**
+ * Pairs each newly-created parent row with the canvas built for it in the same
+ * run, so the canvas rides inside the create and the parent never exists
+ * without its blocks. Routes and custom blocks differ only in how their id is
+ * read off the payload.
+ */
+function pairInlineCanvases<R extends { id: string; payload?: any }, C extends { id: string; payload?: any }>(
+	parents: R[],
+	canvases: C[],
+	targetType: "route" | "custom_block",
+	idOf: (row: R) => string | undefined,
+	inlineCanvas: Map<string, C>,
+	inlined: Set<string>,
+) {
+	for (const parent of parents) {
+		if (parent.payload?.action !== "create") continue;
+		const paired = canvases.find(
+			(c) =>
+				!inlined.has(c.id) &&
+				c.payload?.targetType === targetType &&
+				c.payload?.targetId === idOf(parent),
+		);
+		if (!paired) continue;
+		inlineCanvas.set(parent.id, paired);
+		inlined.add(paired.id);
+	}
+}
+
+/**
+ * Applies every route (or custom block) row, each on its own so one bad output
+ * cannot abort the batch. Both kinds follow the identical shape: apply the
+ * parent with its inlined canvas, record the real id the DB handed back onto
+ * that canvas, and on failure mark the pair unapplied and re-appliable.
+ */
+async function applyParentRows<R extends LabelledRow & { payload?: any }, C extends LabelledRow & { payload?: any }>(
+	ctx: ApplyContext,
+	parents: R[],
+	opts: {
+		inlineCanvas: Map<string, C>;
+		apply: (ctx: ApplyContext, row: R, changes?: any) => Promise<unknown>;
+		idOf: (row: R) => string | undefined;
+		realIds: Map<string, string>;
+		pairedFailure: string;
+		onFailure?: (id: string) => void;
+		done: string[];
+		failures: ApplyFailure[];
+		conversationId: string;
+	},
+) {
+	for (const parent of parents) {
+		const canvasRow = opts.inlineCanvas.get(parent.id);
+		try {
+			await opts.apply(
+				ctx,
+				parent,
+				canvasRow
+					? canvasChangesFromPayload(
+							(canvasRow.payload ?? {}) as BlockBuilderPayload,
+							EMPTY_CANVAS,
+						)
+					: undefined,
+			);
+			opts.done.push(parent.id);
+			if (canvasRow) {
+				const real = opts.realIds.get(opts.idOf(parent) ?? "");
+				if (real)
+					await rememberRealRouteId(
+						opts.conversationId,
+						canvasRow,
+						"targetId",
+						real,
+					);
+				opts.done.push(canvasRow.id);
+			}
+		} catch (error) {
+			const id = opts.idOf(parent);
+			if (id) opts.onFailure?.(id);
+			opts.failures.push(describeFailure(parent, error));
+			// The canvas rode along inside the create, so it did not land either.
+			if (canvasRow)
+				opts.failures.push(describeFailure(canvasRow, opts.pairedFailure));
+		}
+	}
+}
+
+export async function applyArtifact(
+	userId: string,
+	conversationId: string,
+	projectId: string,
+	artifactId: string,
+) {
+	const rows = await getArtifactSubArtifacts(conversationId, artifactId);
+	if (rows.length === 0) throw new NotFoundError("Artifact not found");
+
+	const routes = rows.filter((r) => r.kind === "route");
+	const customBlocks = rows.filter((r) => r.kind === "custom_block");
+	const canvases = await Promise.all(
+		rows
+			.filter((r) => r.kind === "canvas")
+			.map((r) => resolveCanvasTarget(conversationId, projectId, r, rows)),
+	);
+	// `rest` is stamped applied unconditionally at the end, so every kind that
+	// has its own apply path must be excluded — a custom block left in here was
+	// marked applied even when its create had just failed.
+	const rest = rows.filter(
+		(r) => r.kind !== "route" && r.kind !== "canvas" && r.kind !== "custom_block",
+	);
+
+	// Routes go first, so a canvas referencing a route this run created is
+	// already satisfied by the time its turn comes.
+	const applyingRouteIds = new Set(
+		routes.map(routeIdOf).filter((id): id is string => !!id),
+	);
+	await assertParentRoutesReady(projectId, canvases, routes, applyingRouteIds);
+
+	const ctx: ApplyContext = {
+		conversationId,
+		projectId,
+		caller: callerFor(userId, projectId),
+		routeIds: new Map(),
+		customBlockIds: new Map(),
+	};
+
+	// A canvas for a route this run is creating rides along with the create, so
+	// the route never exists without its blocks.
+	const inlineCanvas = new Map<string, (typeof canvases)[number]>();
+	const inlined = new Set<string>();
+	pairInlineCanvases(routes, canvases, "route", routeIdOf, inlineCanvas, inlined);
+	pairInlineCanvases(
+		customBlocks,
+		canvases,
+		"custom_block",
+		customBlockIdOf,
+		inlineCanvas,
+		inlined,
+	);
+
+	const ordered = [...routes, ...customBlocks, ...canvases, ...rest];
+	const done: string[] = [];
+	// One bad output used to abort the whole batch, so a run that got nine
+	// things right and one wrong left the user with nine unapplied outputs and
+	// no idea which one was the problem. Each output is applied on its own now;
+	// what fails stays unapplied and re-appliable, and is named in the result.
+	const failures: ApplyFailure[] = [];
+	/** Routes that did not land — their canvases have nothing to attach to. */
+	const failedRouteIds = new Set<string>();
+
+	await applyParentRows(ctx, routes, {
+		inlineCanvas,
+		apply: applyRouteRow,
+		idOf: routeIdOf,
+		realIds: ctx.routeIds,
+		pairedFailure: "its route could not be created",
+		// A canvas whose route never landed has nothing to attach to.
+		onFailure: (id) => failedRouteIds.add(id),
+		done,
+		failures,
+		conversationId,
+	});
+	await applyParentRows(ctx, customBlocks, {
+		inlineCanvas,
+		apply: applyCustomBlockRow,
+		idOf: customBlockIdOf,
+		realIds: ctx.customBlockIds,
+		pairedFailure: "its custom block could not be created",
+		done,
+		failures,
+		conversationId,
+	});
+
+	for (const canvas of canvases) {
+		if (inlined.has(canvas.id)) continue;
+		const parentRouteId = parentRouteIdOf(canvas as DependencyRow);
+		if (parentRouteId && failedRouteIds.has(parentRouteId)) {
+			failures.push(describeFailure(canvas, "its route could not be created"));
+			continue;
+		}
+		try {
+			await applyCanvasRow(ctx, canvas);
+			done.push(canvas.id);
+		} catch (error) {
+			failures.push(describeFailure(canvas, error));
+		}
+	}
+	done.push(...rest.map((r) => r.id));
+
+	const appliedAt = new Date();
+	if (done.length > 0) await markSubArtifactsApplied(conversationId, done, appliedAt);
+
+	const failedById = new Map(failures.map((f) => [f.id, f]));
+	for (const row of ordered) {
+		const failure = failedById.get(row.id);
+		if (!failure && !done.includes(row.id)) continue;
+		announce(userId, conversationId, row, failure);
+	}
+
+	return {
+		artifactId,
+		appliedAt,
+		applied: ordered
+			.filter((r) => done.includes(r.id))
+			.map((r) => ({ id: r.id, kind: r.kind, action: r.action })),
+		failed: failures,
+	};
+}

--- a/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/normalize.spec.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/normalize.spec.ts
@@ -1,11 +1,52 @@
 import { describe, expect, it } from "bun:test";
 import {
 	canvasChangesFromPayload,
+	customBlockOpFromPayload,
 	routeOpFromPayload,
 	type CanvasItems,
 } from "./normalize";
 
 const EMPTY: CanvasItems = { blocks: [], edges: [] };
+
+describe("customBlockOpFromPayload", () => {
+	// The agent schema is `.nullish()`, the server DTO `.optional()`, and
+	// `.optional()` rejects null — a leaked null came back as "Malformed
+	// operation" from the bus.
+	it("drops nulls inside inputParams, not just at the top level", () => {
+		const op = customBlockOpFromPayload(
+			{
+				action: "create",
+				data: {
+					name: "send_notification",
+					label: "Send Notification",
+					description: null,
+					inputParams: [
+						{ type: "text_input", name: "to", label: "To", description: null },
+						{
+							type: "integration_selector",
+							name: "conn",
+							label: "Connection",
+							group: "email",
+							variant: null,
+							tags: [],
+						},
+					],
+				},
+			},
+			"proj-1",
+		);
+
+		expect(op.action).toBe("create");
+		const params = (op as { data: { inputParams: Record<string, unknown>[] } })
+			.data.inputParams;
+		for (const param of params) {
+			for (const [key, value] of Object.entries(param)) {
+				expect(`${key}=${value}`).not.toBe(`${key}=null`);
+				expect(value).not.toBeNull();
+			}
+		}
+	});
+});
 
 describe("routeOpFromPayload", () => {
 	it("turns a create output into the ops create request", () => {

--- a/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/normalize.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/normalize.ts
@@ -143,10 +143,17 @@ export function customBlockOpFromPayload(
 		if (!payload.customBlockId) throw new Error("Custom block delete output has no customBlockId");
 		return { action: "delete" as const, id: payload.customBlockId };
 	}
+	// `compact` is shallow. The agent schema declares each param's `description`
+	// and `variant` as `.nullish()`, the server DTO as `.optional()` — and
+	// `.optional()` rejects null. An emitted `description: null` therefore rode
+	// through to the bus and came back as "Malformed operation".
+	const inputParams = data.inputParams?.map((param) =>
+		compact((param ?? {}) as Record<string, unknown>),
+	);
 	const common = compact({
 		label: data.label?.trim(),
 		description: data.description?.trim(),
-		inputParams: data.inputParams,
+		inputParams,
 	});
 	if (action === "update-partial") {
 		if (!payload.customBlockId) throw new Error("Custom block update output has no customBlockId");
@@ -157,7 +164,7 @@ export function customBlockOpFromPayload(
 	}
 	return {
 		action: "create" as const,
-		data: { ...common, name: data.name, projectId, inputParams: data.inputParams ?? [] },
+		data: { ...common, name: data.name, projectId, inputParams: inputParams ?? [] },
 	};
 }
 

--- a/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/normalize.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/normalize.ts
@@ -63,6 +63,17 @@ export type RouteConfigPayload = {
 	} | null;
 };
 
+export type CustomBlockConfigPayload = {
+	action?: "create" | "delete" | "update-partial";
+	customBlockId?: string | null;
+	data?: {
+		name?: string | null;
+		label?: string | null;
+		description?: string | null;
+		inputParams?: unknown[] | null;
+	} | null;
+};
+
 /* ------------------------------------------------------------------ routes */
 
 function normalizePath(path: string) {
@@ -119,6 +130,34 @@ export function routeOpFromPayload(payload: RouteConfigPayload, projectId: strin
 				paramsSchema: data.paramsSchema,
 			}),
 		},
+	};
+}
+
+export function customBlockOpFromPayload(
+	payload: CustomBlockConfigPayload,
+	projectId: string,
+) {
+	const action = payload.action ?? "create";
+	const data = payload.data ?? {};
+	if (action === "delete") {
+		if (!payload.customBlockId) throw new Error("Custom block delete output has no customBlockId");
+		return { action: "delete" as const, id: payload.customBlockId };
+	}
+	const common = compact({
+		label: data.label?.trim(),
+		description: data.description?.trim(),
+		inputParams: data.inputParams,
+	});
+	if (action === "update-partial") {
+		if (!payload.customBlockId) throw new Error("Custom block update output has no customBlockId");
+		return { action: "modify" as const, id: payload.customBlockId, data: common };
+	}
+	if (!data.name?.match(/^[a-z0-9_]+$/)) {
+		throw new Error("Custom block create output requires lowercase snake_case name");
+	}
+	return {
+		action: "create" as const,
+		data: { ...common, name: data.name, projectId, inputParams: data.inputParams ?? [] },
 	};
 }
 

--- a/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/opsClient.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/opsClient.ts
@@ -89,6 +89,34 @@ export function deleteRoute(caller: RpcCaller, id: string) {
 	return call<{ id: string }>(RPC_SUBJECTS.route, caller, { action: "delete", id });
 }
 
+export function createCustomBlock(
+	caller: RpcCaller,
+	data: Record<string, unknown>,
+	canvas?: CanvasChanges,
+) {
+	return call<{ id: string }>(RPC_SUBJECTS.customBlock, caller, {
+		action: "create",
+		data,
+		canvas,
+	});
+}
+
+export function modifyCustomBlock(
+	caller: RpcCaller,
+	id: string,
+	data: Record<string, unknown>,
+) {
+	return call<{ id: string }>(RPC_SUBJECTS.customBlock, caller, {
+		action: "modify",
+		id,
+		data,
+	});
+}
+
+export function deleteCustomBlock(caller: RpcCaller, id: string) {
+	return call<{ id: string }>(RPC_SUBJECTS.customBlock, caller, { action: "delete", id });
+}
+
 /** Omitting both change fields is a read — that is how the subject is defined. */
 export function readCanvas(
 	caller: RpcCaller,

--- a/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/route.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/route.ts
@@ -8,11 +8,11 @@ import {
 	subArtifactParamsSchema,
 } from "./dto";
 import {
-	applyArtifact,
 	applySubArtifact,
 	getSubArtifact,
 	listRunSubArtifacts,
 } from "./service";
+import { applyArtifact } from "./applyBatch";
 
 export default function (app: Hono) {
 	app.get(

--- a/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/service.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/service.ts
@@ -33,7 +33,7 @@ import {
 } from "./repository";
 
 /** The subset of a sub-artifact row the dependency check reads. */
-interface DependencyRow {
+export interface DependencyRow {
 	id: string;
 	kind: string;
 	action: string | null;
@@ -42,17 +42,17 @@ interface DependencyRow {
 }
 
 /** The route a `kind: "route"` output creates or edits. */
-const routeIdOf = (row: DependencyRow) => row.payload?.routeId as string | undefined;
-const customBlockIdOf = (row: DependencyRow) => row.payload?.customBlockId as string | undefined;
+export const routeIdOf = (row: DependencyRow) => row.payload?.routeId as string | undefined;
+export const customBlockIdOf = (row: DependencyRow) => row.payload?.customBlockId as string | undefined;
 
 /** The route a `kind: "canvas"` output hangs its blocks off. Canvases targeting a
  *  custom block have no route dependency, so they are not gated. */
-const parentRouteIdOf = (row: DependencyRow) =>
+export const parentRouteIdOf = (row: DependencyRow) =>
 	row.payload?.targetType === "route"
 		? (row.payload?.targetId as string | undefined)
 		: undefined;
 
-const EMPTY_CANVAS: CanvasItems = { blocks: [], edges: [] };
+export const EMPTY_CANVAS: CanvasItems = { blocks: [], edges: [] };
 
 /** One output that did not land, and why. */
 export interface ApplyFailure {
@@ -63,7 +63,7 @@ export interface ApplyFailure {
 	reason: string;
 }
 
-type LabelledRow = {
+export type LabelledRow = {
 	id: string;
 	kind: string;
 	action?: string | null;
@@ -119,7 +119,7 @@ const LIFECYCLE: Record<string, ArtifactStatus["event"]> = {
  * same thing happening, and the only place that knows the resolved name and
  * path is right here, where the payload is in hand.
  */
-function announce(
+export function announce(
 	userId: string,
 	conversationId: string,
 	row: LabelledRow,
@@ -139,7 +139,7 @@ function announce(
 	});
 }
 
-function describeFailure(row: LabelledRow, error: unknown): ApplyFailure {
+export function describeFailure(row: LabelledRow, error: unknown): ApplyFailure {
 	return {
 		id: row.id,
 		kind: row.kind,
@@ -162,7 +162,7 @@ function describeFailure(row: LabelledRow, error: unknown): ApplyFailure {
  * route that still exists in the project. `applyingRouteIds` are the siblings
  * being applied earlier in this same request.
  */
-async function assertParentRoutesReady(
+export async function assertParentRoutesReady(
 	projectId: string,
 	canvases: DependencyRow[],
 	siblings: DependencyRow[],
@@ -206,7 +206,7 @@ async function assertParentRoutesReady(
  * that route is the only thing it can have meant — repair it rather than 404 on
  * an id the user never saw. The repair is persisted so later reads agree.
  */
-async function resolveCanvasTarget<
+export async function resolveCanvasTarget<
 	T extends { id: string; payload: Record<string, any> | null },
 >(conversationId: string, projectId: string, row: T, siblings: DependencyRow[]) {
 	const payload = row.payload ?? {};
@@ -241,7 +241,6 @@ async function resolveCanvasTarget<
 export async function getSubArtifact(conversationId: string, subArtifactId: string) {
 	const row = await getSubArtifactById(conversationId, subArtifactId);
 	if (!row) throw new NotFoundError("Sub-artifact not found");
-	if (row.appliedAt) return row;
 	return row;
 }
 
@@ -254,7 +253,7 @@ export async function listRunSubArtifacts(conversationId: string, runId: string)
  * chose. Rewriting the payload keeps every later read — the artifact chips, the
  * `get_artifact` tool, the canvas dependency check — pointing at the live route.
  */
-async function rememberRealRouteId(
+export async function rememberRealRouteId(
 	conversationId: string,
 	row: { id: string; payload: Record<string, any> | null },
 	field: "routeId" | "customBlockId" | "targetId",
@@ -267,7 +266,7 @@ async function rememberRealRouteId(
 	});
 }
 
-type ApplyContext = {
+export type ApplyContext = {
 	conversationId: string;
 	projectId: string;
 	caller: RpcCaller;
@@ -282,7 +281,7 @@ type ApplyContext = {
  * so the route and its blocks land in one transaction — an approved plan that
  * half-applies leaves the user a route with no logic in it.
  */
-async function applyRouteRow(
+export async function applyRouteRow(
 	ctx: ApplyContext,
 	row: { id: string; payload: Record<string, any> | null },
 	canvas?: CanvasChanges,
@@ -306,7 +305,7 @@ async function applyRouteRow(
 	await rememberRealRouteId(ctx.conversationId, row, "routeId", id);
 }
 
-async function applyCustomBlockRow(
+export async function applyCustomBlockRow(
 	ctx: ApplyContext,
 	row: { id: string; payload: Record<string, any> | null },
 	canvas?: CanvasChanges,
@@ -326,7 +325,7 @@ async function applyCustomBlockRow(
 	await rememberRealRouteId(ctx.conversationId, row, "customBlockId", id);
 }
 
-async function applyCanvasRow(
+export async function applyCanvasRow(
 	ctx: ApplyContext,
 	row: { id: string; payload: Record<string, any> | null },
 ) {
@@ -391,7 +390,6 @@ export async function applySubArtifact(
 		// later read of the link — the apply gate cannot tell the route is live.
 		const realId = agentRouteId ? ctx.routeIds.get(agentRouteId) : undefined;
 		if (realId && agentRouteId !== realId) {
-			const siblings = await getArtifactSubArtifacts(conversationId, row.artifactId);
 			for (const sibling of siblings) {
 				if (sibling.kind !== "canvas") continue;
 				if (sibling.payload?.targetType !== "route") continue;
@@ -399,6 +397,9 @@ export async function applySubArtifact(
 				await rememberRealRouteId(conversationId, sibling, "targetId", realId);
 			}
 		}
+		// The canvas rode inside the create, so it is live. Leaving it unstamped
+		// showed it as pending and let a second apply re-save the same blocks.
+		if (canvasRow) await markSubArtifactsApplied(conversationId, [canvasRow.id], new Date());
 	} else if (row.kind === "custom_block") {
 		const agentCustomBlockId = row.payload?.customBlockId as string | undefined;
 		const siblings = await getArtifactSubArtifacts(conversationId, row.artifactId);
@@ -440,169 +441,3 @@ export async function applySubArtifact(
 }
 
 /** Applies every output of one run's artifact in one shot. */
-export async function applyArtifact(
-	userId: string,
-	conversationId: string,
-	projectId: string,
-	artifactId: string,
-) {
-	const rows = await getArtifactSubArtifacts(conversationId, artifactId);
-	if (rows.length === 0) throw new NotFoundError("Artifact not found");
-
-	const routes = rows.filter((r) => r.kind === "route");
-	const customBlocks = rows.filter((r) => r.kind === "custom_block");
-	const canvases = await Promise.all(
-		rows
-			.filter((r) => r.kind === "canvas")
-			.map((r) => resolveCanvasTarget(conversationId, projectId, r, rows)),
-	);
-	const rest = rows.filter((r) => r.kind !== "route" && r.kind !== "canvas");
-
-	// Routes go first, so a canvas referencing a route this run created is
-	// already satisfied by the time its turn comes.
-	const applyingRouteIds = new Set(
-		routes.map(routeIdOf).filter((id): id is string => !!id),
-	);
-	await assertParentRoutesReady(projectId, canvases, routes, applyingRouteIds);
-
-	const ctx: ApplyContext = {
-		conversationId,
-		projectId,
-		caller: callerFor(userId, projectId),
-		routeIds: new Map(),
-		customBlockIds: new Map(),
-	};
-
-	// A canvas for a route this run is creating rides along with the create, so
-	// the route never exists without its blocks.
-	const inlineCanvas = new Map<string, (typeof canvases)[number]>();
-	const inlined = new Set<string>();
-	for (const route of routes) {
-		if (route.payload?.action !== "create") continue;
-		const paired = canvases.find(
-			(c) =>
-				!inlined.has(c.id) &&
-				c.payload?.targetType === "route" &&
-				c.payload?.targetId === routeIdOf(route),
-		);
-		if (!paired) continue;
-		inlineCanvas.set(route.id, paired);
-		inlined.add(paired.id);
-	}
-	for (const customBlock of customBlocks) {
-		if (customBlock.payload?.action !== "create") continue;
-		const paired = canvases.find(
-			(c) => !inlined.has(c.id) && c.payload?.targetType === "custom_block" && c.payload?.targetId === customBlockIdOf(customBlock),
-		);
-		if (!paired) continue;
-		inlineCanvas.set(customBlock.id, paired);
-		inlined.add(paired.id);
-	}
-
-	const ordered = [...routes, ...customBlocks, ...canvases, ...rest];
-	const done: string[] = [];
-	// One bad output used to abort the whole batch, so a run that got nine
-	// things right and one wrong left the user with nine unapplied outputs and
-	// no idea which one was the problem. Each output is applied on its own now;
-	// what fails stays unapplied and re-appliable, and is named in the result.
-	const failures: ApplyFailure[] = [];
-	/** Routes that did not land — their canvases have nothing to attach to. */
-	const failedRouteIds = new Set<string>();
-
-	for (const route of routes) {
-		const canvasRow = inlineCanvas.get(route.id);
-		try {
-			await applyRouteRow(
-				ctx,
-				route,
-				canvasRow
-					? canvasChangesFromPayload(
-							(canvasRow.payload ?? {}) as BlockBuilderPayload,
-							EMPTY_CANVAS,
-						)
-					: undefined,
-			);
-			done.push(route.id);
-			if (canvasRow) {
-				const real = ctx.routeIds.get(routeIdOf(route) ?? "");
-				if (real)
-					await rememberRealRouteId(conversationId, canvasRow, "targetId", real);
-				done.push(canvasRow.id);
-			}
-		} catch (error) {
-			const routeId = routeIdOf(route);
-			if (routeId) failedRouteIds.add(routeId);
-			failures.push(describeFailure(route, error));
-			// The canvas rode along inside the create, so it did not land either.
-			if (canvasRow) {
-				failures.push(
-					describeFailure(canvasRow, "its route could not be created"),
-				);
-			}
-		}
-	}
-
-	for (const customBlock of customBlocks) {
-			const canvasRow = inlineCanvas.get(customBlock.id);
-			try {
-				await applyCustomBlockRow(
-					ctx,
-					customBlock,
-					canvasRow
-						? canvasChangesFromPayload(
-								(canvasRow.payload ?? {}) as BlockBuilderPayload,
-								EMPTY_CANVAS,
-							)
-						: undefined,
-				);
-				done.push(customBlock.id);
-				if (canvasRow) {
-					const real = ctx.customBlockIds.get(customBlockIdOf(customBlock) ?? "");
-					if (real)
-						await rememberRealRouteId(conversationId, canvasRow, "targetId", real);
-					done.push(canvasRow.id);
-				}
-			} catch (error) {
-				failures.push(describeFailure(customBlock, error));
-				if (canvasRow)
-					failures.push(
-						describeFailure(canvasRow, "its custom block could not be created"),
-					);
-			}
-		}
-
-	for (const canvas of canvases) {
-		if (inlined.has(canvas.id)) continue;
-		const parentRouteId = parentRouteIdOf(canvas as DependencyRow);
-		if (parentRouteId && failedRouteIds.has(parentRouteId)) {
-			failures.push(describeFailure(canvas, "its route could not be created"));
-			continue;
-		}
-		try {
-			await applyCanvasRow(ctx, canvas);
-			done.push(canvas.id);
-		} catch (error) {
-			failures.push(describeFailure(canvas, error));
-		}
-	}
-	done.push(...rest.map((r) => r.id));
-
-	const appliedAt = new Date();
-	if (done.length > 0) await markSubArtifactsApplied(conversationId, done, appliedAt);
-
-	const failedById = new Map(failures.map((f) => [f.id, f]));
-	for (const row of ordered) {
-		const failure = failedById.get(row.id);
-		if (!failure && !done.includes(row.id)) continue;
-		announce(userId, conversationId, row, failure);
-	}
-
-	return {
-		artifactId,
-		appliedAt,
-		applied: ordered
-			.filter((r) => done.includes(r.id))
-			.map((r) => ({ id: r.id, kind: r.kind, action: r.action })),
-		failed: failures,
-	};
-}

--- a/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/service.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/service.ts
@@ -4,16 +4,21 @@ import type { ArtifactStatus } from "../../../../harness/clientContract";
 import type { RpcCaller } from "@fluxify/server/src/db/natsRpc";
 import {
 	canvasChangesFromPayload,
+	customBlockOpFromPayload,
 	routeOpFromPayload,
 	type BlockBuilderPayload,
 	type CanvasChanges,
 	type CanvasItems,
+	type CustomBlockConfigPayload,
 	type RouteConfigPayload,
 } from "./normalize";
 import {
 	callerFor,
+	createCustomBlock,
 	createRoute,
+	deleteCustomBlock,
 	deleteRoute,
+	modifyCustomBlock,
 	modifyRoute,
 	readCanvas,
 	saveCanvas,
@@ -38,6 +43,7 @@ interface DependencyRow {
 
 /** The route a `kind: "route"` output creates or edits. */
 const routeIdOf = (row: DependencyRow) => row.payload?.routeId as string | undefined;
+const customBlockIdOf = (row: DependencyRow) => row.payload?.customBlockId as string | undefined;
 
 /** The route a `kind: "canvas"` output hangs its blocks off. Canvases targeting a
  *  custom block have no route dependency, so they are not gated. */
@@ -235,6 +241,7 @@ async function resolveCanvasTarget<
 export async function getSubArtifact(conversationId: string, subArtifactId: string) {
 	const row = await getSubArtifactById(conversationId, subArtifactId);
 	if (!row) throw new NotFoundError("Sub-artifact not found");
+	if (row.appliedAt) return row;
 	return row;
 }
 
@@ -250,7 +257,7 @@ export async function listRunSubArtifacts(conversationId: string, runId: string)
 async function rememberRealRouteId(
 	conversationId: string,
 	row: { id: string; payload: Record<string, any> | null },
-	field: "routeId" | "targetId",
+	field: "routeId" | "customBlockId" | "targetId",
 	realId: string,
 ) {
 	if (row.payload?.[field] === realId) return;
@@ -266,6 +273,8 @@ type ApplyContext = {
 	caller: RpcCaller;
 	/** the id the agent used for a route it created → the id storage gave it */
 	routeIds: Map<string, string>;
+	/** Planned custom-block id to storage id, same reconciliation as routes. */
+	customBlockIds: Map<string, string>;
 };
 
 /**
@@ -297,6 +306,26 @@ async function applyRouteRow(
 	await rememberRealRouteId(ctx.conversationId, row, "routeId", id);
 }
 
+async function applyCustomBlockRow(
+	ctx: ApplyContext,
+	row: { id: string; payload: Record<string, any> | null },
+	canvas?: CanvasChanges,
+) {
+	const payload = (row.payload ?? {}) as CustomBlockConfigPayload;
+	const op = customBlockOpFromPayload(payload, ctx.projectId);
+	if (op.action === "delete") {
+		await deleteCustomBlock(ctx.caller, op.id);
+		return;
+	}
+	if (op.action === "modify") {
+		await modifyCustomBlock(ctx.caller, op.id, op.data);
+		return;
+	}
+	const { id } = await createCustomBlock(ctx.caller, op.data, canvas);
+	if (payload.customBlockId) ctx.customBlockIds.set(payload.customBlockId, id);
+	await rememberRealRouteId(ctx.conversationId, row, "customBlockId", id);
+}
+
 async function applyCanvasRow(
 	ctx: ApplyContext,
 	row: { id: string; payload: Record<string, any> | null },
@@ -306,7 +335,7 @@ async function applyCanvasRow(
 	const target = payload.targetId;
 	if (!target) throw new NotFoundError("Canvas output has no target to apply to");
 
-	const sourceId = ctx.routeIds.get(target) ?? target;
+	const sourceId = ctx.routeIds.get(target) ?? ctx.customBlockIds.get(target) ?? target;
 	// Normalizing needs the canvas as it stands: it decides which block ids are
 	// already real and which edge is being re-routed.
 	const existing = await readCanvas(ctx.caller, source, sourceId);
@@ -336,6 +365,7 @@ export async function applySubArtifact(
 		projectId,
 		caller: callerFor(userId, projectId),
 		routeIds: new Map(),
+		customBlockIds: new Map(),
 	};
 
 	if (row.kind === "canvas") {
@@ -345,7 +375,17 @@ export async function applySubArtifact(
 		await applyCanvasRow(ctx, resolved);
 	} else if (row.kind === "route") {
 		const agentRouteId = row.payload?.routeId as string | undefined;
-		await applyRouteRow(ctx, row);
+		const siblings = await getArtifactSubArtifacts(conversationId, row.artifactId);
+		const canvasRow = row.payload?.action === "create"
+			? siblings.find(
+					(s) => s.kind === "canvas" && !s.appliedAt && s.payload?.targetType === "route" && s.payload?.targetId === agentRouteId,
+				)
+			: undefined;
+		await applyRouteRow(
+			ctx,
+			row,
+			canvasRow ? canvasChangesFromPayload((canvasRow.payload ?? {}) as BlockBuilderPayload, EMPTY_CANVAS) : undefined,
+		);
 		// The route now has the id storage chose, but its canvas siblings still
 		// point at the id the agent invented. Leaving them stale breaks every
 		// later read of the link — the apply gate cannot tell the route is live.
@@ -359,6 +399,35 @@ export async function applySubArtifact(
 				await rememberRealRouteId(conversationId, sibling, "targetId", realId);
 			}
 		}
+	} else if (row.kind === "custom_block") {
+		const agentCustomBlockId = row.payload?.customBlockId as string | undefined;
+		const siblings = await getArtifactSubArtifacts(conversationId, row.artifactId);
+		const canvasRow = row.payload?.action === "create"
+			? siblings.find(
+					(s) =>
+						s.kind === "canvas" &&
+						!s.appliedAt &&
+						s.payload?.targetType === "custom_block" &&
+						s.payload?.targetId === agentCustomBlockId,
+				)
+			: undefined;
+		await applyCustomBlockRow(
+			ctx,
+			row,
+			canvasRow
+				? canvasChangesFromPayload((canvasRow.payload ?? {}) as BlockBuilderPayload, EMPTY_CANVAS)
+				: undefined,
+		);
+		const realId = agentCustomBlockId ? ctx.customBlockIds.get(agentCustomBlockId) : undefined;
+		if (realId && agentCustomBlockId !== realId) {
+			for (const sibling of siblings) {
+				if (sibling.kind !== "canvas") continue;
+				if (sibling.payload?.targetType !== "custom_block") continue;
+				if (sibling.payload?.targetId !== agentCustomBlockId) continue;
+				await rememberRealRouteId(conversationId, sibling, "targetId", realId);
+			}
+		}
+		if (canvasRow) await markSubArtifactsApplied(conversationId, [canvasRow.id], new Date());
 	}
 
 	const [applied] = await markSubArtifactsApplied(
@@ -381,6 +450,7 @@ export async function applyArtifact(
 	if (rows.length === 0) throw new NotFoundError("Artifact not found");
 
 	const routes = rows.filter((r) => r.kind === "route");
+	const customBlocks = rows.filter((r) => r.kind === "custom_block");
 	const canvases = await Promise.all(
 		rows
 			.filter((r) => r.kind === "canvas")
@@ -400,6 +470,7 @@ export async function applyArtifact(
 		projectId,
 		caller: callerFor(userId, projectId),
 		routeIds: new Map(),
+		customBlockIds: new Map(),
 	};
 
 	// A canvas for a route this run is creating rides along with the create, so
@@ -418,8 +489,17 @@ export async function applyArtifact(
 		inlineCanvas.set(route.id, paired);
 		inlined.add(paired.id);
 	}
+	for (const customBlock of customBlocks) {
+		if (customBlock.payload?.action !== "create") continue;
+		const paired = canvases.find(
+			(c) => !inlined.has(c.id) && c.payload?.targetType === "custom_block" && c.payload?.targetId === customBlockIdOf(customBlock),
+		);
+		if (!paired) continue;
+		inlineCanvas.set(customBlock.id, paired);
+		inlined.add(paired.id);
+	}
 
-	const ordered = [...routes, ...canvases, ...rest];
+	const ordered = [...routes, ...customBlocks, ...canvases, ...rest];
 	const done: string[] = [];
 	// One bad output used to abort the whole batch, so a run that got nine
 	// things right and one wrong left the user with nine unapplied outputs and
@@ -461,6 +541,35 @@ export async function applyArtifact(
 			}
 		}
 	}
+
+	for (const customBlock of customBlocks) {
+			const canvasRow = inlineCanvas.get(customBlock.id);
+			try {
+				await applyCustomBlockRow(
+					ctx,
+					customBlock,
+					canvasRow
+						? canvasChangesFromPayload(
+								(canvasRow.payload ?? {}) as BlockBuilderPayload,
+								EMPTY_CANVAS,
+							)
+						: undefined,
+				);
+				done.push(customBlock.id);
+				if (canvasRow) {
+					const real = ctx.customBlockIds.get(customBlockIdOf(customBlock) ?? "");
+					if (real)
+						await rememberRealRouteId(conversationId, canvasRow, "targetId", real);
+					done.push(canvasRow.id);
+				}
+			} catch (error) {
+				failures.push(describeFailure(customBlock, error));
+				if (canvasRow)
+					failures.push(
+						describeFailure(canvasRow, "its custom block could not be created"),
+					);
+			}
+		}
 
 	for (const canvas of canvases) {
 		if (inlined.has(canvas.id)) continue;

--- a/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/tests/applyBatch.spec.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/tests/applyBatch.spec.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect, mock, spyOn, beforeEach } from "bun:test";
+import * as repository from "../repository";
+import * as serverModule from "@fluxify/server";
+import {
+	applySubArtifact,
+	getSubArtifact,
+	listRunSubArtifacts,
+	describeArtifactEvent,
+} from "../service";
+import { applyArtifact } from "../applyBatch";
+
+mock.module("../repository", () => ({
+	getSubArtifactById: mock(),
+	listSubArtifactsByRun: mock(),
+	getArtifactSubArtifacts: mock(),
+	markSubArtifactsApplied: mock(),
+	updateSubArtifactPayload: mock(),
+	findExistingRouteIds: mock(),
+}));
+
+/** Every project write goes over the bus, so the bus is the seam these tests
+ *  assert against — nothing here should reach NATS or the database. */
+const bus: { call: string; args: any[] }[] = [];
+const record =
+	(call: string, result?: unknown) =>
+	async (...args: any[]) => {
+		bus.push({ call, args });
+		return result;
+	};
+
+mock.module("../opsClient", () => ({
+	callerFor: (userId: string, projectId: string) => ({
+		userId,
+		projectIds: [projectId],
+	}),
+	createRoute: record("createRoute", { id: "live-route" }),
+	createCustomBlock: record("createCustomBlock", { id: "live-custom-block" }),
+	modifyCustomBlock: record("modifyCustomBlock", { id: "live-custom-block" }),
+	deleteCustomBlock: record("deleteCustomBlock", { id: "live-custom-block" }),
+	modifyRoute: record("modifyRoute", { id: "live-route" }),
+	deleteRoute: record("deleteRoute", { id: "live-route" }),
+	readCanvas: record("readCanvas", { blocks: [], edges: [] }),
+	saveCanvas: record("saveCanvas", null),
+}));
+
+const routeRow = (over: Record<string, any> = {}) => ({
+	id: "route-sub",
+	artifactId: "art1",
+	kind: "route",
+	action: "add",
+	appliedAt: null,
+	payload: { action: "create", routeId: "route-1" },
+	...over,
+});
+
+const canvasRow = (over: Record<string, any> = {}) => ({
+	id: "canvas-sub",
+	artifactId: "art1",
+	kind: "canvas",
+	action: "changes",
+	appliedAt: null,
+	payload: { targetType: "route", targetId: "route-1", blocks: [] },
+	...over,
+});
+
+const customBlockRow = (over: Record<string, any> = {}) => ({
+	id: "custom-block-sub",
+	artifactId: "art1",
+	kind: "custom_block",
+	action: "add",
+	appliedAt: null,
+	payload: {
+		action: "create",
+		customBlockId: "custom-block-1",
+		data: { name: "send_notice", label: "Send Notice", inputParams: [] },
+	},
+	...over,
+});
+
+/** Nothing lives in the project unless a test says so. `spyOn` keeps the same
+ *  mock across tests, so call counts must be cleared or they accumulate. */
+beforeEach(() => {
+	bus.length = 0;
+	for (const fn of Object.keys(repository) as (keyof typeof repository)[]) {
+		(repository[fn] as any).mockClear?.();
+	}
+	spyOn(repository, "findExistingRouteIds").mockResolvedValue(new Set() as never);
+	spyOn(repository, "markSubArtifactsApplied").mockImplementation(
+		(async (_c: string, ids: string[], appliedAt: Date) =>
+			ids.map((id) => ({ id, kind: "route", action: "add", appliedAt }))) as never,
+	);
+});
+
+
+describe("Harness Artifacts — applying a whole artifact", () => {
+	it("404s an empty/unknown artifact", async () => {
+		spyOn(repository, "getArtifactSubArtifacts").mockResolvedValue([] as never);
+
+		expect(applyArtifact("user1", "conv1", "proj1", "nope")).rejects.toThrow(
+			serverModule.NotFoundError,
+		);
+	});
+
+	it("applies a whole artifact route-first, so its own canvas is satisfied", async () => {
+		// Both unapplied — only the ordering makes this legal.
+		spyOn(repository, "getArtifactSubArtifacts").mockResolvedValue([
+			canvasRow(),
+			routeRow(),
+		] as never);
+
+		const result = await applyArtifact("user1", "conv1", "proj1", "art1");
+
+		expect(result.applied.map((a) => a.id)).toEqual(["route-sub", "canvas-sub"]);
+		expect(repository.markSubArtifactsApplied).toHaveBeenCalledWith(
+			"conv1",
+			["route-sub", "canvas-sub"],
+			result.appliedAt,
+		);
+	});
+
+	it("creates a route and its canvas in one bus call", async () => {
+		spyOn(repository, "getArtifactSubArtifacts").mockResolvedValue([
+			canvasRow(),
+			routeRow(),
+		] as never);
+
+		await applyArtifact("user1", "conv1", "proj1", "art1");
+
+		// One call, canvas included: the route must never exist without its blocks
+		expect(bus.map((b) => b.call)).toEqual(["createRoute"]);
+		const [caller, data, canvas] = bus[0].args;
+		expect(caller).toEqual({ userId: "user1", projectIds: ["proj1"] });
+		expect(data.projectId).toBe("proj1");
+		expect(canvas).toEqual({
+			actionsToPerform: { blocks: [], edges: [] },
+			changes: { blocks: [], edges: [] },
+		});
+	});
+
+	it("creates a custom block and its canvas in one bus call", async () => {
+		spyOn(repository, "getArtifactSubArtifacts").mockResolvedValue([
+			canvasRow({ payload: { targetType: "custom_block", targetId: "custom-block-1", blocks: [] } }),
+			customBlockRow(),
+		] as never);
+
+		await applyArtifact("user1", "conv1", "proj1", "art1");
+
+		expect(bus.map((b) => b.call)).toEqual(["createCustomBlock"]);
+		expect(bus[0]?.args[1]).toEqual(expect.objectContaining({ name: "send_notice", projectId: "proj1" }));
+		expect(bus[0]?.args[2]).toEqual(expect.objectContaining({ changes: { blocks: [], edges: [] } }));
+		expect(repository.updateSubArtifactPayload).toHaveBeenCalledWith("conv1", "canvas-sub", expect.objectContaining({ targetId: "live-custom-block" }));
+	});
+
+	// `rest` is stamped applied unconditionally, so a custom block left in that
+	// bucket was reported as applied even when its create had just thrown —
+	// the user could not retry it and the chip went green on a failure.
+	it("leaves a failed custom block unapplied", async () => {
+		spyOn(repository, "getArtifactSubArtifacts").mockResolvedValue([
+			customBlockRow({
+				// rejected by customBlockOpFromPayload before it reaches the bus
+				payload: {
+					action: "create",
+					customBlockId: "custom-block-1",
+					data: { name: "Not Snake Case", label: "Bad" },
+				},
+			}),
+		] as never);
+
+		const result = await applyArtifact("user1", "conv1", "proj1", "art1");
+
+		expect(bus.map((b) => b.call)).toEqual([]);
+		expect(result.applied.map((a) => a.id)).toEqual([]);
+		expect(result.failed.map((f) => f.id)).toEqual(["custom-block-sub"]);
+		expect(repository.markSubArtifactsApplied).not.toHaveBeenCalled();
+	});
+
+	it("rewrites the agent's invented route id to the one storage chose", async () => {
+		spyOn(repository, "getArtifactSubArtifacts").mockResolvedValue([
+			canvasRow(),
+			routeRow(),
+		] as never);
+
+		await applyArtifact("user1", "conv1", "proj1", "art1");
+
+		// Both rows carried "route-1", which never existed anywhere but the model's
+		// output — every later read has to find the live route instead.
+		expect(repository.updateSubArtifactPayload).toHaveBeenCalledWith(
+			"conv1",
+			"route-sub",
+			expect.objectContaining({ routeId: "live-route" }) as never,
+		);
+		expect(repository.updateSubArtifactPayload).toHaveBeenCalledWith(
+			"conv1",
+			"canvas-sub",
+			expect.objectContaining({ targetId: "live-route" }) as never,
+		);
+	});
+
+	it("reads the canvas before saving one onto an existing route", async () => {
+		spyOn(repository, "getSubArtifactById").mockResolvedValue(canvasRow() as never);
+		spyOn(repository, "getArtifactSubArtifacts").mockResolvedValue([
+			canvasRow(),
+		] as never);
+		spyOn(repository, "findExistingRouteIds").mockResolvedValue(
+			new Set(["route-1"]) as never,
+		);
+
+		await applySubArtifact("user1", "conv1", "proj1", "canvas-sub");
+
+		// The read is what tells the normalizer which ids are already real.
+		expect(bus.map((b) => b.call)).toEqual(["readCanvas", "saveCanvas"]);
+		expect(bus[1].args.slice(1, 3)).toEqual(["route", "route-1"]);
+	});
+
+	it("404s a whole artifact whose canvas points at a deleted route", async () => {
+		spyOn(repository, "getArtifactSubArtifacts").mockResolvedValue([
+			canvasRow({ payload: { targetType: "route", targetId: "route-gone" } }),
+			routeRow(),
+		] as never);
+
+		expect(applyArtifact("user1", "conv1", "proj1", "art1")).rejects.toThrow(
+			serverModule.NotFoundError,
+		);
+	});
+
+	it("keeps applying after one output fails, and reports what did not land", async () => {
+		// Two independent routes; the first cannot be written.
+		const bad = routeRow({ id: "route-bad", payload: { action: "create", routeId: "route-bad-id" } });
+		const good = routeRow({ id: "route-good", payload: { action: "create", routeId: "route-good-id" } });
+		spyOn(repository, "getArtifactSubArtifacts").mockResolvedValue([bad, good] as never);
+
+		const opsClient = await import("../opsClient");
+		const createSpy = spyOn(opsClient, "createRoute").mockImplementation((async (
+			_caller: any,
+			_data: any,
+			_canvas: any,
+			plannedId?: string,
+		) => {
+			if (plannedId === "route-bad-id") throw new Error("path already taken");
+			return { id: "live-route" };
+		}) as never);
+
+		const result = await applyArtifact("user1", "conv1", "proj1", "art1");
+
+		expect(createSpy).toHaveBeenCalledTimes(2);
+		expect(result.applied.map((a) => a.id)).toEqual(["route-good"]);
+		expect(result.failed).toHaveLength(1);
+		expect(result.failed[0].id).toBe("route-bad");
+		expect(result.failed[0].reason).toBe("path already taken");
+		// Only what actually landed may be stamped applied — a failed output has
+		// to stay applyable by hand.
+		expect(repository.markSubArtifactsApplied).toHaveBeenCalledWith(
+			"conv1",
+			["route-good"],
+			expect.any(Date),
+		);
+	});
+
+	it("does not try a canvas whose route could not be created", async () => {
+		spyOn(repository, "getArtifactSubArtifacts").mockResolvedValue([
+			routeRow(),
+			// a second canvas, so it is not inlined into the route create
+			canvasRow(),
+			canvasRow({ id: "canvas-2" }),
+		] as never);
+
+		const opsClient = await import("../opsClient");
+		spyOn(opsClient, "createRoute").mockImplementation((async () => {
+			throw new Error("bus down");
+		}) as never);
+
+		const result = await applyArtifact("user1", "conv1", "proj1", "art1");
+
+		expect(result.applied).toHaveLength(0);
+		// Nothing was pushed for the orphaned canvas.
+		expect(bus.map((b) => b.call)).not.toContain("saveCanvas");
+		expect(result.failed.map((f) => f.id).sort()).toEqual([
+			"canvas-2",
+			"canvas-sub",
+			"route-sub",
+		]);
+		expect(
+			result.failed.find((f) => f.id === "canvas-2")?.reason,
+		).toBe("its route could not be created");
+	});
+});

--- a/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/tests/artifacts.spec.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/tests/artifacts.spec.ts
@@ -2,12 +2,12 @@ import { describe, it, expect, mock, spyOn, beforeEach } from "bun:test";
 import * as repository from "../repository";
 import * as serverModule from "@fluxify/server";
 import {
-	applyArtifact,
 	applySubArtifact,
 	getSubArtifact,
 	listRunSubArtifacts,
 	describeArtifactEvent,
 } from "../service";
+import { applyArtifact } from "../applyBatch";
 
 mock.module("../repository", () => ({
 	getSubArtifactById: mock(),
@@ -255,174 +255,6 @@ describe("Harness Artifacts Service", () => {
 		await applySubArtifact("user1", "conv1", "proj1", "canvas-sub");
 
 		expect(routesSpy).not.toHaveBeenCalled();
-	});
-
-	it("404s an empty/unknown artifact", async () => {
-		spyOn(repository, "getArtifactSubArtifacts").mockResolvedValue([] as never);
-
-		expect(applyArtifact("user1", "conv1", "proj1", "nope")).rejects.toThrow(
-			serverModule.NotFoundError,
-		);
-	});
-
-	it("applies a whole artifact route-first, so its own canvas is satisfied", async () => {
-		// Both unapplied — only the ordering makes this legal.
-		spyOn(repository, "getArtifactSubArtifacts").mockResolvedValue([
-			canvasRow(),
-			routeRow(),
-		] as never);
-
-		const result = await applyArtifact("user1", "conv1", "proj1", "art1");
-
-		expect(result.applied.map((a) => a.id)).toEqual(["route-sub", "canvas-sub"]);
-		expect(repository.markSubArtifactsApplied).toHaveBeenCalledWith(
-			"conv1",
-			["route-sub", "canvas-sub"],
-			result.appliedAt,
-		);
-	});
-
-	it("creates a route and its canvas in one bus call", async () => {
-		spyOn(repository, "getArtifactSubArtifacts").mockResolvedValue([
-			canvasRow(),
-			routeRow(),
-		] as never);
-
-		await applyArtifact("user1", "conv1", "proj1", "art1");
-
-		// One call, canvas included: the route must never exist without its blocks
-		expect(bus.map((b) => b.call)).toEqual(["createRoute"]);
-		const [caller, data, canvas] = bus[0].args;
-		expect(caller).toEqual({ userId: "user1", projectIds: ["proj1"] });
-		expect(data.projectId).toBe("proj1");
-		expect(canvas).toEqual({
-			actionsToPerform: { blocks: [], edges: [] },
-			changes: { blocks: [], edges: [] },
-		});
-	});
-
-	it("creates a custom block and its canvas in one bus call", async () => {
-		spyOn(repository, "getArtifactSubArtifacts").mockResolvedValue([
-			canvasRow({ payload: { targetType: "custom_block", targetId: "custom-block-1", blocks: [] } }),
-			customBlockRow(),
-		] as never);
-
-		await applyArtifact("user1", "conv1", "proj1", "art1");
-
-		expect(bus.map((b) => b.call)).toEqual(["createCustomBlock"]);
-		expect(bus[0]?.args[1]).toEqual(expect.objectContaining({ name: "send_notice", projectId: "proj1" }));
-		expect(bus[0]?.args[2]).toEqual(expect.objectContaining({ changes: { blocks: [], edges: [] } }));
-		expect(repository.updateSubArtifactPayload).toHaveBeenCalledWith("conv1", "canvas-sub", expect.objectContaining({ targetId: "live-custom-block" }));
-	});
-
-	it("rewrites the agent's invented route id to the one storage chose", async () => {
-		spyOn(repository, "getArtifactSubArtifacts").mockResolvedValue([
-			canvasRow(),
-			routeRow(),
-		] as never);
-
-		await applyArtifact("user1", "conv1", "proj1", "art1");
-
-		// Both rows carried "route-1", which never existed anywhere but the model's
-		// output — every later read has to find the live route instead.
-		expect(repository.updateSubArtifactPayload).toHaveBeenCalledWith(
-			"conv1",
-			"route-sub",
-			expect.objectContaining({ routeId: "live-route" }) as never,
-		);
-		expect(repository.updateSubArtifactPayload).toHaveBeenCalledWith(
-			"conv1",
-			"canvas-sub",
-			expect.objectContaining({ targetId: "live-route" }) as never,
-		);
-	});
-
-	it("reads the canvas before saving one onto an existing route", async () => {
-		spyOn(repository, "getSubArtifactById").mockResolvedValue(canvasRow() as never);
-		spyOn(repository, "getArtifactSubArtifacts").mockResolvedValue([
-			canvasRow(),
-		] as never);
-		spyOn(repository, "findExistingRouteIds").mockResolvedValue(
-			new Set(["route-1"]) as never,
-		);
-
-		await applySubArtifact("user1", "conv1", "proj1", "canvas-sub");
-
-		// The read is what tells the normalizer which ids are already real.
-		expect(bus.map((b) => b.call)).toEqual(["readCanvas", "saveCanvas"]);
-		expect(bus[1].args.slice(1, 3)).toEqual(["route", "route-1"]);
-	});
-
-	it("404s a whole artifact whose canvas points at a deleted route", async () => {
-		spyOn(repository, "getArtifactSubArtifacts").mockResolvedValue([
-			canvasRow({ payload: { targetType: "route", targetId: "route-gone" } }),
-			routeRow(),
-		] as never);
-
-		expect(applyArtifact("user1", "conv1", "proj1", "art1")).rejects.toThrow(
-			serverModule.NotFoundError,
-		);
-	});
-
-	it("keeps applying after one output fails, and reports what did not land", async () => {
-		// Two independent routes; the first cannot be written.
-		const bad = routeRow({ id: "route-bad", payload: { action: "create", routeId: "route-bad-id" } });
-		const good = routeRow({ id: "route-good", payload: { action: "create", routeId: "route-good-id" } });
-		spyOn(repository, "getArtifactSubArtifacts").mockResolvedValue([bad, good] as never);
-
-		const opsClient = await import("../opsClient");
-		const createSpy = spyOn(opsClient, "createRoute").mockImplementation((async (
-			_caller: any,
-			_data: any,
-			_canvas: any,
-			plannedId?: string,
-		) => {
-			if (plannedId === "route-bad-id") throw new Error("path already taken");
-			return { id: "live-route" };
-		}) as never);
-
-		const result = await applyArtifact("user1", "conv1", "proj1", "art1");
-
-		expect(createSpy).toHaveBeenCalledTimes(2);
-		expect(result.applied.map((a) => a.id)).toEqual(["route-good"]);
-		expect(result.failed).toHaveLength(1);
-		expect(result.failed[0].id).toBe("route-bad");
-		expect(result.failed[0].reason).toBe("path already taken");
-		// Only what actually landed may be stamped applied — a failed output has
-		// to stay applyable by hand.
-		expect(repository.markSubArtifactsApplied).toHaveBeenCalledWith(
-			"conv1",
-			["route-good"],
-			expect.any(Date),
-		);
-	});
-
-	it("does not try a canvas whose route could not be created", async () => {
-		spyOn(repository, "getArtifactSubArtifacts").mockResolvedValue([
-			routeRow(),
-			// a second canvas, so it is not inlined into the route create
-			canvasRow(),
-			canvasRow({ id: "canvas-2" }),
-		] as never);
-
-		const opsClient = await import("../opsClient");
-		spyOn(opsClient, "createRoute").mockImplementation((async () => {
-			throw new Error("bus down");
-		}) as never);
-
-		const result = await applyArtifact("user1", "conv1", "proj1", "art1");
-
-		expect(result.applied).toHaveLength(0);
-		// Nothing was pushed for the orphaned canvas.
-		expect(bus.map((b) => b.call)).not.toContain("saveCanvas");
-		expect(result.failed.map((f) => f.id).sort()).toEqual([
-			"canvas-2",
-			"canvas-sub",
-			"route-sub",
-		]);
-		expect(
-			result.failed.find((f) => f.id === "canvas-2")?.reason,
-		).toBe("its route could not be created");
 	});
 
 	it("describes a route the way the user would name it", () => {

--- a/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/tests/artifacts.spec.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/tests/artifacts.spec.ts
@@ -34,6 +34,9 @@ mock.module("../opsClient", () => ({
 		projectIds: [projectId],
 	}),
 	createRoute: record("createRoute", { id: "live-route" }),
+	createCustomBlock: record("createCustomBlock", { id: "live-custom-block" }),
+	modifyCustomBlock: record("modifyCustomBlock", { id: "live-custom-block" }),
+	deleteCustomBlock: record("deleteCustomBlock", { id: "live-custom-block" }),
 	modifyRoute: record("modifyRoute", { id: "live-route" }),
 	deleteRoute: record("deleteRoute", { id: "live-route" }),
 	readCanvas: record("readCanvas", { blocks: [], edges: [] }),
@@ -57,6 +60,20 @@ const canvasRow = (over: Record<string, any> = {}) => ({
 	action: "changes",
 	appliedAt: null,
 	payload: { targetType: "route", targetId: "route-1", blocks: [] },
+	...over,
+});
+
+const customBlockRow = (over: Record<string, any> = {}) => ({
+	id: "custom-block-sub",
+	artifactId: "art1",
+	kind: "custom_block",
+	action: "add",
+	appliedAt: null,
+	payload: {
+		action: "create",
+		customBlockId: "custom-block-1",
+		data: { name: "send_notice", label: "Send Notice", inputParams: [] },
+	},
 	...over,
 });
 
@@ -105,6 +122,36 @@ describe("Harness Artifacts Service", () => {
 		// names it, so letting storage mint a new one orphans the pair
 		expect(bus[0]?.args[3]).toBe("route-1");
 		expect(result?.appliedAt).toBeInstanceOf(Date);
+	});
+
+	it("creates a route with its paired canvas inline", async () => {
+		spyOn(repository, "getSubArtifactById").mockResolvedValue(routeRow() as never);
+		spyOn(repository, "getArtifactSubArtifacts").mockResolvedValue([
+			routeRow(),
+			canvasRow({ payload: { targetType: "route", targetId: "route-1", blocks: [{ id: "entry", blockType: "entrypoint" }] } }),
+		] as never);
+		await applySubArtifact("user1", "conv1", "proj1", "route-sub");
+
+		expect(bus.map((b) => b.call)).toEqual(["createRoute"]);
+		expect(bus[0]?.args[2]).toEqual(expect.objectContaining({ changes: expect.objectContaining({ blocks: expect.any(Array) }) }));
+	});
+
+	it("creates a custom block with its paired canvas inline", async () => {
+		const customCanvas = canvasRow({
+			payload: { targetType: "custom_block", targetId: "custom-block-1", blocks: [{ id: "entry", blockType: "entrypoint" }] },
+		});
+		spyOn(repository, "getSubArtifactById").mockResolvedValue(customBlockRow() as never);
+		spyOn(repository, "getArtifactSubArtifacts").mockResolvedValue([
+			customBlockRow(),
+			customCanvas,
+		] as never);
+		const marked = spyOn(repository, "markSubArtifactsApplied");
+
+		await applySubArtifact("user1", "conv1", "proj1", "custom-block-sub");
+
+		expect(bus.map((b) => b.call)).toEqual(["createCustomBlock"]);
+		expect(bus[0]?.args[2]).toEqual(expect.objectContaining({ changes: expect.objectContaining({ blocks: expect.any(Array) }) }));
+		expect(marked).toHaveBeenCalledWith("conv1", ["canvas-sub"], expect.any(Date));
 	});
 
 	it("re-points a canvas sibling at the id storage gave the new route", async () => {
@@ -252,6 +299,20 @@ describe("Harness Artifacts Service", () => {
 			actionsToPerform: { blocks: [], edges: [] },
 			changes: { blocks: [], edges: [] },
 		});
+	});
+
+	it("creates a custom block and its canvas in one bus call", async () => {
+		spyOn(repository, "getArtifactSubArtifacts").mockResolvedValue([
+			canvasRow({ payload: { targetType: "custom_block", targetId: "custom-block-1", blocks: [] } }),
+			customBlockRow(),
+		] as never);
+
+		await applyArtifact("user1", "conv1", "proj1", "art1");
+
+		expect(bus.map((b) => b.call)).toEqual(["createCustomBlock"]);
+		expect(bus[0]?.args[1]).toEqual(expect.objectContaining({ name: "send_notice", projectId: "proj1" }));
+		expect(bus[0]?.args[2]).toEqual(expect.objectContaining({ changes: { blocks: [], edges: [] } }));
+		expect(repository.updateSubArtifactPayload).toHaveBeenCalledWith("conv1", "canvas-sub", expect.objectContaining({ targetId: "live-custom-block" }));
 	});
 
 	it("rewrites the agent's invented route id to the one storage chose", async () => {

--- a/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/agent.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/agent.ts
@@ -113,14 +113,16 @@ export class BlockBuilderAgent extends BaseAgent {
 					name,
 					label,
 					description,
+					inputParams,
 				}: {
 					name: string;
 					label: string;
 					description: string;
+					inputParams?: unknown[];
 				}) => ({
 					type: `custom:${name}`,
 					name: label,
-					description,
+					description: `${description} Caller parameters: ${JSON.stringify(inputParams ?? [])}`,
 				}),
 			),
 		);
@@ -129,6 +131,14 @@ export class BlockBuilderAgent extends BaseAgent {
 		// block — untrusted, and this one lands in the system prompt rather than
 		// in a tool result, so it needs the fence more than most.
 		return fenceUntrusted("custom_blocks", table);
+	}
+
+	private pairedCustomBlockContract() {
+		const configs = Object.values(this.state.orchestratorState?.subAgentResults ?? {})
+			.map((value) => value as { customBlockId?: string; data?: { name?: string; inputParams?: unknown[] } })
+			.filter((value) => value.customBlockId && value.data?.name);
+		if (configs.length === 0) return "";
+		return `#### Paired Custom Block Contracts (authoritative)\n${configs.map((config) => `- ${config.data?.name} (${config.customBlockId}): ${JSON.stringify(config.data?.inputParams ?? [])}`).join("\n")}`;
 	}
 
 	async execute(): Promise<Partial<GlobalGraphState>> {
@@ -152,7 +162,11 @@ export class BlockBuilderAgent extends BaseAgent {
 		const prefetchedDocs = (await getDocsByTitle(PREFETCH_DOC_TITLES))
 			.map((doc) => doc.content)
 			.join("\n\n---\n\n");
-		const systemPrompt = createSystemPrompt(customBlocksTable, prefetchedDocs);
+		const systemPrompt = createSystemPrompt(
+			customBlocksTable,
+			prefetchedDocs,
+			this.pairedCustomBlockContract(),
+		);
 		const userQuery = createUserQuery(activeTask);
 
 		const tools = [

--- a/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/promptHelpers.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/promptHelpers.ts
@@ -83,6 +83,18 @@ ${CUSTOM_BLOCK_EXECUTION_CONTRACT}
    - Vertical spacing between parallel/branching blocks: ~72 units (48 height + 24 gap).
    - Start new nodes to the right of the rightmost existing node in the canvas.
 
+   **Grouping with 'sticky_note' (OPTIONAL)**
+   A sticky note renders *behind* the blocks, so it is a labelled background panel for a group of related blocks — NOT a floating comment box parked next to them. A small note holding a stray remark like "Output: signed JWT string" is noise; do not produce one.
+   - Use one only when the canvas has two or more distinct phases worth naming ("Handling Errors", "Fetch User Record", "Check for Existence"). A short linear canvas needs none. Skipping notes entirely is always acceptable.
+   - \`data\`: \`{ "notes": "**Group title**", "color": "yellow" | "red" | "green" | "blue", "size": { "width": <number>, "height": <number> } }\`. \`notes\` is markdown and renders at the top-left of the panel, so keep it to a bold two-or-three word title. \`connections\` MUST be \`[]\`.
+   - \`position\` is the panel's TOP-LEFT corner, and \`size\` must be large enough to enclose every block in the group. Given a group whose blocks span from \`(minX, minY)\` to \`(maxX, maxY)\` (block width 168, height 48):
+     - \`position\`: \`{ "x": minX - 24, "y": minY - 44 }\` — the extra top room is where the title sits.
+     - \`size.width\`: \`(maxX - minX) + 168 + 48\`
+     - \`size.height\`: \`(maxY - minY) + 48 + 68\`
+   - Give each group its own colour, and never let two panels overlap — a block must sit inside at most one group.
+   - Worked example: three blocks at x = 0, 192, 384 and y = 300 →
+     \`{ "id": "note_1", "blockType": "sticky_note", "position": { "x": -24, "y": 256 }, "data": { "notes": "**Fetch User Record**", "color": "yellow", "size": { "width": 600, "height": 164 } }, "connections": [] }\`
+
 4. **Connections — how the runtime actually walks the graph**:
    At request time the engine resolves each step by asking a block for the single edge on a named handle. It takes the FIRST edge it finds on that handle and ignores every other edge on it. There is no parallel execution and no fan-out.
 
@@ -104,7 +116,14 @@ ${CUSTOM_BLOCK_EXECUTION_CONTRACT}
    - For JavaScript expressions, use the syntax \`js:<expression>\`. The previous block's output is in the \`input\` global. The full JavaScript API is pre-loaded below under "Platform Reference" — write your JS against it and do NOT search the docs for it.
    - Never put \`blockName\`, \`blockDescription\` or \`blockType\` inside \`data\`. They belong on the block object itself; repeating them in \`data\` is invalid.
 
-6. **Canvas Modifications (canvasChanges)**:
+6. **JavaScript Runtime & Libraries — STRICT**:
+   - The Platform Reference is the source of truth for every runtime global, library API, and module capability. Use only APIs it documents. Never invent globals, imports, fallbacks, polyfills, or replacement implementations.
+   - Bun built-in standard-library modules may be imported with normal ESM \`import\` syntax. Their actual OS-level access is constrained by the execution container; do not assume unrestricted filesystem, process, network, or environment access.
+   - Curated third-party libraries are available globally through \`libs.*\`, not through speculative imports. The Platform Reference lists the currently available members; treat that list as authoritative because it may change.
+   - Prefer a documented library's high-level/native API over recreating its behavior. For example, use a JWT library's supported expiry option when available rather than hand-parsing durations or manually signing tokens.
+   - Never hand-roll security-sensitive primitives such as JWT encoding/signing, cryptography, authentication, token parsing, or validation as a fallback. If the required documented capability is unavailable, return \`status: "impossible"\` and explain what capability is missing.
+
+7. **Canvas Modifications (canvasChanges)**:
    When modifying an existing canvas (non-empty), use the 'canvasChanges' array to express changes to **existing** items.
    - **'edge_swap'**: Re-route an existing connection from one handle/block to another.
      - 'fromEdge': The source block ID of the edge being changed.
@@ -119,12 +138,12 @@ ${CUSTOM_BLOCK_EXECUTION_CONTRACT}
 
    > **Important**: Only use 'canvasChanges' for mutations to items already on the canvas. Brand-new blocks always go in the top-level 'blocks' array.
 
-7. **Target Association**:
+8. **Target Association**:
    - You MUST extract the ID of the route or custom block you are building for from the task context or previous agent outputs (e.g., using \`get_agent_output\`). For a custom block created in this run, fetch its paired Custom Block Config Agent output first and use its exact \`inputParams\` contract.
    - Specify whether the canvas belongs to a \`route\` or \`custom_block\` in the \`targetType\` field.
    - Provide the exact ID in the \`targetId\` field.
 
-8. **Tools**: Everything about the execution model and the JavaScript API is already in "Platform Reference" below — do NOT call 'search_docs' for scripting, \`js:\` expressions, \`input\`, variables, or how blocks execute. Use 'search_docs' only for a platform feature not covered there, and when you do, pass ALL your topics in ONE call ('searchQueries' is an array) rather than calling it repeatedly. Use 'find_resource' to lookup integrations and existing route/custom block canvas (metadata.isNewRoute=true for new routes) — skip this for the canvas already summarized in "Current context" below. When the task description already gives you a resource's exact ID, pass \`searchBy: "id"\`; the default keyword search will not find an ID. Use 'get_block_schemas' to fetch configuration schemas for any blocks you plan to use. Use 'get_agent_output' to fetch the configuration of a newly created route or custom block from a previous agent's output if it's not yet saved in the DB (the task description will provide the task IDs).
+9. **Tools**: Everything about the execution model and the JavaScript API is already in "Platform Reference" below — do NOT call 'search_docs' for scripting, \`js:\` expressions, \`input\`, variables, or how blocks execute. Use 'search_docs' only for a platform feature not covered there, and when you do, pass ALL your topics in ONE call ('searchQueries' is an array) rather than calling it repeatedly. Use 'find_resource' to lookup integrations and existing route/custom block canvas (metadata.isNewRoute=true for new routes) — skip this for the canvas already summarized in "Current context" below. When the task description already gives you a resource's exact ID, pass \`searchBy: "id"\`; the default keyword search will not find an ID. Use 'get_block_schemas' to fetch configuration schemas for any blocks you plan to use. Use 'get_agent_output' to fetch the configuration of a newly created route or custom block from a previous agent's output if it's not yet saved in the DB (the task description will provide the task IDs).
 
 ### Output Contract
 

--- a/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/promptHelpers.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/promptHelpers.ts
@@ -1,5 +1,9 @@
 import { blockAiDescriptions } from "@fluxify/blocks";
 import type { GlobalGraphState } from "../../../types";
+import {
+	CUSTOM_BLOCK_EXECUTION_CONTRACT,
+	CUSTOM_BLOCK_PARAMETER_CONTRACT,
+} from "../customBlockContract";
 
 const TABLE_HEADER = "| Type | Name | Description |\n| --- | --- | --- |";
 
@@ -40,6 +44,7 @@ export const PREFETCH_DOC_TITLES = [
 export function createSystemPrompt(
 	customBlocksTable: string,
 	prefetchedDocs: string,
+	pairedCustomBlockContract = "",
 ): string {
 	return `You are the Block Builder Agent for Fluxify \u2014 an Agentic Low Code Backend Development Platform.
 Your responsibility is to build and modify the canvas of a workflow DAG, which consists of various blocks (nodes) connected by edges. You are capable of building the canvas for both Routes and Custom Blocks. The task description will define what you are editing.
@@ -52,7 +57,12 @@ ${BUILTIN_BLOCKS_TABLE}
 #### Custom Blocks
 ${customBlocksTable}
 
+${pairedCustomBlockContract}
+
 ### Construction Rules
+
+${CUSTOM_BLOCK_PARAMETER_CONTRACT}
+${CUSTOM_BLOCK_EXECUTION_CONTRACT}
 
 1. **Source of Truth Blocks (Entrypoint & Error Handler)**:
    - If the route or custom block is NEWLY created (the canvas is empty), you MUST create exactly one 'entrypoint' block and exactly one 'error_handler' block in the 'blocks' array.
@@ -110,7 +120,7 @@ ${customBlocksTable}
    > **Important**: Only use 'canvasChanges' for mutations to items already on the canvas. Brand-new blocks always go in the top-level 'blocks' array.
 
 7. **Target Association**:
-   - You MUST extract the ID of the route or custom block you are building for from the task context or previous agent outputs (e.g., using \`get_agent_output\`).
+   - You MUST extract the ID of the route or custom block you are building for from the task context or previous agent outputs (e.g., using \`get_agent_output\`). For a custom block created in this run, fetch its paired Custom Block Config Agent output first and use its exact \`inputParams\` contract.
    - Specify whether the canvas belongs to a \`route\` or \`custom_block\` in the \`targetType\` field.
    - Provide the exact ID in the \`targetId\` field.
 

--- a/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/validator.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/validator.ts
@@ -127,7 +127,12 @@ function validateCustomBlockParameterReferences(
 	const errors: string[] = [];
 	for (const block of blocks) {
 		const serialized = JSON.stringify(block.data ?? {});
-		for (const match of serialized.matchAll(/(?:params\.([a-zA-Z0-9_]+)|param:([a-zA-Z0-9_]+))/g)) {
+		// The lookbehind matters: without it `input.params.id` or `data.params.x`
+		// — ordinary property access on a previous block's output — reads as a
+		// caller parameter and bounces a correct canvas back for a retry.
+		for (const match of serialized.matchAll(
+			/(?:(?<![\w.])params\.([a-zA-Z0-9_]+)|(?<![\w.])param:([a-zA-Z0-9_]+))/g,
+		)) {
 			const name = match[1] ?? match[2];
 			if (name && !params.has(name)) errors.push(`Block "${block.id}" references custom-block parameter "${name}", but it is absent from the paired Custom Block Config Agent output.`);
 		}

--- a/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/validator.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/validator.ts
@@ -69,6 +69,7 @@ function validateCustomBlockField(
 	switch (param.type) {
 		case "text_input":
 		case "integration_selector":
+		case "app_config_selector":
 			if (val !== undefined && val !== null && typeof val !== "string") {
 				return `Block "${blockId}" of custom type "${customName}" has invalid field "${param.name}": expected a string value, but received type "${typeof val}".`;
 			}
@@ -96,6 +97,44 @@ function validateCustomBlockField(
 	return null;
 }
 
+function validateCustomBlockInvoke(
+	block: ValidatableBlock,
+	customName: string,
+): string | null {
+	const invoke = (block.data as Record<string, unknown> | undefined)?.invoke;
+	if (invoke === undefined || invoke === "sync" || invoke === "async" || invoke === "queued") return null;
+	return `Block "${block.id}" invokes custom block "${customName}" with "${String(invoke)}". Use only "sync", "async", or "queued"; "scheduled" is not a runtime value.`;
+}
+
+function configuredCustomBlockParamNames(
+	targetId: string | undefined,
+	state: Parameters<AgentOutputValidator>[2],
+): Set<string> | null {
+	if (!targetId) return null;
+	for (const result of Object.values(state.orchestratorState?.subAgentResults ?? {})) {
+		const config = result as { customBlockId?: string; data?: { inputParams?: Array<{ name?: string }> } };
+		if (config.customBlockId !== targetId) continue;
+		return new Set((config.data?.inputParams ?? []).map((param) => param.name).filter((name): name is string => !!name));
+	}
+	return null;
+}
+
+function validateCustomBlockParameterReferences(
+	blocks: ValidatableBlock[],
+	params: Set<string> | null,
+): string[] {
+	if (!params) return [];
+	const errors: string[] = [];
+	for (const block of blocks) {
+		const serialized = JSON.stringify(block.data ?? {});
+		for (const match of serialized.matchAll(/(?:params\.([a-zA-Z0-9_]+)|param:([a-zA-Z0-9_]+))/g)) {
+			const name = match[1] ?? match[2];
+			if (name && !params.has(name)) errors.push(`Block "${block.id}" references custom-block parameter "${name}", but it is absent from the paired Custom Block Config Agent output.`);
+		}
+	}
+	return errors;
+}
+
 function validateBlockAgainstSchemas(
 	block: ValidatableBlock,
 	customBlockSchemasMap: Map<string, any[]>,
@@ -111,6 +150,8 @@ function validateBlockAgainstSchemas(
 		: null;
 
 	if (isCustom && customName) {
+		const invokeError = validateCustomBlockInvoke(block, customName);
+		if (invokeError) errors.push(invokeError);
 		const inputParams = customBlockSchemasMap.get(customName);
 		if (!inputParams) {
 			// A near-miss on a built-in name (`get_http_header` for `httpgetheader`)
@@ -208,6 +249,12 @@ export const validateBlockBuilderOutput: AgentOutputValidator = async (
 	}
 
 	const errors: string[] = validateGraphRules(blocksToValidate);
+	if (typedResult.targetType === "custom_block") {
+		errors.push(...validateCustomBlockParameterReferences(
+			blocksToValidate,
+			configuredCustomBlockParamNames(typedResult.targetId, state),
+		));
+	}
 	for (const block of blocksToValidate) {
 		errors.push(...validateBlockAgainstSchemas(block, customBlockSchemasMap));
 	}

--- a/apps/ai-gateway/src/harness/agents/sub-agents/customBlockConfig.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/customBlockConfig.ts
@@ -1,0 +1,73 @@
+import { generateID } from "@fluxify/lib";
+import { z } from "zod";
+import { dispatchAgentEvent } from "../../callbacks";
+import { createFindResourceTool } from "../../tools/findResource";
+import { searchDocsTool } from "../../tools/searchDocs";
+import { AgentNode, type GlobalGraphState } from "../../types";
+import { BaseAgent } from "../base";
+import { CUSTOM_BLOCK_PARAMETER_CONTRACT } from "./customBlockContract";
+
+const inputParamSchema = z.discriminatedUnion("type", [
+	z.object({ type: z.literal("text_input"), name: z.string(), label: z.string(), description: z.string().nullish() }),
+	z.object({ type: z.literal("checkbox"), name: z.string(), label: z.string(), description: z.string().nullish() }),
+	z.object({ type: z.literal("array_editor"), name: z.string(), label: z.string(), description: z.string().nullish() }),
+	z.object({ type: z.literal("dropdown"), name: z.string(), label: z.string(), options: z.array(z.object({ label: z.string(), value: z.string() })), description: z.string().nullish() }),
+	z.object({ type: z.literal("integration_selector"), name: z.string(), label: z.string(), group: z.string(), variant: z.string().nullish(), tags: z.array(z.string()).default([]), description: z.string().nullish() }),
+	z.object({ type: z.literal("app_config_selector"), name: z.string(), label: z.string(), description: z.string().nullish() }),
+]);
+
+const customBlockConfigSchema = z.object({
+	action: z.enum(["create", "delete", "update-partial"]),
+	customBlockId: z.string().nullish(),
+	data: z.object({
+		name: z.string().nullish(),
+		label: z.string().nullish(),
+		description: z.string().nullish(),
+		inputParams: z.array(inputParamSchema).nullish(),
+	}).nullish(),
+});
+
+export class CustomBlockConfigAgent extends BaseAgent {
+	async execute(): Promise<Partial<GlobalGraphState>> {
+		const activeTask = this.state.activeTask;
+		if (!activeTask) throw new Error("CustomBlockConfigAgent requires an active task.");
+
+		await dispatchAgentEvent({ name: "agent_status", data: { status: "Defining custom block contract...", agent: AgentNode.CUSTOM_BLOCK_CONFIG_AGENT, agentId: activeTask.id } });
+		const systemPrompt = `You are Fluxify's Custom Block Config Agent. Determine exact create, update, or delete intent for reusable custom-block metadata and caller parameters.
+${CUSTOM_BLOCK_PARAMETER_CONTRACT}
+## Strict Rules
+- \`create\` requires \`data.name\`, \`data.label\`, and \`data.inputParams\`. Name is lowercase snake_case and becomes runtime block type; never invent a UUID.
+- \`update-partial\` and \`delete\` require exact \`customBlockId\` from task context. Existing custom block names are immutable because caller canvases invoke them by name; only label, description, and inputParams may change.
+- For new custom blocks, this output runs before Block Builder. Define full caller contract now so canvas agent can consume it exactly.
+- Search docs only for an uncovered platform feature. Batch every query in one \`searchQueries\` call.
+## Output Contract
+\`{ "action": "create", "customBlockId": "<planned id>", "data": { "name": "send_notification", "label": "Send Notification", "description": "Sends a notification", "inputParams": [] } }\``;
+		const response = await this.state.agentWrapper.invokeAgent({
+			zodSchema: customBlockConfigSchema,
+			systemPrompt,
+			context: this.state.internal?.metadata?.contextBlock,
+			tools: [searchDocsTool, createFindResourceTool(this.state.internal.dbService, this.state.internal?.metadata ?? {})],
+			messages: [],
+			userQuery: `Task Title: ${activeTask.title}\nTask Description: ${activeTask.description}${activeTask.supervisorReviews ? `\nSupervisor Reviews:\n${activeTask.supervisorReviews}` : ""}`,
+			agentNode: AgentNode.CUSTOM_BLOCK_CONFIG_AGENT,
+			agentId: activeTask.id,
+		}) as z.infer<typeof customBlockConfigSchema>;
+		if (response.action === "create" && !response.customBlockId) response.customBlockId = generateID();
+		await dispatchAgentEvent({ name: "agent_status", data: { status: "Custom block contract formulated", agent: AgentNode.CUSTOM_BLOCK_CONFIG_AGENT, agentId: activeTask.id, data: response } });
+		return { currentAgent: AgentNode.CUSTOM_BLOCK_CONFIG_AGENT, orchestratorState: { ...this.state.orchestratorState, subAgentResults: { ...(this.state.orchestratorState?.subAgentResults ?? {}), [activeTask.id]: response } } };
+	}
+}
+
+export const validateCustomBlockConfigOutput: import("../../types").AgentOutputValidator = (result) => {
+	const value = result as z.infer<typeof customBlockConfigSchema>;
+	if (!value?.action) return "Missing custom block action.";
+	if ((value.action === "update-partial" || value.action === "delete") && !value.customBlockId) return `Action '${value.action}' requires customBlockId.`;
+	if (value.action === "create") {
+		if (!value.data?.name?.match(/^[a-z0-9_]+$/)) return "Custom block create requires lowercase snake_case data.name.";
+		if (!value.data.label?.trim()) return "Custom block create requires data.label.";
+		if (!value.data.inputParams) return "Custom block create requires data.inputParams (use [] when none).";
+	}
+	const names = value.data?.inputParams?.map((p) => p.name) ?? [];
+	if (new Set(names).size !== names.length) return "Custom block inputParams cannot contain duplicate names.";
+	return null;
+};

--- a/apps/ai-gateway/src/harness/agents/sub-agents/customBlockContract.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/customBlockContract.ts
@@ -1,0 +1,17 @@
+/** Shared prompt contract: custom-block settings define it; canvas authoring obeys it. */
+export const CUSTOM_BLOCK_PARAMETER_CONTRACT = `
+## Custom Block Caller Contract
+Custom-block inputParams are public API supplied by caller blocks, not values produced inside callee graph.
+- Declare every value implementation reads as \`params.<name>\` or substitutes as \`param:<name>\`; names must match exactly.
+- \`text_input\`: string; \`checkbox\`: boolean; \`array_editor\`: array; \`dropdown\`: declared string options.
+- \`integration_selector\`: caller supplies integration id. \`app_config_selector\`: caller supplies app-config KEY, never secret/value; read it only with \`getConfig(params.<name>)\`.
+- Never put credentials, app-config values, or connection ids in custom-block definition or data.
+`;
+
+export const CUSTOM_BLOCK_EXECUTION_CONTRACT = `
+## Custom Block Execution
+- A custom block canvas has same DAG rules as route canvas, plus no direct or indirect call to itself.
+- A caller block's \`invoke\` is \`sync\` (default: waits and receives callee output), \`async\` (worker-local fire-and-forget; no output), or \`queued\` (durable background job; no output). Never generate \`scheduled\` — runtime name is \`queued\`.
+- In custom-block canvas, \`params\` remains caller configuration throughout; \`input\` is previous block output. Keep them separate.
+- A response block returns its HTTP result to caller. If graph ends without response, last executed block output flows to caller's next block. When task says "leave graph open", "pass output to caller", or "continue outside custom block", response block is FORBIDDEN: end the final non-response block with \`"connections": []\`.
+`;

--- a/apps/ai-gateway/src/harness/agents/sub-agents/index.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/index.ts
@@ -1,9 +1,17 @@
 import type { SubAgentMetadata } from "./types";
 import { AgentNode } from "../../types";
 export * from "./routeConfig";
+export * from "./customBlockConfig";
 export * from "./blockBuilder";
 
 export const subAgents: SubAgentMetadata[] = [
+	{
+		name: "Custom Block Config Agent",
+		nodeName: AgentNode.CUSTOM_BLOCK_CONFIG_AGENT,
+		ability: "Create, modify, or delete custom block metadata and input parameters",
+		description:
+			"Responsible for defining a reusable custom block's name, label, description and inputParams. For a new custom block, its task MUST run before the dependent Block Builder task; the builder retrieves this output and builds the matching custom-block canvas. Input params are the caller contract: declare every param the implementation reads, with the exact type and no literal secrets.",
+	},
 	{
 		name: "Route Config Agent",
 		nodeName: AgentNode.ROUTE_CONFIG_AGENT,

--- a/apps/ai-gateway/src/harness/agents/summarizer.ts
+++ b/apps/ai-gateway/src/harness/agents/summarizer.ts
@@ -25,6 +25,10 @@ function isRouteConfigResult(r: any): boolean {
 	);
 }
 
+function isCustomBlockConfigResult(r: any): boolean {
+	return r && typeof r.action === "string" && Object.hasOwn(r, "customBlockId");
+}
+
 function isBlockBuilderResult(r: any): boolean {
 	return (
 		r &&
@@ -128,7 +132,11 @@ export class SummarizerAgent extends BaseAgent {
 					const result = (results as Record<string, any>)[task.id];
 					if (!result) continue;
 
-					if (isRouteConfigResult(result)) {
+					if (isCustomBlockConfigResult(result)) {
+						const type = result.action === "create" ? "add" : result.action === "delete" ? "delete" : "changes";
+						const subId = await harnessService.createSubArtifact({ artifactId, runId, subAgentId: task.id, kind: "custom_block", action: type, payload: result });
+						changes.push({ label: result.data?.label ?? result.data?.name ?? task.title, actionLabel: type, agentRole: "Custom block configuration", token: `:customBlock{type="${type}" sub_artifact_id="${subId}"}` });
+					} else if (isRouteConfigResult(result)) {
 						const type =
 							result.action === "create"
 								? "add"
@@ -236,6 +244,7 @@ The "## Changes" section below lists each change with an EXACT token. You must:
 - These tokens MUST sit at the END of their line (nothing after them) so the chip never breaks the sentence:
   - \`:route{type="add|delete|changes" sub_artifact_id="..."}\` — a route (endpoint) that was added, deleted, or changed.
   - \`:canvasChanges{parent_type="artifact|route|custom_block" parent="..." artifact_id="..."}\` — logic/canvas changes. (parent_type="artifact" means the route is brand new this run; "route"/"custom_block" means it references an existing record.)
+  - \`:customBlock{type="add|delete|changes" sub_artifact_id="..."}\` — custom block configuration.
 
 ## B) Creation chips — YOU author these (only from the Hints section)
 When a hint says the user must create something for the run to work, embed the matching chip INLINE where it reads naturally (these are line-safe and do NOT need to be at line end):

--- a/apps/ai-gateway/src/harness/agents/summarizer.ts
+++ b/apps/ai-gateway/src/harness/agents/summarizer.ts
@@ -4,9 +4,9 @@ import { type GlobalGraphState, AgentNode } from "../types";
 import { dispatchAgentEvent } from "../callbacks";
 import { enforceTokenAllowlist } from "./summarizerTokens";
 import {
-	applyArtifact,
 	type ApplyFailure,
 } from "../../api/v1/harness-conversations/artifacts/service";
+import { applyArtifact } from "../../api/v1/harness-conversations/artifacts/applyBatch";
 
 /** A single change the harness made, with its verbatim special-syntax token. */
 interface ChangeRef {
@@ -115,6 +115,9 @@ export class SummarizerAgent extends BaseAgent {
 		// Persist the artifact + sub-artifacts (regular DB work, no AI involved).
 		const changes: ChangeRef[] = [];
 		let artifactId: string | undefined;
+		// taskId -> sub-artifact row, so a later run can tell "this task's output
+		// is already persisted" from "this task only ran in a process that died".
+		const subArtifactIds: Record<string, string> = {};
 
 		// A DB blip here used to throw out of the last node in the graph and fail
 		// the whole run — losing a build whose results are sitting in state. The
@@ -135,6 +138,7 @@ export class SummarizerAgent extends BaseAgent {
 					if (isCustomBlockConfigResult(result)) {
 						const type = result.action === "create" ? "add" : result.action === "delete" ? "delete" : "changes";
 						const subId = await harnessService.createSubArtifact({ artifactId, runId, subAgentId: task.id, kind: "custom_block", action: type, payload: result });
+						subArtifactIds[task.id] = subId;
 						changes.push({ label: result.data?.label ?? result.data?.name ?? task.title, actionLabel: type, agentRole: "Custom block configuration", token: `:customBlock{type="${type}" sub_artifact_id="${subId}"}` });
 					} else if (isRouteConfigResult(result)) {
 						const type =
@@ -151,6 +155,7 @@ export class SummarizerAgent extends BaseAgent {
 							action: type,
 							payload: result,
 						});
+						subArtifactIds[task.id] = subId;
 						if (type === "add") newRouteSubArtifactId = subId;
 						const label =
 							`${result.data?.method ?? ""} ${result.data?.path ?? task.title}`.trim();
@@ -169,6 +174,7 @@ export class SummarizerAgent extends BaseAgent {
 							action: "changes",
 							payload: result,
 						});
+						subArtifactIds[task.id] = subId;
 						let parentType: string;
 						let parentRef: string;
 						if (result.targetType === "route" && result.targetId) {
@@ -320,7 +326,7 @@ ${hintsText}`;
 
 		return {
 			currentAgent: AgentNode.SUMMARIZER,
-			summarizerState: { markdown, artifactId },
+			summarizerState: { markdown, artifactId, subArtifactIds },
 		};
 	}
 }

--- a/apps/ai-gateway/src/harness/agents/summarizerTokens.spec.ts
+++ b/apps/ai-gateway/src/harness/agents/summarizerTokens.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { enforceTokenAllowlist } from "./summarizerTokens";
 
 const ROUTE = ':route{type="add" sub_artifact_id="sub-1"}';
+const CUSTOM_BLOCK = ':customBlock{type="add" sub_artifact_id="sub-2"}';
 const CANVAS =
 	':canvasChanges{parent_type="artifact" parent="sub-1" artifact_id="sub-2"}';
 
@@ -9,6 +10,12 @@ describe("enforceTokenAllowlist", () => {
 	it("keeps the tokens the harness issued", () => {
 		const md = `Built it.\n- Added a route. ${ROUTE}\n- Wired the logic. ${CANVAS}`;
 		expect(enforceTokenAllowlist(md, [ROUTE, CANVAS])).toBe(md);
+	});
+
+	it("keeps an issued custom block token", () => {
+		expect(enforceTokenAllowlist(`Added reusable block. ${CUSTOM_BLOCK}`, [CUSTOM_BLOCK])).toBe(
+			`Added reusable block. ${CUSTOM_BLOCK}`,
+		);
 	});
 
 	it("drops a token the harness never issued, keeping the sentence", () => {

--- a/apps/ai-gateway/src/harness/agents/summarizerTokens.ts
+++ b/apps/ai-gateway/src/harness/agents/summarizerTokens.ts
@@ -1,7 +1,7 @@
 import { logger } from "@fluxify/common";
 
 /** Reference tokens the summarizer may only ever copy, never author. */
-const REFERENCE_TOKEN = /:(?:route|canvasChanges)\{[^}\n]*\}/gi;
+const REFERENCE_TOKEN = /:(?:route|customBlock|canvasChanges)\{[^}\n]*\}/gi;
 
 /**
  * Keeps only the reference tokens the harness actually handed the summarizer.

--- a/apps/ai-gateway/src/harness/agents/supervisor.ts
+++ b/apps/ai-gateway/src/harness/agents/supervisor.ts
@@ -2,6 +2,7 @@ import { BaseAgent } from "./base";
 import { type GlobalGraphState, AgentNode, type Task } from "../types";
 import { dispatchAgentEvent } from "../callbacks";
 import { validateAgentOutput as validateRouteConfig } from "./sub-agents/routeConfig";
+import { validateCustomBlockConfigOutput } from "./sub-agents/customBlockConfig";
 import { validateBlockBuilderOutput } from "./sub-agents/blockBuilder";
 
 /** Total validation rounds a task gets — the first run plus its retries. */
@@ -75,6 +76,9 @@ export class SupervisorAgent extends BaseAgent {
 			switch (task.assignedAgentNode) {
 				case AgentNode.ROUTE_CONFIG_AGENT:
 					error = await validateRouteConfig(result, task.id, this.state);
+					break;
+				case AgentNode.CUSTOM_BLOCK_CONFIG_AGENT:
+					error = await validateCustomBlockConfigOutput(result, task.id, this.state);
 					break;
 				case AgentNode.BLOCK_BUILDER:
 					error = await validateBlockBuilderOutput(result, task.id, this.state);

--- a/apps/ai-gateway/src/harness/agents/taskGenerator.spec.ts
+++ b/apps/ai-gateway/src/harness/agents/taskGenerator.spec.ts
@@ -52,6 +52,13 @@ describe("sanitizeTasks", () => {
 		expect(notes).toEqual([]);
 	});
 
+	it("accepts the custom block config agent", () => {
+		const { tasks } = sanitizeTasks([
+			raw({ assignedAgentNode: AgentNode.CUSTOM_BLOCK_CONFIG_AGENT }),
+		]);
+		expect(tasks[0]!.assignedAgentNode).toBe(AgentNode.CUSTOM_BLOCK_CONFIG_AGENT);
+	});
+
 	it("re-keys duplicate ids so every task still runs", () => {
 		const { tasks, notes } = sanitizeTasks([
 			raw({ id: "dup01", title: "first" }),

--- a/apps/ai-gateway/src/harness/agents/taskGenerator.ts
+++ b/apps/ai-gateway/src/harness/agents/taskGenerator.ts
@@ -214,6 +214,7 @@ ${SUB_AGENTS_TABLE}
 6. **STRICT NO-CYCLE RULE**: Ensure the Dependency Graph is strictly acyclic. No task should depend on itself or form a circular dependency chain.
 7. **Resource Identifiers**: The plan may contain \`:resource{type="..." identifier="..."}\` directives. You MUST extract the exact \`identifier\` value from these directives and explicitly include it in the task description for the assigned sub-agent so they know exactly which resource to operate on. Write the plain ID in the description — do NOT copy the directive syntax into task descriptions.
 8. **Consolidate Tasks**: Combine related tasks that are assigned to the SAME sub-agent to minimize redundant graph executions. For example, if the plan involves adding blocks and connecting blocks, combine them into a single comprehensive task for the Block Builder Agent.
+9. **Custom Block Order**: For a new custom block, first assign one \`customBlockConfig\` task defining metadata and inputParams, then assign the \`blockBuilder\` canvas task with \`dependsOnAgentId\` containing that config task id. The builder task MUST say to fetch that prior output. For an existing custom block whose caller contract changes, use the same order. Do not use \`routeConfig\` for custom blocks.
 
 If there are no sub-agents available, output an empty task list.`;
 

--- a/apps/ai-gateway/src/harness/callbacks.spec.ts
+++ b/apps/ai-gateway/src/harness/callbacks.spec.ts
@@ -153,3 +153,45 @@ describe("harness event contract", () => {
 		expect(events).toHaveLength(0);
 	});
 });
+
+describe("mid-run checkpointing", () => {
+	it("checkpoints after the supervisor, so a build that dies mid-way is resumable", async () => {
+		const { callbacks, liveStateSaves } = harness();
+
+		await callbacks.onAfter(AgentNode.SUPERVISOR, {
+			output: {
+				orchestratorState: {
+					tasks: [
+						{ id: "t-1", title: "A", status: "completed" },
+						{ id: "t-2", title: "B", status: "pending" },
+					],
+					subAgentResults: { "t-1": { action: "create" } },
+				},
+			},
+		});
+		await callbacks.flush();
+
+		expect(liveStateSaves).toHaveLength(1);
+		const tasks = liveStateSaves[0].graphState.orchestratorState.tasks;
+		expect(tasks.map((t: any) => t.status)).toEqual(["completed", "pending"]);
+		// the completed task's output has to survive too, or a resume re-runs it
+		expect(
+			liveStateSaves[0].graphState.orchestratorState.subAgentResults["t-1"],
+		).toBeDefined();
+	});
+
+	it("does not checkpoint after a node nothing reads back", async () => {
+		const { callbacks, liveStateSaves } = harness();
+		await callbacks.onAfter(AgentNode.SUMMARIZER, { output: {} });
+		await callbacks.flush();
+		expect(liveStateSaves).toHaveLength(0);
+	});
+
+	it("exposes the accumulated state for the terminal handlers", async () => {
+		const { callbacks } = harness();
+		await callbacks.onAfter(AgentNode.PLANNER, {
+			output: { plannerState: { markdownPlan: "# plan" } },
+		});
+		expect(callbacks.snapshotState().plannerState?.markdownPlan).toBe("# plan");
+	});
+});

--- a/apps/ai-gateway/src/harness/callbacks.ts
+++ b/apps/ai-gateway/src/harness/callbacks.ts
@@ -178,12 +178,13 @@ export class HarnessCallbacks {
 			case AgentNode.SUMMARIZER:
 				return { node: AgentNode.SUMMARIZER, data: output.summarizerState ?? {} };
 			case AgentNode.BLOCK_BUILDER:
-			case AgentNode.ROUTE_CONFIG_AGENT: {
+			case AgentNode.ROUTE_CONFIG_AGENT:
+			case AgentNode.CUSTOM_BLOCK_CONFIG_AGENT: {
 				const task = output.activeTask ?? input.activeTask;
 				if (!task) return undefined;
 				const result = output.orchestratorState?.subAgentResults?.[task.id];
 				return {
-					node: node as AgentNode.BLOCK_BUILDER | AgentNode.ROUTE_CONFIG_AGENT,
+					node: node as AgentNode.BLOCK_BUILDER | AgentNode.ROUTE_CONFIG_AGENT | AgentNode.CUSTOM_BLOCK_CONFIG_AGENT,
 					data: {
 						task: {
 							id: task.id,

--- a/apps/ai-gateway/src/harness/callbacks.ts
+++ b/apps/ai-gateway/src/harness/callbacks.ts
@@ -41,10 +41,16 @@ const GRAPH_NODES: ReadonlySet<string> = new Set<string>(
 );
 
 /** Nodes whose accumulated state a later run pass actually reads back — i.e.
- *  the ones a HITL resume rehydrates from. See `onAfter`. */
+ *  the ones a resume rehydrates from. See `onAfter`.
+ *
+ *  The supervisor is here because it is the only node that settles task
+ *  statuses, and task statuses are what a resume reads: without a checkpoint
+ *  after it, a run that dies at task 4 of 6 has persisted nothing since
+ *  planning and restarts the whole build. */
 const RESUMABLE_NODES: ReadonlySet<string> = new Set<string>([
 	AgentNode.PLANNER,
 	AgentNode.HUMAN_IN_THE_LOOP,
+	AgentNode.SUPERVISOR,
 ]);
 
 export interface HarnessCallbackContext {
@@ -140,6 +146,13 @@ export class HarnessCallbacks {
 	}
 
 	/** Awaits all scheduled emits. Called by the harness before finalizing. */
+	/** The state accumulated so far. The terminal handlers persist this when a
+	 *  run dies mid-build — the graph never returns a final state on that path,
+	 *  so this is the only surviving record of what the sub-agents produced. */
+	public snapshotState(): Partial<GlobalGraphState> {
+		return this.mergedState;
+	}
+
 	public async flush(): Promise<void> {
 		await this.emitChain;
 	}

--- a/apps/ai-gateway/src/harness/clientContract.ts
+++ b/apps/ai-gateway/src/harness/clientContract.ts
@@ -38,6 +38,7 @@ export type {
 	SummarizerState,
 	SubAgentResult,
 	RouteConfigAgentResult,
+	CustomBlockConfigAgentResult,
 	BlockBuilderAgentResult,
 } from "./types";
 

--- a/apps/ai-gateway/src/harness/graph.ts
+++ b/apps/ai-gateway/src/harness/graph.ts
@@ -8,6 +8,7 @@ import {
 	HumanInTheLoopAgent,
 	SupervisorAgent,
 	RouteConfigAgent,
+	CustomBlockConfigAgent,
 	TaskGeneratorAgent,
 	BlockBuilderAgent,
 	SummarizerAgent,
@@ -40,6 +41,10 @@ const workflow = new StateGraph(GraphState)
 	})
 	.addNode(AgentNode.ROUTE_CONFIG_AGENT, async (state: GlobalGraphState) => {
 		const agent = new RouteConfigAgent(state);
+		return await agent.execute();
+	})
+	.addNode(AgentNode.CUSTOM_BLOCK_CONFIG_AGENT, async (state: GlobalGraphState) => {
+		const agent = new CustomBlockConfigAgent(state);
 		return await agent.execute();
 	})
 	.addNode(AgentNode.BLOCK_BUILDER, async (state: GlobalGraphState) => {
@@ -113,6 +118,7 @@ const workflow = new StateGraph(GraphState)
 	.addEdge(AgentNode.HUMAN_IN_THE_LOOP, END)
 	.addEdge(AgentNode.DISCUSSION, END)
 	.addEdge(AgentNode.ROUTE_CONFIG_AGENT, AgentNode.SUPERVISOR)
+	.addEdge(AgentNode.CUSTOM_BLOCK_CONFIG_AGENT, AgentNode.SUPERVISOR)
 	.addEdge(AgentNode.BLOCK_BUILDER, AgentNode.SUPERVISOR)
 	.addEdge(AgentNode.SUPERVISOR, AgentNode.ORCHESTRATOR)
 	.addEdge(AgentNode.SUMMARIZER, END);

--- a/apps/ai-gateway/src/harness/index.ts
+++ b/apps/ai-gateway/src/harness/index.ts
@@ -357,7 +357,13 @@ export class FluxifyHarness {
 					conversationId: ctx.conversationId,
 					runId: ctx.runId,
 				});
-				await this.interruptRun(ctx, harnessService, userId, budget);
+				await this.interruptRun(
+					ctx,
+					harnessService,
+					userId,
+					budget,
+					callbacks.snapshotState(),
+				);
 				return undefined;
 			}
 
@@ -377,6 +383,7 @@ export class FluxifyHarness {
 				describeFailure(error, lastNode),
 				lastNode,
 				budget,
+				callbacks.snapshotState(),
 			);
 			throw error;
 		} finally {
@@ -553,6 +560,7 @@ export class FluxifyHarness {
 		aiResponse?: string,
 		node?: AgentNodeName,
 		budget?: RunBudget,
+		graphState?: Partial<GlobalGraphState>,
 	) {
 		const message =
 			error instanceof Error ? error.message : error ? String(error) : "failed";
@@ -568,7 +576,11 @@ export class FluxifyHarness {
 				runId: ctx.runId,
 				conversationId: ctx.conversationId,
 				currentState: "failed",
-				workingMemory: {},
+				// Persist what the run got through, not an empty object. Everything
+				// the sub-agents produced up to the failure lives here, and it is
+				// what a resume reads back — erasing it made every failure a full
+				// restart from the planner.
+				graphState,
 			});
 			await harnessService.updateConversationStatus("failed", null);
 			await this.redisService.clearActiveRun(ctx.conversationId);
@@ -605,6 +617,7 @@ export class FluxifyHarness {
 		harnessService: HarnessService,
 		userId: string | null,
 		budget: RunBudget,
+		graphState?: Partial<GlobalGraphState>,
 	) {
 		const message =
 			"Conversation was interrupted by the user before it finished.";
@@ -621,7 +634,9 @@ export class FluxifyHarness {
 				runId: ctx.runId,
 				conversationId: ctx.conversationId,
 				currentState: "interrupted",
-				workingMemory: {},
+				// An interrupt is the case most worth resuming — the user stopped a
+				// run that was working. Keep what it built.
+				graphState,
 			});
 			await harnessService.updateConversationStatus("interrupted", null);
 			await this.redisService.clearActiveRun(ctx.conversationId);

--- a/apps/ai-gateway/src/harness/models/base.spec.ts
+++ b/apps/ai-gateway/src/harness/models/base.spec.ts
@@ -12,6 +12,7 @@ import { tool, type StructuredTool } from "@langchain/core/tools";
 import { BaseAgentWrapper } from "./base";
 import {
 	SUBMIT_RESULT_TOOL,
+	asHistoryMessage,
 	compactToolHistory,
 	flattenToolMessages,
 } from "./toolLoop";
@@ -704,5 +705,32 @@ describe("compactToolHistory", () => {
 		const once = messages[0]!.content;
 		compactToolHistory(messages);
 		expect(messages[0]!.content).toBe(once);
+	});
+});
+
+describe("asHistoryMessage", () => {
+	it("strips tool_calls before the message is re-sent with a human turn", () => {
+		const response = new AIMessage({
+			content: "here you go",
+			tool_calls: [{ id: "call_1", name: "search_docs", args: {} }],
+		});
+		const out = asHistoryMessage(response, "here you go");
+		expect(out.tool_calls ?? []).toHaveLength(0);
+		expect(out.additional_kwargs?.tool_calls).toBeUndefined();
+	});
+
+	it("strips provider tool_calls carried in additional_kwargs", () => {
+		const response = new AIMessage({
+			content: "",
+			additional_kwargs: {
+				tool_calls: [
+					{ id: "call_1", type: "function", function: { name: "x", arguments: "{}" } },
+				],
+				reasoning_content: "hm",
+			},
+		});
+		const out = asHistoryMessage(response, "");
+		expect(out.additional_kwargs?.tool_calls).toBeUndefined();
+		expect(out.additional_kwargs?.reasoning_content).toBe("hm");
 	});
 });

--- a/apps/ai-gateway/src/harness/models/base.ts
+++ b/apps/ai-gateway/src/harness/models/base.ts
@@ -23,6 +23,7 @@ import {
 import {
 	SUBMIT_RESULT_TOOL,
 	SUBMIT_RESULT_INSTRUCTION,
+	asHistoryMessage,
 	compactToolHistory,
 	debugPrompt,
 	flattenToolMessages,
@@ -696,7 +697,7 @@ ${JSON.stringify(jsonSchema, null, 2)}`;
 
 				modifiedMessages = [
 					...modifiedMessages,
-					this.asHistoryMessage(rawResponse, content),
+					asHistoryMessage(rawResponse, content),
 					new HumanMessage(
 						`Your previous response did not satisfy the required JSON schema.
 
@@ -712,33 +713,6 @@ Respond again with ONLY the corrected JSON object. Use the exact property names 
 		throw new Error(
 			`Failed to parse structured output after ${STRUCTURED_OUTPUT_ATTEMPTS} attempts. Error: ${describeSchemaError(lastError)}`,
 		);
-	}
-
-	/**
-	 * Feeds the model's own message back into the correction turn, rather than a
-	 * fresh AIMessage built from the cleaned text. Reasoning models carry their
-	 * thinking in content blocks or `additional_kwargs.reasoning_content`, and
-	 * dropping it makes attempt 2 re-derive (and re-botch) the same answer.
-	 */
-	private asHistoryMessage(response: unknown, cleaned: string): AIMessage {
-		const raw = response as
-			| { content?: unknown; additional_kwargs?: Record<string, any> }
-			| undefined;
-		if (!raw) return new AIMessage(cleaned || "(empty response)");
-
-		const hasContent =
-			typeof raw.content === "string"
-				? raw.content.trim() !== ""
-				: Array.isArray(raw.content) && raw.content.length > 0;
-
-		if (hasContent && response instanceof AIMessage) return response;
-
-		return new AIMessage({
-			content: hasContent
-				? (raw.content as any)
-				: extractText(raw as any) || "(empty response)",
-			additional_kwargs: raw.additional_kwargs ?? {},
-		});
 	}
 
 }

--- a/apps/ai-gateway/src/harness/models/toolLoop.ts
+++ b/apps/ai-gateway/src/harness/models/toolLoop.ts
@@ -159,3 +159,45 @@ export function debugPrompt(
 		breakdown: messages.map((m) => `${m.getType()}:${size(m)}`).join(" "),
 	});
 }
+
+/**
+ * Feeds the model's own message back into the correction turn, rather than a
+ * fresh AIMessage built from the cleaned text. Reasoning models carry their
+ * thinking in content blocks or `additional_kwargs.reasoning_content`, and
+ * dropping it makes attempt 2 re-derive (and re-botch) the same answer.
+ */
+export function asHistoryMessage(response: unknown, cleaned: string): AIMessage {
+	const raw = response as
+		| { content?: unknown; additional_kwargs?: Record<string, any> }
+		| undefined;
+	if (!raw) return new AIMessage(cleaned || "(empty response)");
+
+	const hasContent =
+		typeof raw.content === "string"
+			? raw.content.trim() !== ""
+			: Array.isArray(raw.content) && raw.content.length > 0;
+
+	// A tool call must never ride into the correction turn. The next thing we
+	// append is a HumanMessage, and an assistant message carrying `tool_calls`
+	// with no ToolMessage answering it is rejected outright ("insufficient tool
+	// messages following tool_calls message") — so every remaining attempt 400s
+	// on the history instead of on the answer. This model is unbound; it has no
+	// tools to call here anyway.
+	const { tool_calls: _tc, ...kwargs } = raw.additional_kwargs ?? {};
+	const hasToolCalls =
+		(response instanceof AIMessage && response.tool_calls?.length) ||
+		Array.isArray(raw.additional_kwargs?.tool_calls);
+
+	if (hasContent && response instanceof AIMessage && !hasToolCalls)
+		return response;
+
+	return new AIMessage({
+		content: hasContent
+			? (raw.content as any)
+			: extractText(raw as any) ||
+				(hasToolCalls
+					? "(attempted a tool call — no tools are available at this step)"
+					: "(empty response)"),
+		additional_kwargs: kwargs,
+	});
+}

--- a/apps/ai-gateway/src/harness/streamTypes.ts
+++ b/apps/ai-gateway/src/harness/streamTypes.ts
@@ -96,8 +96,12 @@ export type HarnessNodePayload =
 			data: { task: HarnessTaskView; result?: SubAgentResult };
 	  }
 	| {
-			node: `${AgentNode.ROUTE_CONFIG_AGENT}`;
-			data: { task: HarnessTaskView; result?: SubAgentResult };
+		node: `${AgentNode.ROUTE_CONFIG_AGENT}`;
+		data: { task: HarnessTaskView; result?: SubAgentResult };
+	  }
+	| {
+		node: `${AgentNode.CUSTOM_BLOCK_CONFIG_AGENT}`;
+		data: { task: HarnessTaskView; result?: SubAgentResult };
 	  }
 	| {
 			node: `${AgentNode.SUPERVISOR}`;
@@ -173,6 +177,7 @@ export interface HarnessSnapshot {
 const SUB_AGENT_NODES: ReadonlySet<AgentNodeName> = new Set<AgentNodeName>([
 	AgentNode.BLOCK_BUILDER,
 	AgentNode.ROUTE_CONFIG_AGENT,
+	AgentNode.CUSTOM_BLOCK_CONFIG_AGENT,
 ]);
 
 export function levelForNode(node: HarnessEventNode): HarnessLevel {
@@ -195,6 +200,7 @@ const NODE_LABELS: Record<string, string> = {
 	[AgentNode.ORCHESTRATOR]: "orchestrator",
 	[AgentNode.HUMAN_IN_THE_LOOP]: "plan review",
 	[AgentNode.ROUTE_CONFIG_AGENT]: "route configurator",
+	[AgentNode.CUSTOM_BLOCK_CONFIG_AGENT]: "custom block configurator",
 	[AgentNode.SUPERVISOR]: "supervisor",
 	[AgentNode.SUMMARIZER]: "summarizer",
 	[RUN_NODE]: "AI harness",
@@ -244,6 +250,10 @@ const NODE_MESSAGES: Record<string, { started: string; ended: string }> = {
 	[AgentNode.ROUTE_CONFIG_AGENT]: {
 		started: "Configuring the API route",
 		ended: "Route configured",
+	},
+	[AgentNode.CUSTOM_BLOCK_CONFIG_AGENT]: {
+		started: "Defining custom block parameters",
+		ended: "Custom block configured",
 	},
 	[AgentNode.SUPERVISOR]: {
 		started: "Reviewing task results",
@@ -313,6 +323,7 @@ export function runStatusForNode(node: HarnessEventNode): HarnessRunStatus {
 			return "orchestrating";
 		case AgentNode.BLOCK_BUILDER:
 		case AgentNode.ROUTE_CONFIG_AGENT:
+		case AgentNode.CUSTOM_BLOCK_CONFIG_AGENT:
 			return "executing";
 		case AgentNode.HUMAN_IN_THE_LOOP:
 			return "awaiting_hitl";

--- a/apps/ai-gateway/src/harness/tools/getBlockSchemas.ts
+++ b/apps/ai-gateway/src/harness/tools/getBlockSchemas.ts
@@ -26,6 +26,9 @@ function mapInputParamsToNaturalLanguage(inputParams: any[]): string {
 			case "integration_selector":
 				typeStr = "string // integration id";
 				break;
+			case "app_config_selector":
+				typeStr = "string // app config key; use getConfig(params.<name>), never a literal secret";
+				break;
 			case "dropdown":
 				if (param.options && Array.isArray(param.options)) {
 					const opts = param.options.map((opt: any) => `"${opt.value}"`);

--- a/apps/ai-gateway/src/harness/types.ts
+++ b/apps/ai-gateway/src/harness/types.ts
@@ -13,6 +13,7 @@ export enum AgentNode {
 	ORCHESTRATOR = "orchestrator",
 	HUMAN_IN_THE_LOOP = "humanInTheLoop",
 	ROUTE_CONFIG_AGENT = "routeConfig",
+	CUSTOM_BLOCK_CONFIG_AGENT = "customBlockConfig",
 	SUPERVISOR = "supervisor",
 	SUMMARIZER = "summarizer",
 }
@@ -143,8 +144,20 @@ export interface BlockBuilderAgentResult {
 	blocks: Record<string, unknown>[];
 }
 
+export interface CustomBlockConfigAgentResult {
+	action: "create" | "delete" | "update-partial";
+	customBlockId?: string;
+	data?: {
+		name?: string;
+		label?: string;
+		description?: string;
+		inputParams?: Array<Record<string, unknown>>;
+	};
+}
+
 export type SubAgentResult =
 	| RouteConfigAgentResult
+	| CustomBlockConfigAgentResult
 	| BlockBuilderAgentResult
 	| Record<string, any>;
 

--- a/apps/ai-gateway/src/harness/types.ts
+++ b/apps/ai-gateway/src/harness/types.ts
@@ -120,6 +120,10 @@ export interface SummarizerState {
 	markdown?: string;
 	/** The parent artifact row this summary was persisted to. */
 	artifactId?: string;
+	/** Sub-artifact row id per task id. A resumed run reads this to tell work
+	 *  that was persisted from work that only ever existed in the dead run's
+	 *  memory — without it, re-running a task duplicates its artifact. */
+	subArtifactIds?: Record<string, string>;
 }
 
 export interface RouteConfigAgentResult {

--- a/apps/portal/src/components/ai/AiDirectives.tsx
+++ b/apps/portal/src/components/ai/AiDirectives.tsx
@@ -77,6 +77,19 @@ export function RouteButton(props: RouteButtonProps) {
 	);
 }
 
+export function CustomBlockButton(props: RouteButtonProps) {
+	const { type, sub_artifact_id } = props;
+	const setSelectedArtifact = useAiHarnessStore((s) => s.setSelectedArtifact);
+	return (
+		<div className="mt-2 mb-4">
+			<Button size="sm" className="bg-surface-secondary border border-border hover:bg-surface text-foreground flex items-center gap-2 cursor-pointer" onPress={() => setSelectedArtifact({ id: sub_artifact_id, type: `Custom Block ${type}`, props })}>
+				<FiBox className="h-4 w-4 text-foreground/70" />
+				<span>View Custom Block {type === "add" ? "Creation" : type === "delete" ? "Deletion" : "Changes"}</span>
+			</Button>
+		</div>
+	);
+}
+
 interface CanvasChangesButtonProps {
 	parent_type: "artifact" | "route" | "custom_block";
 	parent: string;

--- a/apps/portal/src/components/ai/AiDirectives.tsx
+++ b/apps/portal/src/components/ai/AiDirectives.tsx
@@ -80,10 +80,16 @@ export function RouteButton(props: RouteButtonProps) {
 export function CustomBlockButton(props: RouteButtonProps) {
 	const { type, sub_artifact_id } = props;
 	const setSelectedArtifact = useAiHarnessStore((s) => s.setSelectedArtifact);
+	const applied = useIsApplied(sub_artifact_id);
+
 	return (
 		<div className="mt-2 mb-4">
-			<Button size="sm" className="bg-surface-secondary border border-border hover:bg-surface text-foreground flex items-center gap-2 cursor-pointer" onPress={() => setSelectedArtifact({ id: sub_artifact_id, type: `Custom Block ${type}`, props })}>
-				<FiBox className="h-4 w-4 text-foreground/70" />
+			<Button
+				size="sm"
+				className={applied ? VIEW_BTN_APPLIED : VIEW_BTN}
+				onPress={() => setSelectedArtifact({ id: sub_artifact_id, type: `Custom Block ${type}`, props })}
+			>
+				{applied ? <TbCheck className="h-4 w-4" /> : <FiBox className="h-4 w-4 text-foreground/70" />}
 				<span>View Custom Block {type === "add" ? "Creation" : type === "delete" ? "Deletion" : "Changes"}</span>
 			</Button>
 		</div>

--- a/apps/portal/src/components/ai/ArtifactsSidebar.tsx
+++ b/apps/portal/src/components/ai/ArtifactsSidebar.tsx
@@ -2,6 +2,7 @@ import { useAiHarnessStore } from "@/store/aiHarness";
 import { TbChevronsRight } from "react-icons/tb";
 import { RouteArtifact } from "./artifacts/RouteArtifact";
 import { CanvasArtifact } from "./artifacts/CanvasArtifact";
+import { CustomBlockArtifact } from "./artifacts/CustomBlockArtifact";
 
 export function ArtifactsSidebar() {
 	const selectedArtifact = useAiHarnessStore((s) => s.selectedArtifact);
@@ -38,6 +39,8 @@ export function ArtifactsSidebar() {
 							key={selectedArtifact.id}
 							subArtifactId={selectedArtifact.id}
 						/>
+					) : selectedArtifact?.type.startsWith("Custom Block ") ? (
+						<CustomBlockArtifact key={selectedArtifact.id} subArtifactId={selectedArtifact.id} />
 					) : (selectedArtifact && (
 						<div className="flex flex-col gap-5">
 							<div>

--- a/apps/portal/src/components/ai/MarkdownViewer.tsx
+++ b/apps/portal/src/components/ai/MarkdownViewer.tsx
@@ -8,6 +8,7 @@ import {
 	CreationInlineBtn,
 	RouteButton,
 	CanvasChangesButton,
+	CustomBlockButton,
 } from "./AiDirectives";
 import { ResourceChip } from "./ResourceChip";
 
@@ -78,6 +79,7 @@ export function MarkdownViewer({ content }: MarkdownViewerProps) {
 					"ai-createroute": (props: any) => <CreationInlineBtn kind="Route" {...props} />,
 					"ai-createcustomblock": (props: any) => <CreationInlineBtn kind="Custom Block" {...props} />,
 					"ai-route": (props: any) => <RouteButton {...props} />,
+					"ai-customblock": (props: any) => <CustomBlockButton {...props} />,
 					"ai-canvaschanges": (props: any) => <CanvasChangesButton {...props} />,
 				} as any}
 			>

--- a/apps/portal/src/components/ai/artifacts/ApplyBar.tsx
+++ b/apps/portal/src/components/ai/artifacts/ApplyBar.tsx
@@ -11,9 +11,11 @@ import { useArtifactParams } from "./useArtifact";
 function Applied({
 	appliedAt,
 	routeId,
+	customBlockId,
 }: {
 	appliedAt: string | Date;
 	routeId?: string;
+	customBlockId?: string;
 }) {
 	const { projectId } = useArtifactParams();
 	return (
@@ -26,6 +28,17 @@ function Applied({
 						className="flex items-center gap-2"
 					>
 						Go to route <TbExternalLink size={14} />
+					</Link>
+				</Button>
+			)}
+			{customBlockId && (
+				<Button size="sm" className="cursor-pointer">
+					<Link
+						to="/$projectId/custom-block-canvas/$blockId"
+						params={{ projectId, blockId: customBlockId }}
+						className="flex items-center gap-2"
+					>
+						Go to custom block <TbExternalLink size={14} />
 					</Link>
 				</Button>
 			)}
@@ -59,17 +72,20 @@ export function ApplyBar({
 	subArtifactId,
 	appliedAt,
 	routeId,
+	customBlockId,
 	label = "Apply",
 }: {
 	subArtifactId: string;
 	appliedAt: string | Date | null;
 	/** live route to link to once applied; omit to only show the applied stamp */
 	routeId?: string;
+	/** live custom block to link to once applied */
+	customBlockId?: string;
 	label?: string;
 }) {
 	const { run, isPending } = useApply();
 
-	if (appliedAt) return <Applied appliedAt={appliedAt} routeId={routeId} />;
+	if (appliedAt) return <Applied appliedAt={appliedAt} routeId={routeId} customBlockId={customBlockId} />;
 
 	return (
 		<Button

--- a/apps/portal/src/components/ai/artifacts/CustomBlockArtifact.tsx
+++ b/apps/portal/src/components/ai/artifacts/CustomBlockArtifact.tsx
@@ -1,0 +1,40 @@
+import { harnessConversationsQuery } from "@/query/harnessConversationsQuery";
+import { ApplyBar } from "./ApplyBar";
+import { CanvasPreview } from "./CanvasPreview";
+import { useArtifactParams, useCustomBlockCanvasArtifact, useRunSiblings } from "./useArtifact";
+
+export function CustomBlockArtifact({ subArtifactId }: { subArtifactId: string }) {
+	const { projectId, conversationId } = useArtifactParams();
+	const { data: detail, isLoading } = harnessConversationsQuery.subArtifacts.useDetailQuery(projectId, conversationId, subArtifactId);
+	const payload = (detail?.payload ?? {}) as {
+		action?: "create" | "delete" | "update-partial";
+		customBlockId?: string;
+		data?: { name?: string; label?: string; description?: string; inputParams?: Array<{ name?: string; type?: string; label?: string }> };
+	};
+	const action = payload.action ?? "create";
+	const customBlockId = payload.customBlockId ?? "";
+	const data = payload.data ?? {};
+	const canvasSibling = useRunSiblings(detail?.runId, "canvas").find(
+		(s) => s.payload?.targetType === "custom_block" && s.payload?.targetId === customBlockId,
+	);
+	const { graph: canvasGraph } = useCustomBlockCanvasArtifact(canvasSibling);
+	if (isLoading) return <p className="text-sm text-muted">Loading…</p>;
+	if (!detail) return <p className="text-sm text-muted">Not found.</p>;
+	return <div className="flex flex-col gap-4">
+		<div className="flex items-center gap-2">
+			<span className="text-xs px-2 py-0.5 rounded-md border border-border bg-surface-secondary uppercase tracking-wider text-foreground">{action}</span>
+			{detail.appliedAt && <span className="text-xs px-2 py-0.5 rounded-md border border-success/30 bg-success/10 text-foreground">applied</span>}
+		</div>
+		<div className="rounded-xl border border-border bg-surface-secondary p-3">
+			<p className="text-sm font-medium text-foreground">{data.label ?? data.name ?? "Custom block"}</p>
+			{data.name && <p className="text-xs font-mono text-muted mt-1">{data.name}</p>}
+			{data.description && <p className="text-xs text-muted mt-2">{data.description}</p>}
+		</div>
+		<div className="flex flex-col gap-2">
+			<span className="text-[10px] text-muted uppercase font-bold tracking-wider">Caller parameters</span>
+			{data.inputParams?.length ? data.inputParams.map((param, index) => <div key={`${param.name ?? "param"}-${index}`} className="flex items-center justify-between gap-3 rounded-md border border-border bg-surface-secondary px-3 py-2"><span className="text-sm font-mono text-foreground">{param.name ?? "unnamed"}</span><span className="text-xs text-muted">{param.type ?? "unknown"}{param.label ? ` · ${param.label}` : ""}</span></div>) : <p className="text-sm text-muted">No caller parameters</p>}
+		</div>
+		{canvasSibling && canvasGraph.blocks.length > 0 && <div className="flex flex-col gap-2"><span className="text-[10px] text-muted uppercase font-bold tracking-wider">Canvas changes</span><CanvasPreview graph={canvasGraph} title="Proposed custom-block canvas" /></div>}
+		<ApplyBar subArtifactId={detail.id} appliedAt={detail.appliedAt} customBlockId={action === "delete" ? undefined : (payload.customBlockId ?? undefined)} label={`${action === "delete" ? "Delete" : action === "update-partial" ? "Update" : "Create"} custom block${canvasSibling ? " with canvas" : ""}`} />
+	</div>;
+}

--- a/apps/portal/src/components/ai/artifacts/CustomBlockArtifact.tsx
+++ b/apps/portal/src/components/ai/artifacts/CustomBlockArtifact.tsx
@@ -1,40 +1,354 @@
+import { Checkbox, Tabs } from "@fluxify/components";
+import {
+	TbChevronDown,
+	TbKey,
+	TbList,
+	TbPlug,
+	TbPlus,
+} from "react-icons/tb";
 import { harnessConversationsQuery } from "@/query/harnessConversationsQuery";
+import { customBlocksQuery } from "@/query/customBlocksQuery";
 import { ApplyBar } from "./ApplyBar";
 import { CanvasPreview } from "./CanvasPreview";
-import { useArtifactParams, useCustomBlockCanvasArtifact, useRunSiblings } from "./useArtifact";
+import { Field } from "./Field";
+import {
+	useArtifactParams,
+	useCustomBlockCanvasArtifact,
+	useRunSiblings,
+} from "./useArtifact";
+
+/** What the custom block sub-agent writes (see ai-gateway `CustomBlockConfigPayload`). */
+type InputParam = {
+	name?: string;
+	type?: string;
+	label?: string;
+	description?: string;
+	group?: string;
+	variant?: string;
+	options?: Array<{ label?: string; value?: string }>;
+};
+
+type CustomBlockConfigPayload = {
+	action?: "create" | "delete" | "update-partial";
+	customBlockId?: string | null;
+	data?: {
+		name?: string | null;
+		label?: string | null;
+		description?: string | null;
+		inputParams?: InputParam[] | null;
+	} | null;
+};
+
+/** A dead control that looks like the real one. The caller configures this block
+ *  through the settings panel in `blocks/CustomBlockSettings.tsx`; those fields
+ *  are wired to canvas change-tracking and cannot render outside a canvas, so
+ *  each type gets a matching read-only stand-in here. */
+function ControlPreview({ param }: { param: InputParam }) {
+	const box =
+		"flex items-center gap-2 rounded-lg border border-border bg-surface px-2.5 py-1.5 text-xs text-muted";
+
+	switch (param.type) {
+		case "checkbox":
+			return (
+				<Checkbox isSelected={false} isDisabled label={param.label ?? param.name} />
+			);
+
+		case "dropdown": {
+			const options = param.options ?? [];
+			return (
+				<div className="flex flex-col gap-1.5">
+					<div className={`${box} justify-between`}>
+						<span>{options[0]?.label ?? options[0]?.value ?? "Select…"}</span>
+						<TbChevronDown size={14} className="shrink-0" />
+					</div>
+					{options.length > 1 && (
+						<div className="flex flex-wrap gap-1">
+							{options.map((option, index) => (
+								<span
+									key={`${option.value ?? option.label}-${index}`}
+									className="rounded-md border border-border bg-surface-secondary px-1.5 py-0.5 font-mono text-[11px] text-muted"
+								>
+									{option.value ?? option.label}
+								</span>
+							))}
+						</div>
+					)}
+				</div>
+			);
+		}
+
+		case "array_editor":
+			return (
+				<div className="flex flex-col gap-1.5">
+					<div className={box}>
+						<TbList size={14} className="shrink-0" />
+						<span>item 1</span>
+					</div>
+					<div className="flex items-center gap-1.5 text-[11px] text-muted/70">
+						<TbPlus size={12} />
+						<span>caller adds any number of entries</span>
+					</div>
+				</div>
+			);
+
+		case "integration_selector":
+			return (
+				<div className={`${box} justify-between`}>
+					<span className="flex items-center gap-2">
+						<TbPlug size={14} className="shrink-0" />
+						Pick a connection
+					</span>
+					{param.group && (
+						<span className="rounded-md border border-border bg-surface-secondary px-1.5 py-0.5 font-mono text-[11px]">
+							{param.group}
+							{param.variant ? ` · ${param.variant}` : ""}
+						</span>
+					)}
+				</div>
+			);
+
+		case "app_config_selector":
+			return (
+				<div className={box}>
+					<TbKey size={14} className="shrink-0" />
+					<span>
+						Pick a config key — read at runtime with{" "}
+						<code className="font-mono text-foreground/70">
+							getConfig(params.{param.name ?? "key"})
+						</code>
+					</span>
+				</div>
+			);
+
+		case "text_input":
+			return (
+				<div className={box}>
+					<span className="text-muted/70">value or</span>
+					<code className="font-mono text-foreground/70">js: expression</code>
+				</div>
+			);
+
+		default:
+			return (
+				<div className={box}>
+					<span>Unknown parameter type “{param.type ?? "—"}”</span>
+				</div>
+			);
+	}
+}
+
+/** The caller-facing name for each type — "Text" reads better above a field than
+ *  `text_input` does. */
+const TYPE_LABEL: Record<string, string> = {
+	text_input: "Text",
+	checkbox: "Toggle",
+	dropdown: "Dropdown",
+	array_editor: "List",
+	integration_selector: "Integration",
+	app_config_selector: "App config",
+};
+
+function ParamRow({
+	param,
+	state,
+}: {
+	param: InputParam;
+	state: "added" | "removed" | "kept";
+}) {
+	const tone =
+		state === "added"
+			? "border-success/30 bg-success/5"
+			: state === "removed"
+				? "border-danger/30 bg-danger/5"
+				: "border-border bg-surface-secondary";
+
+	return (
+		<div className={`flex flex-col gap-2 rounded-lg border p-3 ${tone}`}>
+			<div className="flex items-start justify-between gap-3">
+				<div className="flex min-w-0 flex-col gap-0.5">
+					<span
+						className={`text-sm font-medium ${
+							state === "removed" ? "text-muted line-through" : "text-foreground"
+						}`}
+					>
+						{param.label || param.name || "Unnamed"}
+					</span>
+					{/* the key the implementation reads as `params.<name>` */}
+					<span className="font-mono text-[11px] text-muted break-all">
+						params.{param.name ?? "unnamed"}
+					</span>
+				</div>
+				<div className="flex shrink-0 items-center gap-1.5">
+					<span className="rounded-md border border-border bg-surface px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-muted">
+						{TYPE_LABEL[param.type ?? ""] ?? param.type ?? "unknown"}
+					</span>
+					{state !== "kept" && (
+						<span
+							className={`text-[10px] font-bold uppercase tracking-wider ${
+								state === "added" ? "text-success" : "text-danger"
+							}`}
+						>
+							{state}
+						</span>
+					)}
+				</div>
+			</div>
+
+			{param.description && (
+				<p className="text-xs text-muted break-words">{param.description}</p>
+			)}
+
+			{state !== "removed" && <ControlPreview param={param} />}
+		</div>
+	);
+}
 
 export function CustomBlockArtifact({ subArtifactId }: { subArtifactId: string }) {
 	const { projectId, conversationId } = useArtifactParams();
-	const { data: detail, isLoading } = harnessConversationsQuery.subArtifacts.useDetailQuery(projectId, conversationId, subArtifactId);
-	const payload = (detail?.payload ?? {}) as {
-		action?: "create" | "delete" | "update-partial";
-		customBlockId?: string;
-		data?: { name?: string; label?: string; description?: string; inputParams?: Array<{ name?: string; type?: string; label?: string }> };
-	};
+	const { data: detail, isLoading } =
+		harnessConversationsQuery.subArtifacts.useDetailQuery(
+			projectId,
+			conversationId,
+			subArtifactId,
+		);
+
+	const payload = (detail?.payload ?? {}) as CustomBlockConfigPayload;
 	const action = payload.action ?? "create";
 	const customBlockId = payload.customBlockId ?? "";
-	const data = payload.data ?? {};
+	const proposed = payload.data ?? {};
+
+	// A create has nothing to merge against; for an update this is what the
+	// caller contract looks like today, which is the whole point of the diff.
+	const { data: blocks } = customBlocksQuery.getAll.useQuery(projectId);
+	const existing = blocks?.find((b) => b.id === customBlockId);
+	const existingParams: InputParam[] = Array.isArray(existing?.inputParams)
+		? (existing.inputParams as InputParam[])
+		: [];
+
+	// The same run may have built this block's logic. Showing it here is the only
+	// way to tell whether the graph changed before applying the contract.
 	const canvasSibling = useRunSiblings(detail?.runId, "canvas").find(
-		(s) => s.payload?.targetType === "custom_block" && s.payload?.targetId === customBlockId,
+		(s) =>
+			s.payload?.targetType === "custom_block" &&
+			s.payload?.targetId === customBlockId,
 	);
 	const { graph: canvasGraph } = useCustomBlockCanvasArtifact(canvasSibling);
+
 	if (isLoading) return <p className="text-sm text-muted">Loading…</p>;
 	if (!detail) return <p className="text-sm text-muted">Not found.</p>;
-	return <div className="flex flex-col gap-4">
-		<div className="flex items-center gap-2">
-			<span className="text-xs px-2 py-0.5 rounded-md border border-border bg-surface-secondary uppercase tracking-wider text-foreground">{action}</span>
-			{detail.appliedAt && <span className="text-xs px-2 py-0.5 rounded-md border border-success/30 bg-success/10 text-foreground">applied</span>}
+
+	const isDelete = action === "delete";
+	const title = proposed.label || existing?.label || proposed.name || existing?.name;
+	const name = proposed.name || existing?.name || "";
+
+	// `inputParams` is the caller's public API, so an added or dropped param is
+	// the change that actually breaks callers — worth more than a JSON blob.
+	const nextParams = proposed.inputParams ?? null;
+	const nextNames = new Set((nextParams ?? []).map((p) => p.name));
+	const removed = nextParams
+		? existingParams.filter((p) => !nextNames.has(p.name))
+		: [];
+	const existingNames = new Set(existingParams.map((p) => p.name));
+	const shownParams = nextParams ?? existingParams;
+
+	return (
+		<div className="flex flex-col gap-5">
+			<div className="rounded-xl border border-border bg-surface-secondary p-3 flex flex-col gap-2">
+				<div className="flex items-center gap-2">
+					<span className="text-xs px-2 py-0.5 rounded-md border border-border bg-surface uppercase tracking-wider text-foreground">
+						{action}
+					</span>
+					{detail.appliedAt && (
+						<span className="text-xs px-2 py-0.5 rounded-md border border-success/30 bg-success/10 text-success">
+							applied
+						</span>
+					)}
+				</div>
+				<p className="text-sm font-medium text-foreground break-words">
+					{title || "Custom block"}
+				</p>
+				{name && <p className="text-xs font-mono text-muted break-all">{name}</p>}
+			</div>
+
+			{isDelete ? (
+				<Field label="Custom block" current={existing?.label ?? name ?? customBlockId} />
+			) : (
+				// Same split as the route panel: identity in one tab, the caller
+				// contract in another — the parameter list is the long one.
+				<Tabs defaultSelectedKey="general" className="flex flex-col gap-3">
+					<Tabs.List aria-label="Custom block settings" className="w-full">
+						<Tabs.Tab id="general">General</Tabs.Tab>
+						<Tabs.Tab id="params">
+							Parameters{shownParams.length ? ` (${shownParams.length})` : ""}
+						</Tabs.Tab>
+					</Tabs.List>
+
+					<Tabs.Panel id="general" className="flex flex-col gap-4">
+						<Field label="Label" current={existing?.label} next={proposed.label} />
+						{/* the runtime block type — immutable once callers invoke it */}
+						<Field label="Name" current={existing?.name} next={proposed.name} />
+						<Field
+							label="Description"
+							current={existing?.description}
+							next={proposed.description}
+						/>
+					</Tabs.Panel>
+
+					<Tabs.Panel id="params" className="flex flex-col gap-2">
+						<div className="flex flex-col gap-0.5">
+							<span className="text-[10px] text-muted uppercase font-bold tracking-wider">
+								Caller parameters
+							</span>
+							<span className="text-xs text-muted/70">
+								How this block's settings panel will look to whoever invokes it.
+							</span>
+						</div>
+						{shownParams.length === 0 && removed.length === 0 ? (
+							<p className="text-sm text-muted">No caller parameters</p>
+						) : (
+							<>
+								{shownParams.map((param, index) => (
+									<ParamRow
+										key={`${param.name ?? "param"}-${index}`}
+										param={param}
+										state={
+											nextParams && !existingNames.has(param.name) && existing
+												? "added"
+												: "kept"
+										}
+									/>
+								))}
+								{removed.map((param, index) => (
+									<ParamRow
+										key={`removed-${param.name ?? "param"}-${index}`}
+										param={param}
+										state="removed"
+									/>
+								))}
+							</>
+						)}
+					</Tabs.Panel>
+				</Tabs>
+			)}
+
+			{canvasSibling && canvasGraph.blocks.length > 0 && (
+				<div className="flex flex-col gap-2">
+					<span className="text-[10px] text-muted uppercase font-bold tracking-wider">
+						Canvas changes
+					</span>
+					<CanvasPreview graph={canvasGraph} title="Proposed custom-block canvas" />
+				</div>
+			)}
+
+			<ApplyBar
+				subArtifactId={detail.id}
+				appliedAt={detail.appliedAt}
+				// a deleted block has nothing left to open
+				customBlockId={isDelete ? undefined : (payload.customBlockId ?? undefined)}
+				label={`${
+					isDelete ? "Delete" : action === "update-partial" ? "Update" : "Create"
+				} custom block${canvasSibling ? " with canvas" : ""}`}
+			/>
 		</div>
-		<div className="rounded-xl border border-border bg-surface-secondary p-3">
-			<p className="text-sm font-medium text-foreground">{data.label ?? data.name ?? "Custom block"}</p>
-			{data.name && <p className="text-xs font-mono text-muted mt-1">{data.name}</p>}
-			{data.description && <p className="text-xs text-muted mt-2">{data.description}</p>}
-		</div>
-		<div className="flex flex-col gap-2">
-			<span className="text-[10px] text-muted uppercase font-bold tracking-wider">Caller parameters</span>
-			{data.inputParams?.length ? data.inputParams.map((param, index) => <div key={`${param.name ?? "param"}-${index}`} className="flex items-center justify-between gap-3 rounded-md border border-border bg-surface-secondary px-3 py-2"><span className="text-sm font-mono text-foreground">{param.name ?? "unnamed"}</span><span className="text-xs text-muted">{param.type ?? "unknown"}{param.label ? ` · ${param.label}` : ""}</span></div>) : <p className="text-sm text-muted">No caller parameters</p>}
-		</div>
-		{canvasSibling && canvasGraph.blocks.length > 0 && <div className="flex flex-col gap-2"><span className="text-[10px] text-muted uppercase font-bold tracking-wider">Canvas changes</span><CanvasPreview graph={canvasGraph} title="Proposed custom-block canvas" /></div>}
-		<ApplyBar subArtifactId={detail.id} appliedAt={detail.appliedAt} customBlockId={action === "delete" ? undefined : (payload.customBlockId ?? undefined)} label={`${action === "delete" ? "Delete" : action === "update-partial" ? "Update" : "Create"} custom block${canvasSibling ? " with canvas" : ""}`} />
-	</div>;
+	);
 }

--- a/apps/portal/src/components/ai/artifacts/Field.tsx
+++ b/apps/portal/src/components/ai/artifacts/Field.tsx
@@ -1,0 +1,44 @@
+/** One before/after row in an artifact panel. Shared by the route and custom
+ *  block panels — both show "this is what the agent wants to change". */
+export function Field({
+	label,
+	current,
+	next,
+}: {
+	label: string;
+	current?: unknown;
+	next?: unknown;
+}) {
+	const text = (v: unknown) =>
+		v === undefined || v === null || v === ""
+			? ""
+			: typeof v === "string"
+				? v
+				: JSON.stringify(v, null, 2);
+	const before = text(current);
+	const after = text(next);
+	// nothing proposed for this field → it stays as-is, show one box
+	const changed = after !== "" && after !== before;
+
+	return (
+		<div>
+			<span className="text-[10px] text-muted uppercase font-bold tracking-wider">
+				{label}
+			</span>
+			{changed && before !== "" && (
+				<pre className="text-xs whitespace-pre-wrap break-all mt-1 p-2 rounded-md bg-danger/10 border border-danger/30 text-muted line-through">
+					{before}
+				</pre>
+			)}
+			<pre
+				className={`text-xs whitespace-pre-wrap break-all mt-1 p-2 rounded-md border ${
+					changed
+						? "bg-success/10 border-success/30 text-foreground"
+						: "bg-surface-secondary border-border text-muted"
+				}`}
+			>
+				{(changed ? after : before) || "—"}
+			</pre>
+		</div>
+	);
+}

--- a/apps/portal/src/components/ai/artifacts/RouteArtifact.tsx
+++ b/apps/portal/src/components/ai/artifacts/RouteArtifact.tsx
@@ -3,6 +3,7 @@ import { harnessConversationsQuery } from "@/query/harnessConversationsQuery";
 import { routesQuery } from "@/query/routesQuery";
 import { RouteApplyBar } from "./ApplyBar";
 import { CanvasPreview } from "./CanvasPreview";
+import { Field } from "./Field";
 import { useArtifactParams, useCanvasArtifact, useRunSiblings } from "./useArtifact";
 
 /** What the route sub-agent writes (see ai-gateway `RouteConfigPayload`). */
@@ -18,49 +19,6 @@ type RouteConfigPayload = {
 		querySchema?: unknown;
 	} | null;
 };
-
-function Field({
-	label,
-	current,
-	next,
-}: {
-	label: string;
-	current?: unknown;
-	next?: unknown;
-}) {
-	const text = (v: unknown) =>
-		v === undefined || v === null || v === ""
-			? ""
-			: typeof v === "string"
-				? v
-				: JSON.stringify(v, null, 2);
-	const before = text(current);
-	const after = text(next);
-	// nothing proposed for this field → it stays as-is, show one box
-	const changed = after !== "" && after !== before;
-
-	return (
-		<div>
-			<span className="text-[10px] text-muted uppercase font-bold tracking-wider">
-				{label}
-			</span>
-			{changed && before !== "" && (
-				<pre className="text-xs whitespace-pre-wrap break-all mt-1 p-2 rounded-md bg-danger/10 border border-danger/30 text-muted line-through">
-					{before}
-				</pre>
-			)}
-			<pre
-				className={`text-xs whitespace-pre-wrap break-all mt-1 p-2 rounded-md border ${
-					changed
-						? "bg-success/10 border-success/30 text-foreground"
-						: "bg-surface-secondary border-border text-muted"
-				}`}
-			>
-				{(changed ? after : before) || "—"}
-			</pre>
-		</div>
-	);
-}
 
 export function RouteArtifact({ subArtifactId }: { subArtifactId: string }) {
 	const { projectId, conversationId } = useArtifactParams();

--- a/apps/portal/src/components/ai/artifacts/useArtifact.ts
+++ b/apps/portal/src/components/ai/artifacts/useArtifact.ts
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { useParams } from "@tanstack/react-router";
 import { harnessConversationsQuery } from "@/query/harnessConversationsQuery";
 import { routesQuery } from "@/query/routesQuery";
+import { customBlocksQuery } from "@/query/customBlocksQuery";
 import type { SubArtifactDetail } from "@/services/harnessConversations";
 import { previewGraph, type BlockBuilderPayload } from "./previewGraph";
 
@@ -83,4 +84,17 @@ export function useCanvasArtifact(detail: SubArtifactDetail | undefined) {
 		blockingRoute,
 		isLoading: route.isLoading || canvasItems.isLoading,
 	};
+}
+
+/** Custom-block canvases have the same graph payload as route canvases, but
+ * live behind the custom-block API rather than the route API. */
+export function useCustomBlockCanvasArtifact(detail: SubArtifactDetail | undefined) {
+	const payload = (detail?.payload ?? {}) as BlockBuilderPayload;
+	const targetId = payload.targetId ?? "";
+	const existingCanvas = customBlocksQuery.canvasItems.useQuery(targetId);
+	const graph = useMemo(
+		() => previewGraph(payload, existingCanvas.data ?? EMPTY_CANVAS),
+		[payload, existingCanvas.data],
+	);
+	return { graph, isLoading: existingCanvas.isLoading };
 }


### PR DESCRIPTION
Closes #232.

## Why

Three strands of work on the harness, all reached through building and then exercising the custom block builder.

## What

### Custom block apply path (`76b82f8`)

Five defects found reviewing the builder implementation:

- **`compact()` is shallow.** A `description: null` inside `inputParams[]` rode through to the server DTO. Agent schemas use `.nullish()`, the DTO uses `.optional()`, and `.optional()` rejects null — so the bus answered `Malformed operation`. This was the user-visible symptom that started the review. Each param is now compacted individually.
- **`rest` did not exclude `custom_block`.** `rest` is stamped applied unconditionally at the end, so a custom block whose create had just thrown was still marked applied — the chip went green on a failure and the work could not be retried.
- **The route branch never stamped its inlined canvas**, showing applied work as pending and permitting a second apply of the same blocks.
- **`validateCustomBlockParameterReferences` false-positived** on ordinary property access (`input.params.id`), bouncing correct canvases into a supervisor retry. Fixed with a lookbehind.
- Dead branch in `getSubArtifact`.

The route and custom-block apply loops were identical bar the id accessor, so they collapse into one `applyParentRows`. `applyArtifact` and its helpers move to `applyBatch.ts` — `service.ts` was already over the FTA cap before this branch.

**Portal:** `CustomBlockButton` gained the applied state it was missing, and the artifact panel now renders each caller parameter as a read-only stand-in for its real control (toggle, dropdown with its options, list, integration picker, config key) instead of a JSON blob. `Field` is extracted so the route and custom block panels share one implementation.

### Sticky notes as group panels (`be09d9a`)

Notes render behind blocks (`zIndex: -1`) and ELK skips them during auto-layout, so their authored positions survive — which makes a note a labelled background panel for a group of blocks. The agent was instead emitting small floating comment boxes parked beside two blocks. The prompt now describes panel usage with geometry it can actually compute, and a worked example. Explicitly optional: only for canvases with two or more phases worth naming.

### Run durability (`e9d5f82`)

- **`failRun` / `interruptRun` called `saveLiveState` with a hardcoded `workingMemory: {}`**, wiping accumulated state on exactly the event worth recovering from. They now persist it, via the new `HarnessCallbacks.snapshotState()`.
- **`RESUMABLE_NODES` held only the planner and HITL nodes**, so nothing was checkpointed after planning — a run dying at task 4 of 6 had kept nothing since. The supervisor is the only node that settles task statuses, so a checkpoint now lands after each task level.
- **`SummarizerState.subArtifactIds`** records sub-artifact row per task id, so a later run can tell persisted work from work that only lived in the dead process.
- **`asHistoryMessage` leaked `tool_calls` into the correction turn.** A model that answered the structured-output call with a tool call instead of JSON had that message echoed back with its `tool_calls` intact, followed by a `HumanMessage`. An assistant message carrying tool_calls that no ToolMessage answers is rejected outright, so all three attempts 400'd on the *history* rather than the answer — one reported run burned 30-40k tokens this way. Tool calls are now stripped from both the field and the provider copy in `additional_kwargs`; reasoning content still travels with the message.

This is groundwork for #267 (resume an unfinished run instead of restarting), which is where the persisted state gets read back.

## Testing

- `bun test apps/ai-gateway/src` — 224 pass
- `bun test --cwd apps/portal src` — 91 pass
- `bun run --cwd apps/ai-gateway lint` and `bun run --cwd apps/portal lint` clean
- New regression tests for the null leak, the unapplied-on-failure custom block, the tool_calls strip, and supervisor checkpointing. Each was confirmed to fail against the pre-fix code.
- No hardcoded colors in the touched portal files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)