### PR TITLE
fix(harness): let a run reference a custom block it created in the same run

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -140,7 +140,11 @@ If you encounter a repeatable issue or bug that might arise in the future, you m
 
 Strip both copies: the `AIMessage.tool_calls` field *and* `additional_kwargs.tool_calls`, where OpenAI-compatible providers keep their own. The model at that point is unbound and has no tools to call anyway. Give the rebuilt message real content saying the tool call was discarded — `"(empty response)"` tells the model nothing about what it did wrong.
 
+**`instanceof AIMessage` does not find them.** `AIMessageChunk` extends `BaseMessageChunk` and only *implements* `AIMessage`, so the check is **false for every streamed reply** — which is most of them. A strip gated on it silently passes the message through with its tool calls intact, and the 400 above comes back looking exactly like a regression of a fix that is still in place. Gate on the message type instead (`getType() === "ai"`, true for both), and read `tool_calls` and `additional_kwargs.tool_calls` together: an OpenAI-compatible provider may report the call **only** in `additional_kwargs` and leave `tool_calls` empty. `toolCallsOf()` in `models/toolLoop.ts` is the one place that does both; use it rather than re-deriving the check — `flattenToolMessages` and `asHistoryMessage` each got this wrong independently.
+
 **General rule:** any time a message is moved, echoed, replayed, or summarized into a new request, an assistant message's `tool_calls` and the `ToolMessage`s answering them must stay together or both be dropped. Splitting them is always a 400.
+
+This class of bug hides on OpenAI, which accepts the malformed history. It surfaces on Anthropic, Mistral, and DeepSeek. Reproduce message-plumbing fixes on a provider that actually enforces the rule.
 
 Also: native `withStructuredOutput` failures are caught and fall through to the prompt fallback rather than killing the run.
 
@@ -207,6 +211,24 @@ The pre-commit hook runs `fta-cli --score-cap 70`, which **fails the commit** fo
 2. Treat any `sql.raw()` on a request-derived string as an injection finding.
 3. Two things parameterization does **not** cover: values that are *syntax* for another parser (a `to_tsquery` string is bound safely but can still be a malformed tsquery → a runtime error), and `ilike(col, \`%${k}%\`)`, where user `%`/`_` act as LIKE wildcards. Bound ≠ harmless — bound means "cannot escape the value slot".
 4. Postgres also errors outright on a type mismatch against a typed id column (`uuid = 'auth'`, `serial = 'auth'`). Where the caller swallows errors into `[]`, one ordinary keyword blanks the entire search — an availability bug, so guard id comparisons with a shape check before they reach the query.
+
+### elkjs Cannot Run Under Bun — Layout Lives in `packages/blocks/layout.ts`
+**Issue:** `TypeError: undefined is not a constructor (evaluating 'new _Worker(url)')` from any server-side code that constructs `new ELK()`. Tests pass under Node and fail under Bun.
+**Cause:** elkjs only lays out inside a Web Worker. Its in-process fallback (`elkjs/lib/elk-worker.min.js`) ends in `module.exports = {default: j, Worker: j}`, and Bun's ESM/CJS interop resolves that to an **empty namespace** — so the constructor is `undefined`. `createRequire`, dynamic `import()`, and passing an explicit `workerFactory` are all dead ends; the module genuinely has nothing to hand back.
+**Fix & Best Practices:**
+1. **Do not add elkjs (or any worker-dependent layout lib) back.** The layered left-to-right layout in `packages/blocks/layout.ts` is dependency-free, runs identically under Bun and in the browser, and is the single implementation shared by the editor's Format button and the harness apply path (`formattedCanvasChanges`).
+2. Import it from the **subpath** `@fluxify/blocks/layout`, never the root barrel — the barrel drags `jsonwebtoken` and the adapters into the browser bundle (see the package-bleed section above).
+3. `layoutGraph(nodes, edges, { changedIds })` returns positions **only** for blocks that actually move, anchored on the leftmost unchanged block, so an AI edit nudges the graph instead of teleporting it to the origin.
+4. A green local lint does not prove a dependency was fully removed — `node_modules` still holds it. After dropping a dependency, grep the source for the import (`grep -rn "elkjs" apps packages`), because CI installs clean and will fail on what your local tree still resolves.
+
+### Harness Task Generation — One Edit Split Across Three Agents
+**Issue:** A request as simple as "put this custom block into a route" spawned a chain of sub-agent tasks (observed: three chained `blockBuilder` tasks, two rejected by the supervisor). Each hop regenerated the whole canvas from the previous one's output, so every hop was a fresh chance to drop a field.
+**Cause:** The planner writes a **user-facing** plan by design — "add the block", "configure it", "return it in the response" — and that is correct behaviour, not the bug. The task generator turned each bullet into its own task on the same agent, all editing the same canvas in series. Prompt rule 8 says to consolidate; nothing enforced it, and the model ignored it.
+**Fix & Best Practices:**
+1. `sanitizeTasks` (`harness/agents/taskGenerator.ts`) contracts a linear chain of same-agent tasks via `mergeChains`. Merging is only safe for a **true chain** — B depends on A alone and nothing else depends on A — so independent same-agent tasks (two different routes) are left alone and later tasks are re-pointed at the merged id.
+2. **Enforce structural rules in code, not only in the prompt.** A rule the model can ignore silently is not a rule; the deterministic repair belongs in `sanitizeTasks` next to the id/node/edge repairs already there.
+3. Do not "fix" this class of bug in the planner. Check `taskGenerator` output first — the planner's prose plan and the task DAG are different artifacts.
+4. When diagnosing a bad run, read it from the database (`agent_harness_runs`, `agent_harness_steps`, `agent_harness_live_states.working_memory`) rather than inferring from the summary. The reported agent is often not the one that misbehaved.
 
 ---
 

--- a/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/agent.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/agent.ts
@@ -1,5 +1,5 @@
 import { logger } from "@fluxify/common";
-import { generateID } from "@fluxify/lib";
+import { generateID, resolveCustomBlockName } from "@fluxify/lib";
 import type { z } from "zod";
 import { BaseAgent } from "../../base";
 import { type GlobalGraphState, AgentNode } from "../../../types";
@@ -11,6 +11,10 @@ import { createGetBlockSchemasTool } from "../../../tools/getBlockSchemas";
 import { createGetAgentOutputTool } from "../../../tools/getAgentOutput";
 import { fenceUntrusted } from "../../../internal/untrusted";
 import { blockBuilderSchema } from "./schemas";
+import {
+	pendingCustomBlocks,
+	type PendingCustomBlock,
+} from "./pendingCustomBlocks";
 import {
 	createBlocksTable,
 	createSystemPrompt,
@@ -101,11 +105,21 @@ export class BlockBuilderAgent extends BaseAgent {
 		return value;
 	}
 
-	private async getCustomBlocksInfo(projectId: string): Promise<string> {
+	/** Stored blocks, as the prompt table plus the names they are stored under.
+	 *  The names are the inhouse guard: only a name absent from here may be
+	 *  assumed to be a project block and given the `user_defined.project.`
+	 *  prefix — inhouse and plugin blocks never went through the create endpoint
+	 *  that adds it, so they are stored bare. */
+	private async getCustomBlocksInfo(
+		projectId: string,
+	): Promise<{ table: string; names: string[] }> {
 		const customBlocks =
 			await this.state.internal.dbService.getAllCustomBlocks(projectId);
+		const names = customBlocks.map(({ name }: { name: string }) => name);
 
-		if (customBlocks.length === 0) return "No custom blocks available.";
+		if (customBlocks.length === 0) {
+			return { table: "No custom blocks available.", names };
+		}
 
 		const table = createBlocksTable(
 			customBlocks.map(
@@ -130,15 +144,45 @@ export class BlockBuilderAgent extends BaseAgent {
 		// Names, labels and descriptions authored by whoever built the custom
 		// block — untrusted, and this one lands in the system prompt rather than
 		// in a tool result, so it needs the fence more than most.
-		return fenceUntrusted("custom_blocks", table);
+		return { table: fenceUntrusted("custom_blocks", table), names };
 	}
 
-	private pairedCustomBlockContract() {
-		const configs = Object.values(this.state.orchestratorState?.subAgentResults ?? {})
-			.map((value) => value as { customBlockId?: string; data?: { name?: string; inputParams?: unknown[] } })
-			.filter((value) => value.customBlockId && value.data?.name);
+	/**
+	 * Rewrites every custom block reference to the name it is stored under.
+	 *
+	 * The prompt shows stored blocks by their full name and pending ones by the
+	 * name they will get, but a model that types the bare `jwt_validate` anyway
+	 * would persist it verbatim — `custom:` is stripped on the way into storage
+	 * (`artifacts/normalize.ts`) and the compiled worker's library is keyed by
+	 * the stored name, so the canvas would validate here and then fail to
+	 * compile with "No codegen for block type".
+	 */
+	private canonicalizeCustomBlockTypes(
+		response: z.infer<typeof blockBuilderSchema>,
+		known: ReadonlySet<string>,
+	) {
+		const fix = (block: { blockType?: string }) => {
+			const raw = block.blockType ?? "";
+			const bare = raw.startsWith("custom:") ? raw.slice(7) : raw;
+			const resolved = resolveCustomBlockName(bare, known);
+			// A name that matches nothing is a built-in, a typo, or an invented
+			// block. Leave it exactly as written: the validator's message for it
+			// is more useful than one about a name this rewrote.
+			if (!known.has(resolved) || resolved === bare) return;
+			block.blockType = `custom:${resolved}`;
+		};
+		response.blocks?.forEach(fix);
+		for (const change of response.canvasChanges ?? []) {
+			if (change.type === "block_change") change.data.blocksInfo.forEach(fix);
+		}
+		return response;
+	}
+
+	/** Reads the same pending proposals the validator does, so the prompt cannot
+	 *  call a block authoritative that validation then rejects as unknown. */
+	private pairedCustomBlockContract(configs: PendingCustomBlock[]) {
 		if (configs.length === 0) return "";
-		return `#### Paired Custom Block Contracts (authoritative)\n${configs.map((config) => `- ${config.data?.name} (${config.customBlockId}): ${JSON.stringify(config.data?.inputParams ?? [])}`).join("\n")}`;
+		return `#### Paired Custom Block Contracts (authoritative)\n${configs.map((config) => `- ${config.name} (${config.customBlockId}): ${JSON.stringify(config.inputParams)}`).join("\n")}`;
 	}
 
 	async execute(): Promise<Partial<GlobalGraphState>> {
@@ -157,15 +201,22 @@ export class BlockBuilderAgent extends BaseAgent {
 		});
 
 		const projectId = this.state.internal?.metadata?.projectId || "NONE";
-		const customBlocksTable = await this.getCustomBlocksInfo(projectId);
+		const { table: customBlocksTable, names: storedCustomBlockNames } =
+			await this.getCustomBlocksInfo(projectId);
 		const contextBlock = this.state.internal?.metadata?.contextBlock;
 		const prefetchedDocs = (await getDocsByTitle(PREFETCH_DOC_TITLES))
 			.map((doc) => doc.content)
 			.join("\n\n---\n\n");
+		const pending = pendingCustomBlocks(this.state, activeTask.id);
+		// Stored names plus the names this run's proposals will be stored under.
+		const knownCustomBlockNames = new Set([
+			...storedCustomBlockNames,
+			...pending.map((block) => block.name),
+		]);
 		const systemPrompt = createSystemPrompt(
 			customBlocksTable,
 			prefetchedDocs,
-			this.pairedCustomBlockContract(),
+			this.pairedCustomBlockContract(pending),
 		);
 		const userQuery = createUserQuery(activeTask);
 
@@ -179,7 +230,11 @@ export class BlockBuilderAgent extends BaseAgent {
 				this.state.internal.dbService,
 				this.state.internal?.metadata || {},
 			),
-			createGetBlockSchemasTool(this.state.internal.dbService, projectId),
+			createGetBlockSchemasTool(
+				this.state.internal.dbService,
+				projectId,
+				new Map(pending.map((block) => [block.name, block.inputParams])),
+			),
 			createGetAgentOutputTool(
 				this.state.orchestratorState?.subAgentResults || {},
 			),
@@ -202,7 +257,10 @@ export class BlockBuilderAgent extends BaseAgent {
 				.map((block) => [block.id, generateID()]),
 		);
 		const processedResponse = await this.reconcileRouteTarget(
-			this.replaceShortIds(this.stripEchoedMetadata(response), shortIdMap),
+			this.canonicalizeCustomBlockTypes(
+				this.replaceShortIds(this.stripEchoedMetadata(response), shortIdMap),
+				knownCustomBlockNames,
+			),
 			projectId,
 		);
 

--- a/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/pendingCustomBlocks.spec.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/pendingCustomBlocks.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "bun:test";
+import { withCustomBlockPrefix } from "@fluxify/lib";
+import { pendingCustomBlockSchemas } from "./pendingCustomBlocks";
+
+/** The config agent emits a bare name; the create endpoint stores it prefixed,
+ *  and that stored form is what a canvas must reference. */
+const stored = withCustomBlockPrefix;
+
+const task = (id: string, dependsOnAgentId: string[] = []) => ({
+	id,
+	title: id,
+	description: "",
+	dependsOnAgentId,
+	status: "pending" as const,
+	assignedAgentNode: "blockBuilder" as never,
+});
+
+const blockConfig = (name: string, action = "create") => ({
+	action,
+	customBlockId: `cb-${name}`,
+	data: { name, inputParams: [{ name: "secret", type: "text_input" }] },
+});
+
+const state = (tasks: ReturnType<typeof task>[], results: Record<string, unknown>) =>
+	({ orchestratorState: { tasks, subAgentResults: results } }) as never;
+
+describe("pendingCustomBlockSchemas", () => {
+	it("sees a block proposed by a task it declared a dependency on", () => {
+		const map = pendingCustomBlockSchemas(
+			state([task("cfg"), task("canvas", ["cfg"])], {
+				cfg: blockConfig("jwt_validate"),
+			}),
+			"canvas",
+		);
+		expect(map.get(stored("jwt_validate"))).toEqual([
+			{ name: "secret", type: "text_input" },
+		]);
+	});
+
+	it("reaches a proposal one hop past its declared dependency", () => {
+		// route canvas -> custom block canvas -> custom block config
+		const map = pendingCustomBlockSchemas(
+			state(
+				[task("cfg"), task("blockCanvas", ["cfg"]), task("route", ["blockCanvas"])],
+				{ cfg: blockConfig("jwt_validate") },
+			),
+			"route",
+		);
+		expect(map.has(stored("jwt_validate"))).toBe(true);
+	});
+
+	it("ignores a sibling it never declared a dependency on", () => {
+		const map = pendingCustomBlockSchemas(
+			state([task("cfg"), task("route")], { cfg: blockConfig("jwt_validate") }),
+			"route",
+		);
+		expect(map.size).toBe(0);
+	});
+
+	it("ignores a block this run is deleting", () => {
+		const map = pendingCustomBlockSchemas(
+			state([task("cfg"), task("route", ["cfg"])], {
+				cfg: blockConfig("jwt_validate", "delete"),
+			}),
+			"route",
+		);
+		expect(map.size).toBe(0);
+	});
+
+	it("terminates on a dependency cycle", () => {
+		const map = pendingCustomBlockSchemas(
+			state([task("a", ["b"]), task("b", ["a"])], { b: blockConfig("looped") }),
+			"a",
+		);
+		expect(map.has(stored("looped"))).toBe(true);
+	});
+});

--- a/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/pendingCustomBlocks.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/pendingCustomBlocks.ts
@@ -1,0 +1,93 @@
+import { withCustomBlockPrefix } from "@fluxify/lib";
+import type {
+	CustomBlockConfigAgentResult,
+	GlobalGraphState,
+	Task,
+} from "../../../types";
+
+export interface PendingCustomBlock {
+	/** The name this block will be *stored* under, prefix included. The config
+	 *  agent emits a bare snake_case name and the create endpoint namespaces it,
+	 *  so a reference to the bare form resolves nowhere once applied. */
+	name: string;
+	customBlockId: string;
+	inputParams: Array<Record<string, unknown>>;
+}
+
+/**
+ * Every task `taskId` transitively depends on.
+ *
+ * Transitive, not direct: a route canvas task names the custom block's *canvas*
+ * task as its dependency, and the block's name and caller params live one hop
+ * further back on the config task that canvas depends on. Depending on B, which
+ * depends on A, still means A applies first — so widening the lookup this way
+ * cannot admit a block the apply order will not have created yet.
+ */
+function dependencyClosure(state: GlobalGraphState, taskId: string): Set<string> {
+	const byId = new Map<string, Task>(
+		(state.orchestratorState?.tasks ?? []).map((task) => [task.id, task]),
+	);
+	// The task list is written by the task generator; `activeTask` is the only
+	// task guaranteed present when validating a run resumed mid-flight.
+	if (state.activeTask && !byId.has(state.activeTask.id)) {
+		byId.set(state.activeTask.id, state.activeTask);
+	}
+
+	const seen = new Set<string>();
+	const queue = [...(byId.get(taskId)?.dependsOnAgentId ?? [])];
+	while (queue.length > 0) {
+		const id = queue.pop() as string;
+		if (seen.has(id)) continue;
+		seen.add(id);
+		queue.push(...(byId.get(id)?.dependsOnAgentId ?? []));
+	}
+	return seen;
+}
+
+/**
+ * Custom blocks this run has proposed but has not written to the database yet.
+ *
+ * A single message that creates a custom block and uses it in a route produces
+ * two sibling tasks: the block is still a proposal sitting in `subAgentResults`
+ * when the route's canvas is validated, so a database-only lookup misses it and
+ * rejects a correct canvas. This is the one source both the prompt contract and
+ * the validator read, so they cannot disagree about whether the block exists.
+ *
+ * Scoped to the declared dependency graph on purpose: a task that binds to a
+ * block it never declared a dependency on would pass validation here and then
+ * apply in the wrong order.
+ */
+export function pendingCustomBlocks(
+	state: GlobalGraphState,
+	taskId: string,
+): PendingCustomBlock[] {
+	const results = state.orchestratorState?.subAgentResults ?? {};
+	const pending: PendingCustomBlock[] = [];
+
+	for (const id of dependencyClosure(state, taskId)) {
+		const result = results[id] as CustomBlockConfigAgentResult | undefined;
+		if (!result?.customBlockId || !result.data?.name) continue;
+		// A block this run is deleting is not one a sibling may bind to.
+		if (result.action === "delete") continue;
+		pending.push({
+			name: withCustomBlockPrefix(result.data.name),
+			customBlockId: result.customBlockId,
+			inputParams: result.data.inputParams ?? [],
+		});
+	}
+
+	return pending;
+}
+
+/** The same proposals shaped like `getCustomBlocksBatch`, for merging under it. */
+export function pendingCustomBlockSchemas(
+	state: GlobalGraphState,
+	taskId: string,
+): Map<string, Array<Record<string, unknown>>> {
+	return new Map(
+		pendingCustomBlocks(state, taskId).map((block) => [
+			block.name,
+			block.inputParams,
+		]),
+	);
+}

--- a/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/validator.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/validator.ts
@@ -1,6 +1,8 @@
 import { builtinBlockSchemas, BlockTypes } from "@fluxify/blocks";
+import { resolveCustomBlockName, withCustomBlockPrefix } from "@fluxify/lib";
 import type { AgentOutputValidator } from "../../../types";
 import { detectCycles } from "./cycleDetector";
+import { pendingCustomBlockSchemas } from "./pendingCustomBlocks";
 import { validateGraphRules } from "./graphRules";
 import type { BlockBuilderResult, ValidatableBlock } from "./schemas";
 
@@ -157,7 +159,11 @@ function validateBlockAgainstSchemas(
 	if (isCustom && customName) {
 		const invokeError = validateCustomBlockInvoke(block, customName);
 		if (invokeError) errors.push(invokeError);
-		const inputParams = customBlockSchemasMap.get(customName);
+		// `agent.ts` already rewrote known references to their stored name; this
+		// resolve covers the paths that skip it — a resumed run, a re-validation.
+		const inputParams = customBlockSchemasMap.get(
+			resolveCustomBlockName(customName, new Set(customBlockSchemasMap.keys())),
+		);
 		if (!inputParams) {
 			// A near-miss on a built-in name (`get_http_header` for `httpgetheader`)
 			// used to sail through and persist a type nothing can execute.
@@ -245,12 +251,25 @@ export const validateBlockBuilderOutput: AgentOutputValidator = async (
 
 	const projectId = state.internal?.metadata?.projectId || "";
 	let customBlockSchemasMap = new Map<string, any[]>();
-	if (customBlockNamesToFetch.size > 0 && state.internal?.dbService) {
-		customBlockSchemasMap =
-			await state.internal.dbService.getCustomBlocksBatch(
-				projectId,
-				Array.from(customBlockNamesToFetch),
-			);
+	if (customBlockNamesToFetch.size > 0) {
+		const dbSchemas = state.internal?.dbService
+			? await state.internal.dbService.getCustomBlocksBatch(
+					projectId,
+					// Both forms: the canvas may hold the bare name while the row is
+					// stored prefixed, and inhouse blocks are stored bare.
+					Array.from(customBlockNamesToFetch).flatMap((name) => [
+						name,
+						withCustomBlockPrefix(name),
+					]),
+				)
+			: new Map<string, any[]>();
+		// Pending first so a real record always wins over a proposal: the block
+		// may exist already under the same name, and the stored schema is the one
+		// the canvas will actually execute against.
+		customBlockSchemasMap = new Map<string, any[]>([
+			...pendingCustomBlockSchemas(state, taskId),
+			...dbSchemas,
+		]);
 	}
 
 	const errors: string[] = validateGraphRules(blocksToValidate);

--- a/apps/ai-gateway/src/harness/agents/sub-agents/customBlockConfig.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/customBlockConfig.ts
@@ -1,4 +1,5 @@
-import { generateID } from "@fluxify/lib";
+import { logger } from "@fluxify/common";
+import { generateID, uniqueCustomBlockName } from "@fluxify/lib";
 import { z } from "zod";
 import { dispatchAgentEvent } from "../../callbacks";
 import { createFindResourceTool } from "../../tools/findResource";
@@ -28,6 +29,29 @@ const customBlockConfigSchema = z.object({
 });
 
 export class CustomBlockConfigAgent extends BaseAgent {
+	/**
+	 * Settles the name here, before Block Builder writes `custom:<name>` into a
+	 * caller's canvas. A collision resolved any later is not resolvable at all:
+	 * the caller is already bound to the block that held the name first, and the
+	 * create fails with a conflict at apply.
+	 */
+	private async freeName(name: string): Promise<string> {
+		const projectId = this.state.internal?.metadata?.projectId || "";
+		const taken = new Set(
+			(
+				await this.state.internal.dbService.getAllCustomBlocks(projectId)
+			).map(({ name }: { name: string }) => name),
+		);
+		const free = uniqueCustomBlockName(name, taken);
+		if (free !== name) {
+			logger.warn("[CustomBlockConfig] Renamed custom block, name taken", {
+				requested: name,
+				renamed: free,
+			});
+		}
+		return free;
+	}
+
 	async execute(): Promise<Partial<GlobalGraphState>> {
 		const activeTask = this.state.activeTask;
 		if (!activeTask) throw new Error("CustomBlockConfigAgent requires an active task.");
@@ -53,6 +77,9 @@ ${CUSTOM_BLOCK_PARAMETER_CONTRACT}
 			agentId: activeTask.id,
 		}) as z.infer<typeof customBlockConfigSchema>;
 		if (response.action === "create" && !response.customBlockId) response.customBlockId = generateID();
+		if (response.action === "create" && response.data?.name) {
+			response.data.name = await this.freeName(response.data.name);
+		}
 		await dispatchAgentEvent({ name: "agent_status", data: { status: "Custom block contract formulated", agent: AgentNode.CUSTOM_BLOCK_CONFIG_AGENT, agentId: activeTask.id, data: response } });
 		return { currentAgent: AgentNode.CUSTOM_BLOCK_CONFIG_AGENT, orchestratorState: { ...this.state.orchestratorState, subAgentResults: { ...(this.state.orchestratorState?.subAgentResults ?? {}), [activeTask.id]: response } } };
 	}

--- a/apps/ai-gateway/src/harness/models/base.spec.ts
+++ b/apps/ai-gateway/src/harness/models/base.spec.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import {
 	AIMessage,
+	AIMessageChunk,
 	HumanMessage,
 	SystemMessage,
 	ToolMessage,
@@ -648,6 +649,62 @@ describe("flattenToolMessages", () => {
 		expect(String(flat.at(-1)!.content)).toContain('{"routes":[]}');
 		// Reasoning written alongside the call is kept.
 		expect(flat.some((m) => m.content === "let me look")).toBe(true);
+	});
+
+	it("strips tool calls off an AIMessageChunk", () => {
+		// AIMessageChunk implements AIMessage but extends BaseMessageChunk, so an
+		// `instanceof AIMessage` gate misses a streamed reply entirely and its
+		// tool calls ride into the unbound structured-output call.
+		const flat = flattenToolMessages([
+			new HumanMessage("build it"),
+			new AIMessageChunk({
+				content: "streamed reasoning",
+				tool_calls: [{ id: "1", name: "get_block_schemas", args: {} }],
+			}),
+			new ToolMessage({
+				tool_call_id: "1",
+				name: "get_block_schemas",
+				content: "### Custom Block: user_defined.project.validate_jwt",
+			}),
+		]);
+
+		expect(flat.some((m) => (m as AIMessage).tool_calls?.length)).toBe(false);
+		expect(flat.some((m) => m instanceof ToolMessage)).toBe(false);
+		expect(flat.at(-1)!.getType()).toBe("human");
+		expect(flat.some((m) => m.content === "streamed reasoning")).toBe(true);
+	});
+
+	it("strips tool calls an OpenAI-compatible provider left only in additional_kwargs", () => {
+		// DeepSeek reports the call in `additional_kwargs` with `tool_calls`
+		// empty. Keeping that message sends an assistant turn with tool calls and
+		// no ToolMessage answering it — a 400 on every structured-output attempt.
+		const flat = flattenToolMessages([
+			new HumanMessage("build it"),
+			new AIMessage({
+				content: "checking the block",
+				additional_kwargs: {
+					tool_calls: [
+						{
+							id: "1",
+							type: "function",
+							function: { name: "get_block_schemas", arguments: "{}" },
+						},
+					],
+				},
+			}),
+			new ToolMessage({
+				tool_call_id: "1",
+				name: "get_block_schemas",
+				content: "### Custom Block: user_defined.project.validate_jwt",
+			}),
+		]);
+
+		expect(
+			flat.some((m) => Array.isArray(m.additional_kwargs?.tool_calls)),
+		).toBe(false);
+		expect(flat.some((m) => m instanceof ToolMessage)).toBe(false);
+		expect(flat.at(-1)!.getType()).toBe("human");
+		expect(flat.some((m) => m.content === "checking the block")).toBe(true);
 	});
 });
 

--- a/apps/ai-gateway/src/harness/models/toolLoop.ts
+++ b/apps/ai-gateway/src/harness/models/toolLoop.ts
@@ -100,6 +100,39 @@ export function parseAsSchema<T>(
 }
 
 /**
+ * Every tool call on a message, wherever the provider put it.
+ *
+ * Two traps, and a message can spring either:
+ *
+ * 1. `AIMessageChunk` **implements** `AIMessage` but extends `BaseMessageChunk`,
+ *    so `instanceof AIMessage` is false for a streamed reply. Gate on the
+ *    message type instead — both report `"ai"`.
+ * 2. OpenAI-compatible providers (DeepSeek among them) report the call in
+ *    `additional_kwargs.tool_calls` and may leave `tool_calls` empty.
+ *
+ * Miss either and an assistant message reaches the unbound structured-output
+ * call still carrying tool calls that no ToolMessage answers — a 400
+ * ("insufficient tool messages following tool_calls message") on every attempt,
+ * spending the whole retry budget on the history rather than on the answer.
+ */
+export function toolCallsOf(message: unknown): unknown[] {
+	const m = message as
+		| {
+				getType?: () => string;
+				tool_calls?: unknown;
+				additional_kwargs?: Record<string, any>;
+		  }
+		| undefined;
+	if (m?.getType?.() !== "ai") return [];
+	return [
+		...(Array.isArray(m.tool_calls) ? m.tool_calls : []),
+		...(Array.isArray(m.additional_kwargs?.tool_calls)
+			? m.additional_kwargs.tool_calls
+			: []),
+	];
+}
+
+/**
  * Collapses tool traffic into plain turns, ending on a human message.
  *
  * The structured-output fallback invokes the *unbound* model. Anthropic and
@@ -120,8 +153,9 @@ export function flattenToolMessages(messages: BaseMessage[]): BaseMessage[] {
 			);
 			continue;
 		}
-		if (m instanceof AIMessage && m.tool_calls?.length) {
+		if (toolCallsOf(m).length > 0) {
 			// Keep any reasoning it wrote alongside the call, drop the call itself.
+			// A fresh AIMessage carries no `additional_kwargs`, so both copies go.
 			const text = extractText(m);
 			if (text.trim()) out.push(new AIMessage(text));
 			continue;
@@ -184,9 +218,7 @@ export function asHistoryMessage(response: unknown, cleaned: string): AIMessage 
 	// on the history instead of on the answer. This model is unbound; it has no
 	// tools to call here anyway.
 	const { tool_calls: _tc, ...kwargs } = raw.additional_kwargs ?? {};
-	const hasToolCalls =
-		(response instanceof AIMessage && response.tool_calls?.length) ||
-		Array.isArray(raw.additional_kwargs?.tool_calls);
+	const hasToolCalls = toolCallsOf(response).length > 0;
 
 	if (hasContent && response instanceof AIMessage && !hasToolCalls)
 		return response;

--- a/apps/ai-gateway/src/harness/tools/getBlockSchemas.ts
+++ b/apps/ai-gateway/src/harness/tools/getBlockSchemas.ts
@@ -2,6 +2,7 @@ import { fencedTool } from "./fenced";
 import { z } from "zod";
 import { logger } from "@fluxify/common";
 import { blockAiDescriptions } from "@fluxify/blocks";
+import { resolveCustomBlockName, withCustomBlockPrefix } from "@fluxify/lib";
 import type { DbService } from "../internal/dbService";
 
 function mapInputParamsToNaturalLanguage(inputParams: any[]): string {
@@ -54,6 +55,10 @@ const MAX_BLOCK_TYPES_PER_CALL = 8;
 export const createGetBlockSchemasTool = (
 	dbService: DbService,
 	projectId: string,
+	/** Custom blocks this run has proposed but not written yet. Without these the
+	 *  model asks for the schema mid-run, is told the block does not exist, and
+	 *  designs around it long before validation gets a chance to disagree. */
+	pendingCustomBlocks: Map<string, Array<Record<string, unknown>>> = new Map(),
 ) => {
 	return fencedTool(
 		async ({ blockTypes }) => {
@@ -72,7 +77,22 @@ export const createGetBlockSchemasTool = (
 			for (const blockType of requestedTypes) {
 				if (blockType.startsWith("custom:")) {
 					const customName = blockType.replace("custom:", "");
-					const inputParams = await dbService.getCustomBlockInputParams(projectId, customName);
+					// DB first, same precedence as the validator: a stored block under
+					// this name is what the canvas will execute against. Both name
+					// forms are tried — an inhouse block is stored bare, a project one
+					// under the `user_defined.project.` prefix the create endpoint adds.
+					const inputParams =
+						(await dbService.getCustomBlockInputParams(projectId, customName)) ??
+						(await dbService.getCustomBlockInputParams(
+							projectId,
+							withCustomBlockPrefix(customName),
+						)) ??
+						pendingCustomBlocks.get(
+							resolveCustomBlockName(
+								customName,
+								new Set(pendingCustomBlocks.keys()),
+							),
+						);
 					if (inputParams) {
 						const mappedSchema = mapInputParamsToNaturalLanguage(inputParams);
 						results.push(`### Custom Block: ${customName}\n${mappedSchema}`);

--- a/apps/server/src/api/v1/custom-blocks/create/service.ts
+++ b/apps/server/src/api/v1/custom-blocks/create/service.ts
@@ -8,7 +8,7 @@ import {
 } from "./repository";
 import { ConflictError } from "../../../../errors/conflictError";
 import { db, type DbTransactionType } from "../../../../db";
-import { generateID } from "@fluxify/lib";
+import { generateID, withCustomBlockPrefix } from "@fluxify/lib";
 import { NotFoundError } from "../../../../errors/notFoundError";
 
 /**
@@ -28,7 +28,9 @@ export default async function handleRequest(
 				`project with id ${data.projectId} does not exist`,
 			);
 		}
-		data.name = `user_defined.project.${data.name}`;
+		// Idempotent: callers that already resolved the stored name — the harness
+		// binds a route to a block by it — must not end up double-prefixed.
+		data.name = withCustomBlockPrefix(data.name);
 		const existingBlock = await checkCustomBlockExist(
 			data.projectId,
 			data.name,

--- a/packages/lib/customBlockName.ts
+++ b/packages/lib/customBlockName.ts
@@ -1,0 +1,73 @@
+/**
+ * Project-scoped custom blocks are stored under a namespaced name: the create
+ * endpoint prepends this, and the compiled worker's block library is keyed by
+ * the stored name (`compiler/service.ts` → `registerLocally`). A canvas that
+ * holds the bare name compiles to "No codegen for block type".
+ *
+ * Blocks with `sourceType` "inhouse" or "plugin" never go through that endpoint,
+ * so their names are stored bare. Nothing may prefix a name unconditionally.
+ */
+export const CUSTOM_BLOCK_NAME_PREFIX = "user_defined.project.";
+
+/** Idempotent: a name that already carries the prefix is returned unchanged. */
+export function withCustomBlockPrefix(name: string): string {
+	return name.startsWith(CUSTOM_BLOCK_NAME_PREFIX)
+		? name
+		: `${CUSTOM_BLOCK_NAME_PREFIX}${name}`;
+}
+
+export function withoutCustomBlockPrefix(name: string): string {
+	return name.startsWith(CUSTOM_BLOCK_NAME_PREFIX)
+		? name.slice(CUSTOM_BLOCK_NAME_PREFIX.length)
+		: name;
+}
+
+/**
+ * The name a reference to `name` should actually use, given the names that
+ * exist (stored blocks plus anything the current run has proposed).
+ *
+ * Resolve-then-prefix rather than prefix-always: an inhouse block is stored
+ * bare, so blind prefixing would break every reference to one. Only a name that
+ * matches nothing falls back to the prefixed form — that is a block being
+ * created right now, and the create endpoint will store it prefixed.
+ */
+/**
+ * A free name for a block being created, given the names already taken.
+ *
+ * Two blocks cannot share a name: the create endpoint rejects a duplicate with
+ * a conflict, and a canvas that references the name binds to whichever block
+ * already holds it. Renaming has to happen before anything commits to the
+ * string — once a sibling task has written `custom:<name>` into a canvas, the
+ * two are bound to different blocks.
+ *
+ * Both forms count as taken. An inhouse block stored bare under `jwt_validate`
+ * does not collide with `user_defined.project.jwt_validate` in the database,
+ * but a reference to `jwt_validate` resolves to the inhouse one and the new
+ * block is silently shadowed.
+ */
+export function uniqueCustomBlockName(
+	name: string,
+	taken: ReadonlySet<string>,
+): string {
+	const isTaken = (candidate: string) =>
+		taken.has(candidate) || taken.has(withCustomBlockPrefix(candidate));
+	if (!isTaken(name)) return name;
+	// `taken` is finite, so this terminates; the suffix keeps snake_case.
+	let suffix = 2;
+	while (isTaken(`${name}_${suffix}`)) suffix++;
+	return `${name}_${suffix}`;
+}
+
+export function resolveCustomBlockName(
+	name: string,
+	known: ReadonlySet<string>,
+): string {
+	for (const candidate of [
+		name,
+		withCustomBlockPrefix(name),
+		withoutCustomBlockPrefix(name),
+	]) {
+		if (known.has(candidate)) return candidate;
+	}
+	return withCustomBlockPrefix(name);
+}

--- a/packages/lib/index.ts
+++ b/packages/lib/index.ts
@@ -1,4 +1,5 @@
 export * from "./objects/deepfreeze";
+export * from "./customBlockName";
 export * from "./evaluators/condition";
 export * from "./random/id";
 export * from "./routing/parser";

--- a/packages/lib/tests/customBlockName.spec.ts
+++ b/packages/lib/tests/customBlockName.spec.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "bun:test";
+import {
+	resolveCustomBlockName,
+	uniqueCustomBlockName,
+	withCustomBlockPrefix,
+	withoutCustomBlockPrefix,
+} from "../customBlockName";
+
+describe("withCustomBlockPrefix", () => {
+	it("prefixes a bare name", () => {
+		expect(withCustomBlockPrefix("jwt_validate")).toBe(
+			"user_defined.project.jwt_validate",
+		);
+	});
+
+	it("is idempotent", () => {
+		const once = withCustomBlockPrefix("jwt_validate");
+		expect(withCustomBlockPrefix(once)).toBe(once);
+	});
+
+	it("round-trips", () => {
+		expect(withoutCustomBlockPrefix(withCustomBlockPrefix("notify"))).toBe(
+			"notify",
+		);
+	});
+});
+
+describe("resolveCustomBlockName", () => {
+	const known = new Set([
+		"user_defined.project.jwt_validate", // created through the project endpoint
+		"send_email", // inhouse: stored bare, never prefixed
+	]);
+
+	it("prefixes a bare project block", () => {
+		expect(resolveCustomBlockName("jwt_validate", known)).toBe(
+			"user_defined.project.jwt_validate",
+		);
+	});
+
+	it("leaves an inhouse block bare", () => {
+		expect(resolveCustomBlockName("send_email", known)).toBe("send_email");
+	});
+
+	it("does not double-prefix an already-resolved name", () => {
+		expect(
+			resolveCustomBlockName("user_defined.project.jwt_validate", known),
+		).toBe("user_defined.project.jwt_validate");
+	});
+
+	it("strips a prefix wrongly applied to an inhouse block", () => {
+		expect(resolveCustomBlockName("user_defined.project.send_email", known)).toBe(
+			"send_email",
+		);
+	});
+
+	it("assumes a name it has never seen is a block being created now", () => {
+		expect(resolveCustomBlockName("brand_new", known)).toBe(
+			"user_defined.project.brand_new",
+		);
+	});
+});
+
+describe("uniqueCustomBlockName", () => {
+	it("keeps a name nothing has taken", () => {
+		expect(uniqueCustomBlockName("jwt_validate", new Set())).toBe(
+			"jwt_validate",
+		);
+	});
+
+	it("renames around a stored project block", () => {
+		expect(
+			uniqueCustomBlockName(
+				"jwt_validate",
+				new Set(["user_defined.project.jwt_validate"]),
+			),
+		).toBe("jwt_validate_2");
+	});
+
+	it("renames around an inhouse block that would shadow it", () => {
+		// stored bare, so no database conflict — but `custom:jwt_validate`
+		// would resolve to the inhouse block, not the one being created
+		expect(uniqueCustomBlockName("jwt_validate", new Set(["jwt_validate"]))).toBe(
+			"jwt_validate_2",
+		);
+	});
+
+	it("skips suffixes that are themselves taken", () => {
+		expect(
+			uniqueCustomBlockName(
+				"jwt_validate",
+				new Set([
+					"user_defined.project.jwt_validate",
+					"user_defined.project.jwt_validate_2",
+					"user_defined.project.jwt_validate_3",
+				]),
+			),
+		).toBe("jwt_validate_4");
+	});
+
+	it("stays lowercase snake_case, which the config validator requires", () => {
+		const renamed = uniqueCustomBlockName(
+			"jwt_validate",
+			new Set(["jwt_validate"]),
+		);
+		expect(renamed).toMatch(/^[a-z0-9_]+$/);
+	});
+});


### PR DESCRIPTION
Closes #272.

## The bug

The block builder resolved every `custom:<name>` against the database, so a block proposed earlier in the same run — not applied yet, therefore not in the DB — came back as *"neither a built-in nor a custom block"*. The supervisor sent the task back and the run either looped or dropped the reference.

Fixing the lookup alone just moves the failure to apply time. A pending block's name is bare (`validate_jwt`) while the stored one is prefixed (`user_defined.project.validate_jwt`), so the canvas would bind to a name the create endpoint never produces. Both halves have to land together, which is why this touches the server as well as the gateway.

## What changed

**`packages/lib/customBlockName.ts`** — one home for the prefix rules, shared by server and gateway.

- `withCustomBlockPrefix` is idempotent, so a caller that already resolved the stored name cannot double-prefix.
- `resolveCustomBlockName` resolves against known names *before* prefixing. Inhouse and plugin blocks are stored **bare**; prefixing blindly would break every reference to them. A name matching nothing is assumed to be a block being created now.
- `uniqueCustomBlockName` picks a free `_2`, `_3`, … suffix.

**`blockBuilder/pendingCustomBlocks.ts`** — walks the task's *transitive* dependency closure for `customBlockConfig` results. Transitive because a route canvas task depends on the block's **canvas** task, and the name lives one hop further back on the **config** task. Only declared dependencies count, so an unrelated sibling still cannot be referenced, and `delete` actions are skipped.

**Validator + `getBlockSchemas`** — pending proposals are merged *under* the DB (a real block always wins) and both name forms are queried, so the model can inspect a pending block's parameters instead of guessing at them.

**Block builder** — canonicalizes `custom:<name>` in its own output against the names it knows, at **no extra query**: the name list already fetched for the prompt is reused. A name that matches nothing is left exactly as written — the validator's message about it is more useful than one about a name this rewrote.

**`customBlockConfig`** — settles name collisions at create time. Any later is too late: the caller is already bound to whichever block held the name first, and the create fails with a conflict at apply.

**Create endpoint** — now uses the shared idempotent helper instead of unconditional concatenation.

## Also in here: a pre-existing 400 this exposed

Both tool-call strips in `toolLoop.ts` gated on `instanceof AIMessage`. That is **false for `AIMessageChunk`** — it extends `BaseMessageChunk` and only *implements* `AIMessage` — so a streamed reply carried its tool calls into the unbound structured-output call, and all three retries 400'd on the history rather than on the answer. Second trap: OpenAI-compatible providers may report the call only in `additional_kwargs.tool_calls`.

`toolCallsOf()` gates on the message type and reads both locations. Unrelated to #272 in cause — OpenAI accepts the malformed history, which is why it stayed hidden — but it blocked every acceptance run on DeepSeek, so it is fixed here rather than left to resurface.

## Verification

End to end against DeepSeek. A run that creates `validate_jwt` and references it from a route canvas **completes**, with the artifact holding:

```json
"blockType": "custom:user_defined.project.validate_jwt"
```

for a block that exists only as this run's proposal — no rejection anywhere in the log. The rename guard fired live on a real collision (`generate_jwt` → `generate_jwt_2`), and on a re-run correctly stayed out of the way when the model chose `update-partial` over `create`.

18 new unit tests; full monorepo suite green (801 pass / 0 fail) via the pre-commit hook.

## Note

`AGENT.md` also carries two entries that were already sitting uncommitted in the working tree — they document the elkjs removal (#431e351) and the task-generation merge (#1deef0f) and were evidently meant to ship with those. Shout if you would rather they went separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
