### PR TITLE
feat(harness): apply sub-artifacts in dependency order, gate partial apply

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ apps/ai-gateway/src/test-trace.ts
 .claude/worktrees
 .issue-tracker/
 apps/ai-gateway/src/harness/IMPROVEMENTS.md
+graphify-out/

--- a/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/applyBatch.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/applyBatch.ts
@@ -1,8 +1,11 @@
 import { NotFoundError } from "@fluxify/server";
 import {
-	formattedCanvasChanges,
-	type BlockBuilderPayload,
-} from "./normalize";
+	inlineCanvasFor,
+	kindLabel,
+	parentsOf,
+	topoOrder,
+	type GraphRow,
+} from "./dependencies";
 import { callerFor } from "./opsClient";
 import {
 	getArtifactSubArtifacts,
@@ -10,107 +13,17 @@ import {
 } from "./repository";
 import {
 	announce,
-	applyCanvasRow,
-	applyCustomBlockRow,
-	applyRouteRow,
-	assertParentRoutesReady,
-	customBlockIdOf,
+	APPLY_BY_KIND,
+	assertExternalRoutesExist,
+	canvasFor,
 	describeFailure,
 	EMPTY_CANVAS,
-	parentRouteIdOf,
-	rememberRealRouteId,
+	newApplyContext,
+	rememberRealIdsOnChildren,
 	resolveCanvasTarget,
-	routeIdOf,
-	type ApplyContext,
 	type ApplyFailure,
 	type DependencyRow,
-	type LabelledRow,
 } from "./service";
-
-/**
- * Pairs each newly-created parent row with the canvas built for it in the same
- * run, so the canvas rides inside the create and the parent never exists
- * without its blocks. Routes and custom blocks differ only in how their id is
- * read off the payload.
- */
-function pairInlineCanvases<R extends { id: string; payload?: any }, C extends { id: string; payload?: any }>(
-	parents: R[],
-	canvases: C[],
-	targetType: "route" | "custom_block",
-	idOf: (row: R) => string | undefined,
-	inlineCanvas: Map<string, C>,
-	inlined: Set<string>,
-) {
-	for (const parent of parents) {
-		if (parent.payload?.action !== "create") continue;
-		const paired = canvases.find(
-			(c) =>
-				!inlined.has(c.id) &&
-				c.payload?.targetType === targetType &&
-				c.payload?.targetId === idOf(parent),
-		);
-		if (!paired) continue;
-		inlineCanvas.set(parent.id, paired);
-		inlined.add(paired.id);
-	}
-}
-
-/**
- * Applies every route (or custom block) row, each on its own so one bad output
- * cannot abort the batch. Both kinds follow the identical shape: apply the
- * parent with its inlined canvas, record the real id the DB handed back onto
- * that canvas, and on failure mark the pair unapplied and re-appliable.
- */
-async function applyParentRows<R extends LabelledRow & { payload?: any }, C extends LabelledRow & { payload?: any }>(
-	ctx: ApplyContext,
-	parents: R[],
-	opts: {
-		inlineCanvas: Map<string, C>;
-		apply: (ctx: ApplyContext, row: R, changes?: any) => Promise<unknown>;
-		idOf: (row: R) => string | undefined;
-		realIds: Map<string, string>;
-		pairedFailure: string;
-		onFailure?: (id: string) => void;
-		done: string[];
-		failures: ApplyFailure[];
-		conversationId: string;
-	},
-) {
-	for (const parent of parents) {
-		const canvasRow = opts.inlineCanvas.get(parent.id);
-		try {
-			await opts.apply(
-				ctx,
-				parent,
-				canvasRow
-					? await formattedCanvasChanges(
-							(canvasRow.payload ?? {}) as BlockBuilderPayload,
-							EMPTY_CANVAS,
-						)
-					: undefined,
-			);
-			opts.done.push(parent.id);
-			if (canvasRow) {
-				const real = opts.realIds.get(opts.idOf(parent) ?? "");
-				if (real)
-					await rememberRealRouteId(
-						opts.conversationId,
-						canvasRow,
-						"targetId",
-						real,
-					);
-				opts.done.push(canvasRow.id);
-			}
-		} catch (error) {
-			const id = opts.idOf(parent);
-			if (id) opts.onFailure?.(id);
-			opts.failures.push(describeFailure(parent, error));
-			// The canvas rode along inside the create, so it did not land either.
-			if (canvasRow)
-				opts.failures.push(describeFailure(canvasRow, opts.pairedFailure));
-		}
-	}
-}
 
 export async function applyArtifact(
 	userId: string,
@@ -118,100 +31,93 @@ export async function applyArtifact(
 	projectId: string,
 	artifactId: string,
 ) {
-	const rows = await getArtifactSubArtifacts(conversationId, artifactId);
-	if (rows.length === 0) throw new NotFoundError("Artifact not found");
+	const raw = await getArtifactSubArtifacts(conversationId, artifactId);
+	if (raw.length === 0) throw new NotFoundError("Artifact not found");
 
-	const routes = rows.filter((r) => r.kind === "route");
-	const customBlocks = rows.filter((r) => r.kind === "custom_block");
-	const canvases = await Promise.all(
-		rows
-			.filter((r) => r.kind === "canvas")
-			.map((r) => resolveCanvasTarget(conversationId, projectId, r, rows)),
+	// The target repair has to happen before the graph is read: the id it fixes
+	// is the edge between a canvas and the parent it hangs off.
+	const rows = await Promise.all(
+		raw.map((row) => resolveCanvasTarget(conversationId, projectId, row, raw)),
 	);
-	// `rest` is stamped applied unconditionally at the end, so every kind that
-	// has its own apply path must be excluded — a custom block left in here was
-	// marked applied even when its create had just failed.
-	const rest = rows.filter(
-		(r) => r.kind !== "route" && r.kind !== "canvas" && r.kind !== "custom_block",
-	);
-
-	// Routes go first, so a canvas referencing a route this run created is
-	// already satisfied by the time its turn comes.
-	const applyingRouteIds = new Set(
-		routes.map(routeIdOf).filter((id): id is string => !!id),
-	);
-	await assertParentRoutesReady(projectId, canvases, routes, applyingRouteIds);
-
-	const ctx: ApplyContext = {
-		conversationId,
+	await assertExternalRoutesExist(
 		projectId,
-		caller: callerFor(userId, projectId),
-		routeIds: new Map(),
-		customBlockIds: new Map(),
-	};
-
-	// A canvas for a route this run is creating rides along with the create, so
-	// the route never exists without its blocks.
-	const inlineCanvas = new Map<string, (typeof canvases)[number]>();
-	const inlined = new Set<string>();
-	pairInlineCanvases(routes, canvases, "route", routeIdOf, inlineCanvas, inlined);
-	pairInlineCanvases(
-		customBlocks,
-		canvases,
-		"custom_block",
-		customBlockIdOf,
-		inlineCanvas,
-		inlined,
+		rows.filter((r) => r.kind === "canvas") as DependencyRow[],
+		rows as DependencyRow[],
 	);
 
-	const ordered = [...routes, ...customBlocks, ...canvases, ...rest];
+	// A canvas for a parent this run is creating rides along with the create, so
+	// the parent never exists without its blocks — it is applied there, not in
+	// its own turn.
+	const inlined = new Set<string>();
+	const inlineCanvas = new Map<string, (typeof rows)[number]>();
+	for (const row of rows) {
+		const child = inlineCanvasFor(row as GraphRow, rows as GraphRow[], inlined);
+		if (!child) continue;
+		inlineCanvas.set(row.id, child as (typeof rows)[number]);
+		inlined.add(child.id);
+	}
+
+	// The run's own DAG decides the order. Every relationship — a canvas needing
+	// its route, a route invoking a custom block created alongside it — is the
+	// same edge, so none of them is hardcoded here.
+	const ordered = topoOrder(rows as GraphRow[]) as typeof rows;
+
+	const ctx = newApplyContext(conversationId, projectId, userId);
 	const done: string[] = [];
 	// One bad output used to abort the whole batch, so a run that got nine
 	// things right and one wrong left the user with nine unapplied outputs and
 	// no idea which one was the problem. Each output is applied on its own now;
 	// what fails stays unapplied and re-appliable, and is named in the result.
 	const failures: ApplyFailure[] = [];
-	/** Routes that did not land — their canvases have nothing to attach to. */
-	const failedRouteIds = new Set<string>();
+	/** Rows that did not land, so anything hanging off them cannot either. */
+	const failed = new Map<string, (typeof rows)[number]>();
 
-	await applyParentRows(ctx, routes, {
-		inlineCanvas,
-		apply: applyRouteRow,
-		idOf: routeIdOf,
-		realIds: ctx.routeIds,
-		pairedFailure: "its route could not be created",
-		// A canvas whose route never landed has nothing to attach to.
-		onFailure: (id) => failedRouteIds.add(id),
-		done,
-		failures,
-		conversationId,
-	});
-	await applyParentRows(ctx, customBlocks, {
-		inlineCanvas,
-		apply: applyCustomBlockRow,
-		idOf: customBlockIdOf,
-		realIds: ctx.customBlockIds,
-		pairedFailure: "its custom block could not be created",
-		done,
-		failures,
-		conversationId,
-	});
+	for (const row of ordered) {
+		if (inlined.has(row.id)) continue;
 
-	for (const canvas of canvases) {
-		if (inlined.has(canvas.id)) continue;
-		const parentRouteId = parentRouteIdOf(canvas as DependencyRow);
-		if (parentRouteId && failedRouteIds.has(parentRouteId)) {
-			failures.push(describeFailure(canvas, "its route could not be created"));
+		// Cascade, in dependency order: a parent that failed is already in here by
+		// the time its children come round, and a skipped child is added itself,
+		// so the skip carries down a chain of any length.
+		const brokenParent = parentsOf(row as GraphRow, rows as GraphRow[]).find((p) =>
+			failed.has(p.id),
+		);
+		if (brokenParent) {
+			const reason = `its ${kindLabel(brokenParent.kind)} could not be created`;
+			failures.push(describeFailure(row, reason));
+			failed.set(row.id, row);
+			const child = inlineCanvas.get(row.id);
+			if (child) failures.push(describeFailure(child, reason));
 			continue;
 		}
+
+		const child = inlineCanvas.get(row.id);
+		const apply = APPLY_BY_KIND[row.kind];
+		if (!apply) {
+			done.push(row.id);
+			continue;
+		}
+
 		try {
-			await applyCanvasRow(ctx, canvas);
-			done.push(canvas.id);
+			await apply(
+				ctx,
+				row,
+				child ? await canvasFor(ctx, child, EMPTY_CANVAS) : undefined,
+			);
+			done.push(row.id);
+			if (child) {
+				await rememberRealIdsOnChildren(ctx, [child]);
+				done.push(child.id);
+			}
 		} catch (error) {
-			failures.push(describeFailure(canvas, error));
+			failed.set(row.id, row);
+			failures.push(describeFailure(row, error));
+			// The canvas rode along inside the create, so it did not land either.
+			if (child)
+				failures.push(
+					describeFailure(child, `its ${kindLabel(row.kind)} could not be created`),
+				);
 		}
 	}
-	done.push(...rest.map((r) => r.id));
 
 	const appliedAt = new Date();
 	if (done.length > 0) await markSubArtifactsApplied(conversationId, done, appliedAt);

--- a/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/dependencies.spec.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/dependencies.spec.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "bun:test";
+import {
+	inlineCanvasFor,
+	kindLabel,
+	parentsOf,
+	topoOrder,
+	type GraphRow,
+} from "./dependencies";
+
+const row = (over: Partial<GraphRow> & { id: string }): GraphRow => ({
+	kind: "canvas",
+	payload: {},
+	...over,
+});
+
+/** A run that builds a custom block and a route that invokes it. The route
+ *  names the block by name, deep in a canvas, so only the task edge records it. */
+const block = row({
+	id: "block",
+	kind: "custom_block",
+	subAgentId: "task-block",
+	dependsOn: [],
+	payload: { action: "create", customBlockId: "cb-1" },
+});
+const blockCanvas = row({
+	id: "block-canvas",
+	subAgentId: "task-block-canvas",
+	dependsOn: ["task-block"],
+	payload: { targetType: "custom_block", targetId: "cb-1" },
+});
+const route = row({
+	id: "route",
+	kind: "route",
+	subAgentId: "task-route",
+	dependsOn: ["task-block"],
+	payload: { action: "create", routeId: "rt-1" },
+});
+const routeCanvas = row({
+	id: "route-canvas",
+	subAgentId: "task-route-canvas",
+	dependsOn: ["task-route"],
+	payload: { targetType: "route", targetId: "rt-1" },
+});
+const rows = [routeCanvas, route, blockCanvas, block];
+
+describe("parentsOf", () => {
+	it("reads the declared task edge", () => {
+		// Nothing in the route's payload mentions the custom block — the run's own
+		// task graph is the only record that this order matters.
+		expect(parentsOf(route, rows).map((r) => r.id)).toEqual(["block"]);
+	});
+
+	it("reads the payload link, so a row written before dependsOn still works", () => {
+		const legacy = row({
+			id: "legacy-canvas",
+			payload: { targetType: "route", targetId: "rt-1" },
+		});
+		expect(parentsOf(legacy, [...rows, legacy]).map((r) => r.id)).toEqual(["route"]);
+	});
+
+	it("does not depend on a parent that only edits something already live", () => {
+		const existing = row({
+			id: "modify",
+			kind: "route",
+			payload: { action: "update-partial", routeId: "rt-9" },
+		});
+		const canvas = row({
+			id: "canvas",
+			payload: { targetType: "route", targetId: "rt-9" },
+		});
+		expect(parentsOf(canvas, [existing, canvas])).toEqual([]);
+	});
+
+	it("never makes a row its own parent", () => {
+		const self = row({
+			id: "self",
+			kind: "route",
+			subAgentId: "t",
+			dependsOn: ["t"],
+			payload: { action: "create", routeId: "rt-1", targetId: "rt-1" },
+		});
+		expect(parentsOf(self, [self])).toEqual([]);
+	});
+});
+
+describe("topoOrder", () => {
+	it("puts every row after everything it depends on", () => {
+		const order = topoOrder(rows).map((r) => r.id);
+		expect(order.indexOf("block")).toBeLessThan(order.indexOf("route"));
+		expect(order.indexOf("route")).toBeLessThan(order.indexOf("route-canvas"));
+		expect(order.indexOf("block")).toBeLessThan(order.indexOf("block-canvas"));
+	});
+
+	it("keeps input order for rows with no relationship", () => {
+		const a = row({ id: "a", kind: "other" });
+		const b = row({ id: "b", kind: "other" });
+		expect(topoOrder([b, a]).map((r) => r.id)).toEqual(["b", "a"]);
+	});
+
+	it("terminates on a cycle instead of hanging", () => {
+		const a = row({ id: "a", subAgentId: "ta", dependsOn: ["tb"] });
+		const b = row({ id: "b", subAgentId: "tb", dependsOn: ["ta"] });
+		expect(topoOrder([a, b]).map((r) => r.id).sort()).toEqual(["a", "b"]);
+	});
+
+	it("loses nothing", () => {
+		expect(topoOrder(rows)).toHaveLength(rows.length);
+	});
+});
+
+describe("inlineCanvasFor", () => {
+	it("finds the canvas built for a parent being created", () => {
+		expect(inlineCanvasFor(block, rows, new Set())?.id).toBe("block-canvas");
+		expect(inlineCanvasFor(route, rows, new Set())?.id).toBe("route-canvas");
+	});
+
+	it("leaves a canvas alone once another parent has taken it", () => {
+		expect(inlineCanvasFor(route, rows, new Set(["route-canvas"]))).toBeUndefined();
+	});
+
+	it("does not inline into a parent that already exists", () => {
+		const modify = row({
+			id: "modify",
+			kind: "route",
+			subAgentId: "task-modify",
+			payload: { action: "update-partial", routeId: "rt-2" },
+		});
+		const canvas = row({
+			id: "modify-canvas",
+			dependsOn: ["task-modify"],
+			payload: { targetType: "route", targetId: "rt-2" },
+		});
+		expect(inlineCanvasFor(modify, [modify, canvas], new Set())).toBeUndefined();
+	});
+});
+
+describe("kindLabel", () => {
+	it("says what a user would say", () => {
+		expect(kindLabel("custom_block")).toBe("custom block");
+		expect(kindLabel("route")).toBe("route");
+	});
+});

--- a/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/dependencies.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/dependencies.ts
@@ -1,0 +1,121 @@
+/**
+ * The dependency graph between one artifact's outputs.
+ *
+ * A run already produces a DAG — the task graph — and every sub-artifact row is
+ * stamped with the task that produced it. This module is the only place that
+ * turns those two facts back into edges, so ordering, inline pairing, the apply
+ * gate and the cascade skip are all one mechanism instead of four hardcoded
+ * ones, each pinned to a single relationship.
+ *
+ * Nothing here branches on `kind`. A new resource kind that stores its planned
+ * id in the payload and is referenced by `targetId` gets ordering and gating
+ * for free; if you find yourself adding a kind here, the abstraction is wrong.
+ */
+
+/** The columns the graph reads. Deliberately narrow so both the batch apply and
+ *  the single apply can pass their own row shapes. */
+export interface GraphRow {
+	id: string;
+	kind: string;
+	/** The task that produced this row — the other end of `dependsOn`. */
+	subAgentId?: string | null;
+	/** Task ids the producing task declared a dependency on. */
+	dependsOn?: string[] | null;
+	payload?: Record<string, any> | null;
+}
+
+/**
+ * The resource this row brings into existence, or undefined if it only edits
+ * something already live. Only a create is a dependency: a modify targets a
+ * resource that is already there, so nothing has to wait for it.
+ */
+export function createdIdOf(row: Pick<GraphRow, "payload">): string | undefined {
+	if (row.payload?.action !== "create") return undefined;
+	return (row.payload?.routeId ?? row.payload?.customBlockId) as string | undefined;
+}
+
+/** The resource this row hangs itself off. */
+export function referencedIdOf(row: Pick<GraphRow, "payload">): string | undefined {
+	return row.payload?.targetId as string | undefined;
+}
+
+/**
+ * The rows this row must be applied after.
+ *
+ * Two sources, unioned, because neither alone is complete:
+ *
+ * - **The declared task edge.** Carries dependencies no payload records — a
+ *   route that invokes a custom block created in the same run references it by
+ *   name, deep inside a canvas, not by an id any column holds.
+ * - **The payload link.** `targetId` naming an id another row is creating is
+ *   ground truth: it is the same link the apply itself uses to attach the
+ *   canvas. The declared edge is a model's claim and can be missing.
+ *
+ * Rows written before `dependsOn` existed have only the second source, which is
+ * exactly the behaviour they had before this module.
+ */
+export function parentsOf<T extends GraphRow>(row: T, rows: readonly T[]): T[] {
+	const declared = new Set(row.dependsOn ?? []);
+	const references = referencedIdOf(row);
+	return rows.filter(
+		(other) =>
+			other.id !== row.id &&
+			((other.subAgentId != null && declared.has(other.subAgentId)) ||
+				(references != null && createdIdOf(other) === references)),
+	);
+}
+
+/**
+ * Every row, ordered so each one follows everything it depends on.
+ *
+ * Rows with no relationship keep their input order, so a batch whose graph is
+ * empty applies exactly as it did before.
+ */
+export function topoOrder<T extends GraphRow>(rows: readonly T[]): T[] {
+	// ponytail: O(n²). A run produces a handful of outputs, not a build graph;
+	// swap in Kahn's with an adjacency map if that ever stops being true.
+	const parentIds = new Map(
+		rows.map((row) => [row.id, parentsOf(row, rows).map((p) => p.id)]),
+	);
+	const emitted = new Set<string>();
+	const out: T[] = [];
+	const remaining = [...rows];
+
+	while (remaining.length > 0) {
+		const ready = remaining.findIndex((row) =>
+			(parentIds.get(row.id) ?? []).every((id) => emitted.has(id)),
+		);
+		// Only a malformed graph has no ready row. Emitting the rest in input
+		// order beats hanging — and the apply gate still refuses anything whose
+		// parent genuinely did not land.
+		const [row] = remaining.splice(ready === -1 ? 0 : ready, 1);
+		if (!row) break;
+		emitted.add(row.id);
+		out.push(row);
+	}
+	return out;
+}
+
+/**
+ * The canvas built for a parent this run is creating. It rides inside the
+ * parent's create so the parent never exists without its blocks, which is why
+ * it is pulled out of the ordering rather than applied in its own turn.
+ *
+ * `taken` stops one canvas being inlined into two parents.
+ */
+export function inlineCanvasFor<T extends GraphRow>(
+	parent: T,
+	rows: readonly T[],
+	taken: ReadonlySet<string>,
+): T | undefined {
+	if (parent.payload?.action !== "create") return undefined;
+	return rows.find(
+		(row) =>
+			row.kind === "canvas" &&
+			!taken.has(row.id) &&
+			parentsOf(row, rows).some((p) => p.id === parent.id),
+	);
+}
+
+/** `custom_block` → `custom block`: the kind, as a human would say it. */
+export const kindLabel = (kind: string) => kind.replace(/_/g, " ");

--- a/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/dto.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/dto.ts
@@ -27,6 +27,10 @@ export const subArtifactSummarySchema = z.object({
 	action: z.string().nullable(),
 	appliedAt: z.union([z.string(), z.date()]).nullable(),
 	createdAt: z.union([z.string(), z.date()]),
+	/** The producing task. `dependsOn` names these, which is how the client
+	 *  rebuilds the chain without fetching every payload. */
+	subAgentId: z.string().nullish(),
+	dependsOn: z.array(z.string()).nullish(),
 });
 
 export const listResponseSchema = z.object({
@@ -36,7 +40,6 @@ export const listResponseSchema = z.object({
 export const subArtifactDetailSchema = subArtifactSummarySchema.extend({
 	conversationId: z.string(),
 	runId: z.string(),
-	subAgentId: z.string().nullable(),
 	payload: z.record(z.string(), z.any()),
 });
 
@@ -50,7 +53,7 @@ export const applySubArtifactResponseSchema = z.object({
 export const applyArtifactResponseSchema = z.object({
 	artifactId: z.string(),
 	appliedAt: z.union([z.string(), z.date()]),
-	/** Route outputs first — the order the project mutation must run in. */
+	/** Dependency order — the order the project mutation actually ran in. */
 	applied: z.array(
 		z.object({
 			id: z.string(),

--- a/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/normalize.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/normalize.ts
@@ -188,6 +188,47 @@ function canonicalType(raw: string) {
 	return CANONICAL_TYPE.get(key(raw)) ?? raw;
 }
 
+/**
+ * Rewrites `custom:<old>` to `custom:<new>` everywhere a canvas payload names a
+ * block type, for every entry in `renames`.
+ *
+ * A custom block's stored name is not always the name the run asked for — the
+ * create endpoint namespaces it, and the config agent renames around a
+ * collision. The caller's canvas invokes the block *by name*, so a canvas built
+ * against the requested name resolves to nothing once the block lands under a
+ * different one. The map is normally empty; this only does work when a name
+ * actually moved between generation and apply.
+ */
+export function remapCustomBlockNames(
+	payload: BlockBuilderPayload,
+	renames: ReadonlyMap<string, string>,
+): BlockBuilderPayload {
+	if (renames.size === 0) return payload;
+
+	const rename = (block: AgentBlock) => {
+		const raw = block.blockType ?? "";
+		if (!raw.startsWith("custom:")) return block;
+		const to = renames.get(raw.slice("custom:".length));
+		return to ? { ...block, blockType: `custom:${to}` } : block;
+	};
+
+	return {
+		...payload,
+		blocks: payload.blocks?.map(rename) ?? payload.blocks,
+		canvasChanges: payload.canvasChanges?.map((change) =>
+			change?.type === "block_change" && Array.isArray(change.data?.blocksInfo)
+				? {
+						...change,
+						data: {
+							...change.data,
+							blocksInfo: (change.data.blocksInfo as AgentBlock[]).map(rename),
+						},
+					}
+				: change,
+		),
+	};
+}
+
 /** Edges persist `<blockId>-<kind>`; the agent emits the bare kind. */
 function fullHandle(blockId: string, handle: string | null | undefined, fallback: string) {
 	const kind = (handle ?? fallback).trim() || fallback;

--- a/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/repository.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/repository.ts
@@ -34,6 +34,11 @@ export async function listSubArtifactsByRun(conversationId: string, runId: strin
 			action: subArtifacts.action,
 			appliedAt: subArtifacts.appliedAt,
 			createdAt: subArtifacts.createdAt,
+			// The dependency chain drives the apply buttons, so the list has to
+			// carry it — otherwise the UI must fetch every payload to know whether
+			// one output is applyable yet.
+			subAgentId: subArtifacts.subAgentId,
+			dependsOn: subArtifacts.dependsOn,
 		})
 		.from(subArtifacts)
 		.where(
@@ -58,6 +63,8 @@ export async function getArtifactSubArtifacts(
 			action: subArtifacts.action,
 			appliedAt: subArtifacts.appliedAt,
 			payload: subArtifacts.payload,
+			subAgentId: subArtifacts.subAgentId,
+			dependsOn: subArtifacts.dependsOn,
 		})
 		.from(subArtifacts)
 		.where(

--- a/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/service.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/service.ts
@@ -1,10 +1,12 @@
 import { ConflictError, NotFoundError } from "@fluxify/server";
+import { withCustomBlockPrefix } from "@fluxify/lib";
 import { publishArtifactStatus } from "../../../../harness/notifications";
 import type { ArtifactStatus } from "../../../../harness/clientContract";
 import type { RpcCaller } from "@fluxify/server/src/db/natsRpc";
 import {
 	formattedCanvasChanges,
 	customBlockOpFromPayload,
+	remapCustomBlockNames,
 	routeOpFromPayload,
 	type BlockBuilderPayload,
 	type CanvasChanges,
@@ -12,6 +14,12 @@ import {
 	type CustomBlockConfigPayload,
 	type RouteConfigPayload,
 } from "./normalize";
+import {
+	inlineCanvasFor,
+	kindLabel,
+	parentsOf,
+	referencedIdOf,
+} from "./dependencies";
 import {
 	callerFor,
 	createCustomBlock,
@@ -39,6 +47,8 @@ export interface DependencyRow {
 	action: string | null;
 	appliedAt: Date | null;
 	payload: Record<string, any> | null;
+	subAgentId?: string | null;
+	dependsOn?: string[] | null;
 }
 
 /** The route a `kind: "route"` output creates or edits. */
@@ -98,7 +108,11 @@ export function describeArtifactRow(row: LabelledRow): string {
 		const what = payload.targetType === "custom_block" ? "custom block" : "route";
 		return `logic for the ${what}`;
 	}
-	return `${row.kind} ${row.id}`;
+	if (row.kind === "custom_block") {
+		const name = payload.data?.label ?? payload.data?.name;
+		return name ? `custom block '${name}'` : `custom block ${row.id}`;
+	}
+	return `${kindLabel(row.kind)} ${row.id}`;
 }
 
 /** `Created route 'Get Order' (GET /orders/:id)` — the whole event, in words. */
@@ -154,42 +168,67 @@ export function describeFailure(row: LabelledRow, error: unknown): ApplyFailure 
 }
 
 /**
- * A canvas is meaningless without its route — its blocks hang off a route id, so
- * the route has to be live before the graph can be pushed.
+ * The parent of `row` that is not live yet, if there is one.
  *
- * Two ways the dependency is satisfied: the route is a sibling output of the same
- * artifact (this run created it) and has already been applied, or it is an older
- * route that still exists in the project. `applyingRouteIds` are the siblings
- * being applied earlier in this same request.
+ * Applying a child before its parent produces a resource that cannot execute —
+ * a route invoking a custom block that does not exist, a canvas hanging off a
+ * route that was never created. Nothing here knows which kinds those are; the
+ * edge comes from the run's own task graph.
+ *
+ * `applying` are siblings this same request is about to apply earlier in the
+ * order, which satisfies the dependency just as an already-applied row does.
  */
-export async function assertParentRoutesReady(
+export function unappliedParent(
+	row: DependencyRow,
+	siblings: DependencyRow[],
+	applying: ReadonlySet<string> = new Set(),
+): DependencyRow | undefined {
+	return parentsOf(row, siblings).find(
+		(parent) => !parent.appliedAt && !applying.has(parent.id),
+	);
+}
+
+/**
+ * Refuses a child whose parent has not been applied, naming the parent.
+ *
+ * Deliberately not a cascade-apply: creating a resource in the user's project
+ * because they clicked a different one is a surprise they cannot undo. Block,
+ * say what to apply first, and let them press it.
+ */
+export function assertParentsApplied(
+	row: DependencyRow,
+	siblings: DependencyRow[],
+	applying?: ReadonlySet<string>,
+) {
+	const parent = unappliedParent(row, siblings, applying);
+	if (!parent) return;
+	throw new ConflictError(
+		`This ${kindLabel(row.kind)} output depends on the ${describeArtifactRow(
+			parent,
+		)} this run created, which has not been applied yet. Apply it (sub-artifact ${
+			parent.id
+		}) first.`,
+	);
+}
+
+/**
+ * Referential check, not a dependency one: a canvas may legitimately target a
+ * route from an earlier run, and if that route has since been deleted the save
+ * fails deep in the canvas service with a message about a parent id the user
+ * never saw. Rows created *this* run are handled by the dependency gate above.
+ */
+export async function assertExternalRoutesExist(
 	projectId: string,
 	canvases: DependencyRow[],
 	siblings: DependencyRow[],
-	applyingRouteIds: Set<string>,
 ) {
-	const external: string[] = [];
-
-	for (const routeId of new Set(
-		canvases.map(parentRouteIdOf).filter((id): id is string => !!id),
-	)) {
-		if (applyingRouteIds.has(routeId)) continue;
-
-		const sibling = siblings.find(
-			(s) => s.kind === "route" && routeIdOf(s) === routeId,
-		);
-		if (!sibling) {
-			external.push(routeId);
-			continue;
-		}
-		if (!sibling.appliedAt) {
-			throw new ConflictError(
-				`These canvas changes belong to a route this run created that has not been applied yet. Apply the route (sub-artifact ${sibling.id}) first.`,
-			);
-		}
-	}
-
+	const external = [
+		...new Set(canvases.map(parentRouteIdOf).filter((id): id is string => !!id)),
+	].filter(
+		(routeId) => !siblings.some((s) => s.kind === "route" && routeIdOf(s) === routeId),
+	);
 	if (external.length === 0) return;
+
 	const existing = await findExistingRouteIds(projectId, external);
 	const missing = external.find((id) => !existing.has(id));
 	if (missing) {
@@ -274,7 +313,24 @@ export type ApplyContext = {
 	routeIds: Map<string, string>;
 	/** Planned custom-block id to storage id, same reconciliation as routes. */
 	customBlockIds: Map<string, string>;
+	/** The name a custom block was created under, when storage did not use the
+	 *  one the run asked for. Canvases invoke a block by name, so a canvas built
+	 *  against the requested name has to be rewritten before it is saved. */
+	customBlockNames: Map<string, string>;
 };
+
+export const newApplyContext = (
+	conversationId: string,
+	projectId: string,
+	userId: string,
+): ApplyContext => ({
+	conversationId,
+	projectId,
+	caller: callerFor(userId, projectId),
+	routeIds: new Map(),
+	customBlockIds: new Map(),
+	customBlockNames: new Map(),
+});
 
 /**
  * Writes one route output through the bus. `canvas` is sent inline on a create
@@ -320,9 +376,32 @@ export async function applyCustomBlockRow(
 		await modifyCustomBlock(ctx.caller, op.id, op.data);
 		return;
 	}
+	// Storage namespaces a project block, so the name a caller's canvas has to
+	// invoke is not the bare one this payload asked for. Recorded before the
+	// create so an inlined canvas in the same call is rewritten too.
+	ctx.customBlockNames.set(op.data.name, withCustomBlockPrefix(op.data.name));
 	const { id } = await createCustomBlock(ctx.caller, op.data, canvas);
 	if (payload.customBlockId) ctx.customBlockIds.set(payload.customBlockId, id);
 	await rememberRealRouteId(ctx.conversationId, row, "customBlockId", id);
+}
+
+/**
+ * One canvas payload, ready for the bus. Every path that pushes a graph goes
+ * through here so the name remap cannot be forgotten on one of them — a canvas
+ * saved with a stale `custom:<name>` looks fine and resolves to nothing.
+ */
+export function canvasFor(
+	ctx: ApplyContext,
+	row: { payload: Record<string, any> | null },
+	existing: CanvasItems,
+) {
+	return formattedCanvasChanges(
+		remapCustomBlockNames(
+			(row.payload ?? {}) as BlockBuilderPayload,
+			ctx.customBlockNames,
+		),
+		existing,
+	);
 }
 
 export async function applyCanvasRow(
@@ -338,14 +417,42 @@ export async function applyCanvasRow(
 	// Normalizing needs the canvas as it stands: it decides which block ids are
 	// already real and which edge is being re-routed.
 	const existing = await readCanvas(ctx.caller, source, sourceId);
-	await saveCanvas(
-		ctx.caller,
-		source,
-		sourceId,
-		await formattedCanvasChanges(payload, existing),
-	);
+	await saveCanvas(ctx.caller, source, sourceId, await canvasFor(ctx, row, existing));
 	if (sourceId !== target) {
 		await rememberRealRouteId(ctx.conversationId, row, "targetId", sourceId);
+	}
+}
+
+/** How each kind is written to the project. Ordering, pairing and gating are
+ *  kind-agnostic; only the write itself knows what it is writing. */
+export const APPLY_BY_KIND: Record<
+	string,
+	(
+		ctx: ApplyContext,
+		row: { id: string; payload: Record<string, any> | null },
+		canvas?: CanvasChanges,
+	) => Promise<void>
+> = {
+	route: applyRouteRow,
+	custom_block: applyCustomBlockRow,
+	canvas: applyCanvasRow,
+};
+
+/**
+ * The parent has the id storage chose; its children still name the one the
+ * agent invented. Leaving them stale breaks every later read of the link — the
+ * apply gate cannot tell the parent is live.
+ */
+export async function rememberRealIdsOnChildren(
+	ctx: ApplyContext,
+	rows: { id: string; payload: Record<string, any> | null }[],
+) {
+	for (const row of rows) {
+		const planned = referencedIdOf(row);
+		if (!planned) continue;
+		const real = ctx.routeIds.get(planned) ?? ctx.customBlockIds.get(planned);
+		if (real && real !== planned)
+			await rememberRealRouteId(ctx.conversationId, row, "targetId", real);
 	}
 }
 
@@ -359,76 +466,34 @@ export async function applySubArtifact(
 	const row = await getSubArtifactById(conversationId, subArtifactId);
 	if (!row) throw new NotFoundError("Sub-artifact not found");
 
-	const ctx: ApplyContext = {
-		conversationId,
-		projectId,
-		caller: callerFor(userId, projectId),
-		routeIds: new Map(),
-		customBlockIds: new Map(),
-	};
+	const ctx = newApplyContext(conversationId, projectId, userId);
+	const siblings = await getArtifactSubArtifacts(conversationId, row.artifactId);
+	// A no-op unless this is a canvas whose target was mis-copied, but it has to
+	// run before the graph is read: every edge into this row goes through the id
+	// it repairs.
+	const resolved = await resolveCanvasTarget(conversationId, projectId, row, siblings);
+	const rows = siblings.map((s) => (s.id === resolved.id ? { ...s, ...resolved } : s));
 
-	if (row.kind === "canvas") {
-		const siblings = await getArtifactSubArtifacts(conversationId, row.artifactId);
-		const resolved = await resolveCanvasTarget(conversationId, projectId, row, siblings);
-		await assertParentRoutesReady(projectId, [resolved], siblings, new Set());
-		await applyCanvasRow(ctx, resolved);
-	} else if (row.kind === "route") {
-		const agentRouteId = row.payload?.routeId as string | undefined;
-		const siblings = await getArtifactSubArtifacts(conversationId, row.artifactId);
-		const canvasRow = row.payload?.action === "create"
-			? siblings.find(
-					(s) => s.kind === "canvas" && !s.appliedAt && s.payload?.targetType === "route" && s.payload?.targetId === agentRouteId,
-				)
-			: undefined;
-		await applyRouteRow(
-			ctx,
-			row,
-			canvasRow ? await formattedCanvasChanges((canvasRow.payload ?? {}) as BlockBuilderPayload, EMPTY_CANVAS) : undefined,
+	assertParentsApplied(resolved as DependencyRow, rows);
+	await assertExternalRoutesExist(projectId, [resolved as DependencyRow], rows);
+
+	const apply = APPLY_BY_KIND[resolved.kind];
+	if (apply) {
+		// An already-applied canvas must not ride along a second time.
+		const child = inlineCanvasFor(
+			resolved as DependencyRow,
+			rows,
+			new Set(rows.filter((s) => s.appliedAt).map((s) => s.id)),
 		);
-		// The route now has the id storage chose, but its canvas siblings still
-		// point at the id the agent invented. Leaving them stale breaks every
-		// later read of the link — the apply gate cannot tell the route is live.
-		const realId = agentRouteId ? ctx.routeIds.get(agentRouteId) : undefined;
-		if (realId && agentRouteId !== realId) {
-			for (const sibling of siblings) {
-				if (sibling.kind !== "canvas") continue;
-				if (sibling.payload?.targetType !== "route") continue;
-				if (sibling.payload?.targetId !== agentRouteId) continue;
-				await rememberRealRouteId(conversationId, sibling, "targetId", realId);
-			}
-		}
+		await apply(
+			ctx,
+			resolved,
+			child ? await canvasFor(ctx, child, EMPTY_CANVAS) : undefined,
+		);
+		await rememberRealIdsOnChildren(ctx, rows);
 		// The canvas rode inside the create, so it is live. Leaving it unstamped
 		// showed it as pending and let a second apply re-save the same blocks.
-		if (canvasRow) await markSubArtifactsApplied(conversationId, [canvasRow.id], new Date());
-	} else if (row.kind === "custom_block") {
-		const agentCustomBlockId = row.payload?.customBlockId as string | undefined;
-		const siblings = await getArtifactSubArtifacts(conversationId, row.artifactId);
-		const canvasRow = row.payload?.action === "create"
-			? siblings.find(
-					(s) =>
-						s.kind === "canvas" &&
-						!s.appliedAt &&
-						s.payload?.targetType === "custom_block" &&
-						s.payload?.targetId === agentCustomBlockId,
-				)
-			: undefined;
-		await applyCustomBlockRow(
-			ctx,
-			row,
-			canvasRow
-				? await formattedCanvasChanges((canvasRow.payload ?? {}) as BlockBuilderPayload, EMPTY_CANVAS)
-				: undefined,
-		);
-		const realId = agentCustomBlockId ? ctx.customBlockIds.get(agentCustomBlockId) : undefined;
-		if (realId && agentCustomBlockId !== realId) {
-			for (const sibling of siblings) {
-				if (sibling.kind !== "canvas") continue;
-				if (sibling.payload?.targetType !== "custom_block") continue;
-				if (sibling.payload?.targetId !== agentCustomBlockId) continue;
-				await rememberRealRouteId(conversationId, sibling, "targetId", realId);
-			}
-		}
-		if (canvasRow) await markSubArtifactsApplied(conversationId, [canvasRow.id], new Date());
+		if (child) await markSubArtifactsApplied(conversationId, [child.id], new Date());
 	}
 
 	const [applied] = await markSubArtifactsApplied(

--- a/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/tests/applyBatch.spec.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/tests/applyBatch.spec.ts
@@ -78,11 +78,22 @@ const customBlockRow = (over: Record<string, any> = {}) => ({
 });
 
 /** Nothing lives in the project unless a test says so. `spyOn` keeps the same
- *  mock across tests, so call counts must be cleared or they accumulate. */
-beforeEach(() => {
+ *  mock across tests, so call counts must be cleared or they accumulate — and a
+ *  test that stubs a bus call to throw leaves that stub in place for every test
+ *  after it, silently. Both are reset here rather than ordered around. */
+beforeEach(async () => {
 	bus.length = 0;
 	for (const fn of Object.keys(repository) as (keyof typeof repository)[]) {
 		(repository[fn] as any).mockClear?.();
+	}
+	const opsClient = await import("../opsClient");
+	for (const [call, result] of [
+		["createRoute", { id: "live-route" }],
+		["createCustomBlock", { id: "live-custom-block" }],
+	] as const) {
+		const spy = spyOn(opsClient, call);
+		spy.mockClear();
+		spy.mockImplementation(record(call, result) as never);
 	}
 	spyOn(repository, "findExistingRouteIds").mockResolvedValue(new Set() as never);
 	spyOn(repository, "markSubArtifactsApplied").mockImplementation(
@@ -254,6 +265,136 @@ describe("Harness Artifacts — applying a whole artifact", () => {
 			["route-good"],
 			expect.any(Date),
 		);
+	});
+
+	// #272 lets a run reference a custom block it created in the same run. The
+	// route then cannot be applied until that block exists — an ordering nothing
+	// in either payload records, only the task graph.
+	it("applies a custom block before the route that invokes it", async () => {
+		spyOn(repository, "getArtifactSubArtifacts").mockResolvedValue([
+			routeRow({ subAgentId: "task-route", dependsOn: ["task-block"] }),
+			customBlockRow({ subAgentId: "task-block", dependsOn: [] }),
+		] as never);
+
+		const result = await applyArtifact("user1", "conv1", "proj1", "art1");
+
+		expect(bus.map((b) => b.call)).toEqual(["createCustomBlock", "createRoute"]);
+		expect(result.applied.map((a) => a.id)).toEqual([
+			"custom-block-sub",
+			"route-sub",
+		]);
+	});
+
+	it("skips the route when its custom block could not be created", async () => {
+		spyOn(repository, "getArtifactSubArtifacts").mockResolvedValue([
+			routeRow({ subAgentId: "task-route", dependsOn: ["task-block"] }),
+			customBlockRow({ subAgentId: "task-block", dependsOn: [] }),
+		] as never);
+
+		const opsClient = await import("../opsClient");
+		spyOn(opsClient, "createCustomBlock").mockImplementation((async () => {
+			throw new Error("name already taken");
+		}) as never);
+
+		const result = await applyArtifact("user1", "conv1", "proj1", "art1");
+
+		// The route was never attempted: it would have created a route whose
+		// canvas invokes a block that does not exist.
+		expect(bus.map((b) => b.call)).toEqual([]);
+		expect(result.applied).toHaveLength(0);
+		expect(result.failed.find((f) => f.id === "route-sub")?.reason).toBe(
+			"its custom block could not be created",
+		);
+	});
+
+	it("carries the skip down a chain, not just to the first child", async () => {
+		spyOn(repository, "getArtifactSubArtifacts").mockResolvedValue([
+			customBlockRow({ subAgentId: "task-block", dependsOn: [] }),
+			routeRow({ subAgentId: "task-route", dependsOn: ["task-block"] }),
+			// a second canvas for the route, so it is not inlined into the create
+			canvasRow({ subAgentId: "task-canvas-a", dependsOn: ["task-route"] }),
+			canvasRow({
+				id: "canvas-2",
+				subAgentId: "task-canvas-b",
+				dependsOn: ["task-route"],
+			}),
+		] as never);
+
+		const opsClient = await import("../opsClient");
+		spyOn(opsClient, "createCustomBlock").mockImplementation((async () => {
+			throw new Error("name already taken");
+		}) as never);
+
+		const result = await applyArtifact("user1", "conv1", "proj1", "art1");
+
+		expect(result.failed.map((f) => f.id).sort()).toEqual([
+			"canvas-2",
+			"canvas-sub",
+			"custom-block-sub",
+			"route-sub",
+		]);
+		// Two hops from the failure, and still reported against its own parent.
+		expect(result.failed.find((f) => f.id === "canvas-2")?.reason).toBe(
+			"its route could not be created",
+		);
+	});
+
+	// Storage namespaces a project block, so the name the canvas has to invoke is
+	// not the bare one the run asked for. A canvas saved with the stale name looks
+	// fine and resolves to nothing.
+	it("rewrites a canvas that invokes the custom block by its pre-storage name", async () => {
+		spyOn(repository, "getArtifactSubArtifacts").mockResolvedValue([
+			customBlockRow({ subAgentId: "task-block", dependsOn: [] }),
+			routeRow({ subAgentId: "task-route", dependsOn: ["task-block"] }),
+			canvasRow({
+				subAgentId: "task-canvas",
+				dependsOn: ["task-route"],
+				payload: {
+					targetType: "route",
+					targetId: "route-1",
+					blocks: [{ id: "b1", blockType: "custom:send_notice" }],
+				},
+			}),
+		] as never);
+
+		await applyArtifact("user1", "conv1", "proj1", "art1");
+
+		const created = bus.find((b) => b.call === "createRoute");
+		expect(JSON.stringify(created?.args[2])).toContain(
+			"user_defined.project.send_notice",
+		);
+		expect(JSON.stringify(created?.args[2])).not.toContain('"custom:send_notice"');
+	});
+
+	it("refuses a single apply whose parent is still a proposal, and names it", async () => {
+		const route = routeRow({ subAgentId: "task-route", dependsOn: ["task-block"] });
+		spyOn(repository, "getSubArtifactById").mockResolvedValue(route as never);
+		spyOn(repository, "getArtifactSubArtifacts").mockResolvedValue([
+			route,
+			customBlockRow({ subAgentId: "task-block", dependsOn: [] }),
+		] as never);
+
+		expect(
+			applySubArtifact("user1", "conv1", "proj1", "route-sub"),
+		).rejects.toThrow(/custom-block-sub/);
+		expect(bus).toHaveLength(0);
+	});
+
+	it("allows the single apply once the parent has landed", async () => {
+		const route = routeRow({ subAgentId: "task-route", dependsOn: ["task-block"] });
+		spyOn(repository, "getSubArtifactById").mockResolvedValue(route as never);
+		spyOn(repository, "getArtifactSubArtifacts").mockResolvedValue([
+			route,
+			customBlockRow({
+				subAgentId: "task-block",
+				dependsOn: [],
+				appliedAt: new Date(),
+			}),
+		] as never);
+
+		await applySubArtifact("user1", "conv1", "proj1", "route-sub");
+
+		expect(bus.map((b) => b.call)).toEqual(["createRoute"]);
 	});
 
 	it("does not try a canvas whose route could not be created", async () => {

--- a/apps/ai-gateway/src/harness/agents/sub-agents/customBlockConfig.spec.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/customBlockConfig.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+import { settleName, validateCustomBlockConfigOutput } from "./customBlockConfig";
+import type { GlobalGraphState, SubAgentResult } from "../../types";
+
+const check = (result: SubAgentResult) =>
+	validateCustomBlockConfigOutput(result, "t-1", {} as GlobalGraphState);
+
+describe("settleName", () => {
+	it("strips the storage prefix the model copies out of the inventory", () => {
+		// The exact name a failed run proposed: correct intent, wrong vocabulary.
+		expect(settleName("user_defined.project.generate_random_ids", new Set())).toBe(
+			"generate_random_ids",
+		);
+	});
+
+	it("still resolves a collision after stripping", () => {
+		expect(
+			settleName(
+				"user_defined.project.generate_jwt",
+				new Set(["user_defined.project.generate_jwt"]),
+			),
+		).toBe("generate_jwt_2");
+	});
+
+	it("leaves a bare, free name alone", () => {
+		expect(settleName("send_notification", new Set())).toBe("send_notification");
+	});
+});
+
+describe("validateCustomBlockConfigOutput", () => {
+	it("says what is wrong with the name, so a retry can fix it", () => {
+		const error = check({
+			action: "create",
+			data: { name: "Generate Random IDs", label: "x", inputParams: [] },
+		});
+		// A retry only helps if the review names the offending value.
+		expect(error).toContain("Generate Random IDs");
+	});
+
+	it("accepts a bare snake_case create", () => {
+		expect(
+			check({
+				action: "create",
+				data: { name: "generate_random_ids", label: "Generate Random IDs", inputParams: [] },
+			}),
+		).toBeNull();
+	});
+});

--- a/apps/ai-gateway/src/harness/agents/sub-agents/customBlockConfig.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/customBlockConfig.ts
@@ -1,5 +1,9 @@
 import { logger } from "@fluxify/common";
-import { generateID, uniqueCustomBlockName } from "@fluxify/lib";
+import {
+	generateID,
+	uniqueCustomBlockName,
+	withoutCustomBlockPrefix,
+} from "@fluxify/lib";
 import { z } from "zod";
 import { dispatchAgentEvent } from "../../callbacks";
 import { createFindResourceTool } from "../../tools/findResource";
@@ -28,6 +32,18 @@ const customBlockConfigSchema = z.object({
 	}).nullish(),
 });
 
+/**
+ * The bare, unclaimed name to store a new block under.
+ *
+ * Stored project blocks carry the `user_defined.project.` prefix, so that is
+ * the form the model sees in the inventory and in the current-context block —
+ * and it proposes it straight back, dots and all. The create DTO takes the
+ * bare name only (storage adds the prefix itself), so a prefixed name is a
+ * correct intent in the wrong vocabulary, not a mistake to reject: strip it.
+ */
+export const settleName = (name: string, taken: ReadonlySet<string>) =>
+	uniqueCustomBlockName(withoutCustomBlockPrefix(name), taken);
+
 export class CustomBlockConfigAgent extends BaseAgent {
 	/**
 	 * Settles the name here, before Block Builder writes `custom:<name>` into a
@@ -42,9 +58,9 @@ export class CustomBlockConfigAgent extends BaseAgent {
 				await this.state.internal.dbService.getAllCustomBlocks(projectId)
 			).map(({ name }: { name: string }) => name),
 		);
-		const free = uniqueCustomBlockName(name, taken);
+		const free = settleName(name, taken);
 		if (free !== name) {
-			logger.warn("[CustomBlockConfig] Renamed custom block, name taken", {
+			logger.warn("[CustomBlockConfig] Settled custom block name", {
 				requested: name,
 				renamed: free,
 			});
@@ -61,6 +77,7 @@ export class CustomBlockConfigAgent extends BaseAgent {
 ${CUSTOM_BLOCK_PARAMETER_CONTRACT}
 ## Strict Rules
 - \`create\` requires \`data.name\`, \`data.label\`, and \`data.inputParams\`. Name is lowercase snake_case and becomes runtime block type; never invent a UUID.
+- \`data.name\` is the bare name (\`generate_random_ids\`). Existing blocks are listed under a \`user_defined.project.\` storage prefix — never copy that prefix into \`data.name\`; storage adds it.
 - \`update-partial\` and \`delete\` require exact \`customBlockId\` from task context. Existing custom block names are immutable because caller canvases invoke them by name; only label, description, and inputParams may change.
 - For new custom blocks, this output runs before Block Builder. Define full caller contract now so canvas agent can consume it exactly.
 - Search docs only for an uncovered platform feature. Batch every query in one \`searchQueries\` call.
@@ -90,7 +107,7 @@ export const validateCustomBlockConfigOutput: import("../../types").AgentOutputV
 	if (!value?.action) return "Missing custom block action.";
 	if ((value.action === "update-partial" || value.action === "delete") && !value.customBlockId) return `Action '${value.action}' requires customBlockId.`;
 	if (value.action === "create") {
-		if (!value.data?.name?.match(/^[a-z0-9_]+$/)) return "Custom block create requires lowercase snake_case data.name.";
+		if (!value.data?.name?.match(/^[a-z0-9_]+$/)) return `Custom block create requires lowercase snake_case data.name — letters, digits and underscores only, with no dots and no "user_defined.project." prefix. Got "${value.data?.name ?? ""}".`;
 		if (!value.data.label?.trim()) return "Custom block create requires data.label.";
 		if (!value.data.inputParams) return "Custom block create requires data.inputParams (use [] when none).";
 	}

--- a/apps/ai-gateway/src/harness/agents/summarizer.ts
+++ b/apps/ai-gateway/src/harness/agents/summarizer.ts
@@ -137,7 +137,7 @@ export class SummarizerAgent extends BaseAgent {
 
 					if (isCustomBlockConfigResult(result)) {
 						const type = result.action === "create" ? "add" : result.action === "delete" ? "delete" : "changes";
-						const subId = await harnessService.createSubArtifact({ artifactId, runId, subAgentId: task.id, kind: "custom_block", action: type, payload: result });
+						const subId = await harnessService.createSubArtifact({ artifactId, runId, subAgentId: task.id, dependsOn: task.dependsOnAgentId, kind: "custom_block", action: type, payload: result });
 						subArtifactIds[task.id] = subId;
 						changes.push({ label: result.data?.label ?? result.data?.name ?? task.title, actionLabel: type, agentRole: "Custom block configuration", token: `:customBlock{type="${type}" sub_artifact_id="${subId}"}` });
 					} else if (isRouteConfigResult(result)) {
@@ -151,6 +151,7 @@ export class SummarizerAgent extends BaseAgent {
 							artifactId,
 							runId,
 							subAgentId: task.id,
+							dependsOn: task.dependsOnAgentId,
 							kind: "route",
 							action: type,
 							payload: result,
@@ -170,6 +171,7 @@ export class SummarizerAgent extends BaseAgent {
 							artifactId,
 							runId,
 							subAgentId: task.id,
+							dependsOn: task.dependsOnAgentId,
 							kind: "canvas",
 							action: "changes",
 							payload: result,

--- a/apps/ai-gateway/src/harness/internal/harnessService.ts
+++ b/apps/ai-gateway/src/harness/internal/harnessService.ts
@@ -272,6 +272,10 @@ export class HarnessService {
 		artifactId: string;
 		runId: string;
 		subAgentId?: string;
+		/** The producing task's `dependsOnAgentId`. Stored as task ids, not row
+		 *  ids: the rows are written in one pass and a task's dependency may not
+		 *  have a row yet, while `subAgentId` resolves the two at read time. */
+		dependsOn?: string[];
 		kind: string;
 		action?: string;
 		payload: Record<string, any>;
@@ -283,6 +287,7 @@ export class HarnessService {
 				conversationId: this.conversationId,
 				runId: input.runId,
 				subAgentId: input.subAgentId,
+				dependsOn: input.dependsOn,
 				kind: input.kind,
 				action: input.action,
 				payload: input.payload,

--- a/apps/portal/src/components/ai/ArtifactsSidebar.tsx
+++ b/apps/portal/src/components/ai/ArtifactsSidebar.tsx
@@ -1,8 +1,59 @@
 import { useAiHarnessStore } from "@/store/aiHarness";
-import { TbChevronsRight } from "react-icons/tb";
+import { TbCheck, TbChevronRight, TbChevronsRight } from "react-icons/tb";
+import { harnessConversationsQuery } from "@/query/harnessConversationsQuery";
 import { RouteArtifact } from "./artifacts/RouteArtifact";
 import { CanvasArtifact } from "./artifacts/CanvasArtifact";
 import { CustomBlockArtifact } from "./artifacts/CustomBlockArtifact";
+import {
+	artifactTypeForKind,
+	kindLabel,
+	useArtifactParams,
+	useDependencyChain,
+} from "./artifacts/useArtifact";
+
+/**
+ * What this output is waiting on, oldest ancestor first.
+ *
+ * A run's outputs are not a flat list — a route can invoke a custom block built
+ * beside it, and applying them out of order produces something that cannot run.
+ * Showing the chain turns "this is blocked" into "apply these, in this order".
+ */
+function DependencyChain({ subArtifactId }: { subArtifactId: string }) {
+	const { projectId, conversationId } = useArtifactParams();
+	const setSelectedArtifact = useAiHarnessStore((s) => s.setSelectedArtifact);
+	const { data: detail } = harnessConversationsQuery.subArtifacts.useDetailQuery(
+		projectId,
+		conversationId,
+		subArtifactId,
+	);
+	const chain = useDependencyChain(detail);
+	if (chain.length === 0) return null;
+
+	return (
+		<nav className="flex items-center gap-1 flex-wrap mb-4 text-xs">
+			{chain.map((parent) => (
+				<span key={parent.id} className="flex items-center gap-1">
+					<button
+						type="button"
+						onClick={() =>
+							setSelectedArtifact({
+								id: parent.id,
+								type: artifactTypeForKind(parent.kind),
+								props: {},
+							})
+						}
+						className="flex items-center gap-1 px-2 py-1 rounded-md border border-border bg-surface-secondary text-muted hover:text-foreground cursor-pointer"
+					>
+						{parent.appliedAt && <TbCheck size={12} className="text-success" />}
+						{kindLabel(parent.kind)}
+					</button>
+					<TbChevronRight size={12} className="text-muted" />
+				</span>
+			))}
+			<span className="px-2 py-1 text-foreground">this output</span>
+		</nav>
+	);
+}
 
 export function ArtifactsSidebar() {
 	const selectedArtifact = useAiHarnessStore((s) => s.selectedArtifact);
@@ -29,6 +80,7 @@ export function ArtifactsSidebar() {
 				</div>
 				
 				<div className="flex-1 overflow-y-auto p-4 custom-scrollbar">
+					{selectedArtifact && <DependencyChain subArtifactId={selectedArtifact.id} />}
 					{selectedArtifact?.type.startsWith("Route ") ? (
 						<RouteArtifact
 							key={selectedArtifact.id}

--- a/apps/portal/src/components/ai/artifacts/ApplyBar.tsx
+++ b/apps/portal/src/components/ai/artifacts/ApplyBar.tsx
@@ -4,7 +4,8 @@ import { Link } from "@tanstack/react-router";
 import { TbCheck, TbChevronDown, TbExternalLink } from "react-icons/tb";
 import { harnessConversationsQuery } from "@/query/harnessConversationsQuery";
 import { showErrorNotification } from "@/lib/errorNotifier";
-import { useArtifactParams } from "./useArtifact";
+import { useAiHarnessStore } from "@/store/aiHarness";
+import { artifactTypeForKind, kindLabel, useArtifactParams } from "./useArtifact";
 
 /** Once an output has landed there is nothing left to apply, so the control
  *  becomes a way into the thing that changed. */
@@ -50,6 +51,42 @@ function Applied({
 	);
 }
 
+/** What this output is waiting on. Enough to name it and to open it. */
+export type BlockingParent = { id: string; kind: string };
+
+/**
+ * An output whose parent is still a proposal. The server refuses this apply, so
+ * offering the button would just produce a 409 — say what has to happen first
+ * and give the user one click to get there.
+ *
+ * Deliberately not an "apply both" shortcut: creating a resource the user never
+ * asked for, because they clicked a different one, is not theirs to undo.
+ */
+function Blocked({ parent }: { parent: BlockingParent }) {
+	const setSelectedArtifact = useAiHarnessStore((s) => s.setSelectedArtifact);
+	const what = kindLabel(parent.kind);
+	return (
+		<div className="flex items-center gap-3 self-start">
+			<Button size="sm" variant="primary" isDisabled className="self-start">
+				Needs the {what} applied first
+			</Button>
+			<button
+				type="button"
+				className="text-xs text-muted hover:text-foreground underline cursor-pointer"
+				onClick={() =>
+					setSelectedArtifact({
+						id: parent.id,
+						type: artifactTypeForKind(parent.kind),
+						props: {},
+					})
+				}
+			>
+				Open the {what}
+			</button>
+		</div>
+	);
+}
+
 /** Applies sub-artifacts in the order given — a canvas is only valid once the
  *  route it hangs off exists, so order is the caller's contract. */
 function useApply() {
@@ -73,6 +110,7 @@ export function ApplyBar({
 	appliedAt,
 	routeId,
 	customBlockId,
+	blockedBy,
 	label = "Apply",
 }: {
 	subArtifactId: string;
@@ -81,11 +119,14 @@ export function ApplyBar({
 	routeId?: string;
 	/** live custom block to link to once applied */
 	customBlockId?: string;
+	/** sibling output that has to land first, if one has not yet */
+	blockedBy?: BlockingParent;
 	label?: string;
 }) {
 	const { run, isPending } = useApply();
 
 	if (appliedAt) return <Applied appliedAt={appliedAt} routeId={routeId} customBlockId={customBlockId} />;
+	if (blockedBy) return <Blocked parent={blockedBy} />;
 
 	return (
 		<Button
@@ -118,6 +159,7 @@ export function RouteApplyBar({
 	appliedAt,
 	routeId,
 	action,
+	blockedBy,
 }: {
 	subArtifactId: string;
 	/** the same run's canvas output for this route, if it produced one */
@@ -125,12 +167,16 @@ export function RouteApplyBar({
 	appliedAt: string | Date | null;
 	routeId?: string;
 	action: string;
+	/** sibling output that has to land first — a route invoking a custom block
+	 *  this run created cannot execute until that block exists */
+	blockedBy?: BlockingParent;
 }) {
 	const { run, isPending } = useApply();
 	const [open, setOpen] = useState(false);
 	const verb = VERB[action] ?? "Apply";
 
 	if (appliedAt) return <Applied appliedAt={appliedAt} routeId={routeId} />;
+	if (blockedBy) return <Blocked parent={blockedBy} />;
 
 	if (!canvasSubArtifactId)
 		return (

--- a/apps/portal/src/components/ai/artifacts/CanvasArtifact.tsx
+++ b/apps/portal/src/components/ai/artifacts/CanvasArtifact.tsx
@@ -1,14 +1,14 @@
-import { Button } from "@fluxify/components";
-import { TbArrowRight } from "react-icons/tb";
 import { harnessConversationsQuery } from "@/query/harnessConversationsQuery";
-import { useAiHarnessStore } from "@/store/aiHarness";
 import { ApplyBar } from "./ApplyBar";
 import { CanvasPreview } from "./CanvasPreview";
-import { useArtifactParams, useCanvasArtifact } from "./useArtifact";
+import {
+	useArtifactParams,
+	useBlockingParent,
+	useCanvasArtifact,
+} from "./useArtifact";
 
 export function CanvasArtifact({ subArtifactId }: { subArtifactId: string }) {
 	const { projectId, conversationId } = useArtifactParams();
-	const setSelectedArtifact = useAiHarnessStore((s) => s.setSelectedArtifact);
 
 	const { data: detail, isLoading } =
 		harnessConversationsQuery.subArtifacts.useDetailQuery(
@@ -16,8 +16,9 @@ export function CanvasArtifact({ subArtifactId }: { subArtifactId: string }) {
 			conversationId,
 			subArtifactId,
 		);
-	const { graph, route, routeId, routeExists, blockingRoute } =
+	const { graph, route, routeId, routeExists, targetsRoute } =
 		useCanvasArtifact(detail);
+	const blockingParent = useBlockingParent(detail);
 
 	if (isLoading) return <p className="text-sm text-muted">Loading…</p>;
 	if (!detail) return <p className="text-sm text-muted">Not found.</p>;
@@ -38,33 +39,22 @@ export function CanvasArtifact({ subArtifactId }: { subArtifactId: string }) {
 				{graph.blocks.length} blocks · {graph.edges.length} connections
 			</p>
 
-			{routeExists ? (
+			{/* A sibling that has not been applied yet is the ApplyBar's business —
+			    it names the output and offers a way in. This warning is for the
+			    other case: a route from an earlier run that is simply gone. */}
+			{routeExists || blockingParent || !targetsRoute ? (
 				<ApplyBar
 					subArtifactId={detail.id}
 					appliedAt={detail.appliedAt}
 					routeId={routeId || undefined}
+					blockedBy={blockingParent}
 				/>
 			) : (
-				<div className="rounded-lg border border-warning/30 bg-warning/10 p-3 flex flex-col gap-2">
+				<div className="rounded-lg border border-warning/30 bg-warning/10 p-3">
 					<p className="text-xs text-foreground">
 						These changes hang off a route that doesn't exist yet. Create the route
 						first, then come back and apply them.
 					</p>
-					{blockingRoute && (
-						<Button
-							size="sm"
-							className="self-start flex items-center gap-2 cursor-pointer"
-							onPress={() =>
-								setSelectedArtifact({
-									id: blockingRoute.id,
-									type: "Route changes",
-									props: {},
-								})
-							}
-						>
-							Open route settings <TbArrowRight size={14} />
-						</Button>
-					)}
 				</div>
 			)}
 		</div>

--- a/apps/portal/src/components/ai/artifacts/CustomBlockArtifact.tsx
+++ b/apps/portal/src/components/ai/artifacts/CustomBlockArtifact.tsx
@@ -13,6 +13,7 @@ import { CanvasPreview } from "./CanvasPreview";
 import { Field } from "./Field";
 import {
 	useArtifactParams,
+	useBlockingParent,
 	useCustomBlockCanvasArtifact,
 	useRunSiblings,
 } from "./useArtifact";
@@ -233,6 +234,7 @@ export function CustomBlockArtifact({ subArtifactId }: { subArtifactId: string }
 			s.payload?.targetId === customBlockId,
 	);
 	const { graph: canvasGraph } = useCustomBlockCanvasArtifact(canvasSibling);
+	const blockingParent = useBlockingParent(detail);
 
 	if (isLoading) return <p className="text-sm text-muted">Loading…</p>;
 	if (!detail) return <p className="text-sm text-muted">Not found.</p>;
@@ -345,6 +347,7 @@ export function CustomBlockArtifact({ subArtifactId }: { subArtifactId: string }
 				appliedAt={detail.appliedAt}
 				// a deleted block has nothing left to open
 				customBlockId={isDelete ? undefined : (payload.customBlockId ?? undefined)}
+				blockedBy={blockingParent}
 				label={`${
 					isDelete ? "Delete" : action === "update-partial" ? "Update" : "Create"
 				} custom block${canvasSibling ? " with canvas" : ""}`}

--- a/apps/portal/src/components/ai/artifacts/RouteArtifact.tsx
+++ b/apps/portal/src/components/ai/artifacts/RouteArtifact.tsx
@@ -4,7 +4,12 @@ import { routesQuery } from "@/query/routesQuery";
 import { RouteApplyBar } from "./ApplyBar";
 import { CanvasPreview } from "./CanvasPreview";
 import { Field } from "./Field";
-import { useArtifactParams, useCanvasArtifact, useRunSiblings } from "./useArtifact";
+import {
+	useArtifactParams,
+	useBlockingParent,
+	useCanvasArtifact,
+	useRunSiblings,
+} from "./useArtifact";
 
 /** What the route sub-agent writes (see ai-gateway `RouteConfigPayload`). */
 type RouteConfigPayload = {
@@ -40,6 +45,9 @@ export function RouteArtifact({ subArtifactId }: { subArtifactId: string }) {
 	const canvasSiblings = useRunSiblings(subArtifact?.runId, "canvas");
 	const canvasSibling = canvasSiblings.find((s) => s.payload?.targetId === routeId);
 	const { graph: canvasGraph } = useCanvasArtifact(canvasSibling);
+	// A route that invokes a custom block this run created cannot execute until
+	// that block exists, so the server refuses the apply — say so up front.
+	const blockingParent = useBlockingParent(subArtifact);
 
 	if (isLoading) return <p className="text-sm text-muted">Loading…</p>;
 	if (!subArtifact) return <p className="text-sm text-muted">Not found.</p>;
@@ -120,6 +128,7 @@ export function RouteArtifact({ subArtifactId }: { subArtifactId: string }) {
 				// a deleted route has nothing left to open
 				routeId={isDelete ? undefined : (payload.routeId ?? undefined)}
 				action={action}
+				blockedBy={blockingParent}
 			/>
 		</div>
 	);

--- a/apps/portal/src/components/ai/artifacts/useArtifact.ts
+++ b/apps/portal/src/components/ai/artifacts/useArtifact.ts
@@ -1,10 +1,16 @@
 import { useMemo } from "react";
 import { useParams } from "@tanstack/react-router";
+import {
+	kindLabel,
+	parentsOf,
+} from "@fluxify/ai-gateway/src/api/v1/harness-conversations/artifacts/dependencies";
 import { harnessConversationsQuery } from "@/query/harnessConversationsQuery";
 import { routesQuery } from "@/query/routesQuery";
 import { customBlocksQuery } from "@/query/customBlocksQuery";
 import type { SubArtifactDetail } from "@/services/harnessConversations";
 import { previewGraph, type BlockBuilderPayload } from "./previewGraph";
+
+export { kindLabel };
 
 export function useArtifactParams() {
 	return useParams({ from: "/_authed/$projectId/ai/$conversationId" });
@@ -36,17 +42,70 @@ export function useRunSiblings(runId: string | undefined, kind?: string) {
 		.filter((d): d is SubArtifactDetail => Boolean(d));
 }
 
+/** What the sidebar switches on. One map, so opening an output from a
+ *  dependency chain lands on the same panel the chat chip would. */
+const SIDEBAR_TYPE: Record<string, string> = {
+	route: "Route changes",
+	canvas: "Canvas Changes",
+	custom_block: "Custom Block changes",
+};
+
+export const artifactTypeForKind = (kind: string) => SIDEBAR_TYPE[kind] ?? kind;
+
+/**
+ * The output that has to be applied before this one can be, if there is one.
+ *
+ * The server refuses a child whose parent is still a proposal, so the UI asks
+ * the same question rather than offering a button that 409s. Both use the same
+ * `parentsOf`, so they cannot drift.
+ */
+export function useBlockingParent(detail: SubArtifactDetail | undefined) {
+	const siblings = useRunSiblings(detail?.runId);
+	return useMemo(
+		() =>
+			detail
+				? parentsOf(detail, siblings).find((parent) => !parent.appliedAt)
+				: undefined,
+		[detail, siblings],
+	);
+}
+
+/**
+ * Everything this output hangs off, furthest ancestor first — the order the
+ * user has to apply them in. Rendered as a trail so a blocked output shows what
+ * it is waiting on rather than just refusing.
+ */
+export function useDependencyChain(detail: SubArtifactDetail | undefined) {
+	const siblings = useRunSiblings(detail?.runId);
+	return useMemo(() => {
+		const chain: SubArtifactDetail[] = [];
+		const seen = new Set<string>();
+		let current = detail;
+		while (current && !seen.has(current.id)) {
+			seen.add(current.id);
+			// One parent is enough for a trail; a genuine fan-in is not something a
+			// run produces, and a list of them reads worse than the nearest one.
+			current = parentsOf(current, siblings).find((p) => !seen.has(p.id));
+			if (current) chain.unshift(current);
+		}
+		return chain;
+	}, [detail, siblings]);
+}
+
 const EMPTY_CANVAS = { blocks: [], edges: [] };
 
 /**
  * A canvas output resolved against the workspace: the graph it would produce,
- * and whether its route is live yet. A canvas whose route this run created can
- * only be applied after that route output is — the server rejects it otherwise,
- * so the UI points at the route instead of offering a button that 409s.
+ * and whether its route is live yet.
+ *
+ * `routeExists` answers only "is there a route to hang this off" — a route from
+ * an earlier run that has since been deleted. Whether a *sibling* output has to
+ * be applied first is {@link useBlockingParent}'s job, for every kind at once.
  */
 export function useCanvasArtifact(detail: SubArtifactDetail | undefined) {
 	const payload = (detail?.payload ?? {}) as BlockBuilderPayload;
-	const targetId = payload.targetType === "custom_block" ? "" : (payload.targetId ?? "");
+	const targetsRoute = payload.targetType !== "custom_block";
+	const targetId = targetsRoute ? (payload.targetId ?? "") : "";
 
 	// The route output of this same run, if the run created the route.
 	const routeSiblings = useRunSiblings(detail?.runId, "route");
@@ -64,7 +123,6 @@ export function useCanvasArtifact(detail: SubArtifactDetail | undefined) {
 	// A just-applied sibling counts even before its route resolves here — the
 	// apply already happened, so gating on the fetch would flap.
 	const routeExists = Boolean(route.data) || Boolean(sibling?.appliedAt);
-	const blockingRoute = sibling && !sibling.appliedAt ? sibling : undefined;
 
 	// merging against the live graph is only meaningful once the route is there
 	const canvasItems = routesQuery.canvasItems.useQuery(route.data ? routeId : "");
@@ -81,7 +139,7 @@ export function useCanvasArtifact(detail: SubArtifactDetail | undefined) {
 		route: route.data,
 		routeId,
 		routeExists,
-		blockingRoute,
+		targetsRoute,
 		isLoading: route.isLoading || canvasItems.isLoading,
 	};
 }

--- a/apps/server/src/db/agent-harness-schema.ts
+++ b/apps/server/src/db/agent-harness-schema.ts
@@ -276,6 +276,12 @@ export const agentHarnessSubArtifactsEntity = pgTable(
 			.references(() => agentHarnessRunsEntity.id, { onDelete: "cascade" })
 			.notNull(),
 		subAgentId: varchar("sub_agent_id", { length: 100 }),
+		/** Task ids this output's task declared a dependency on, copied from
+		 *  `Task.dependsOnAgentId`. Resolved back to sibling rows through
+		 *  `subAgentId`, which is the same task id — so the apply path gets the
+		 *  run's DAG without inventing a second link. Null on rows written before
+		 *  this column existed; those simply have no edges. */
+		dependsOn: jsonb("depends_on").$type<string[]>(),
 		// "route" | "canvas"
 		kind: varchar("kind", { length: 50 }).notNull(),
 		// "add" | "delete" | "changes"

--- a/apps/server/src/db/migrations/0054_sour_husk.sql
+++ b/apps/server/src/db/migrations/0054_sour_husk.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "agent_harness_sub_artifacts" ADD COLUMN "depends_on" jsonb;

--- a/apps/server/src/db/migrations/meta/0054_snapshot.json
+++ b/apps/server/src/db/migrations/meta/0054_snapshot.json
@@ -1,0 +1,3384 @@
+{
+  "id": "fb210295-9c9b-4a6c-a941-6a66d3fc8056",
+  "prevId": "e3c4aa16-b3aa-498f-ae6b-95a016dcdc10",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.access_control": {
+      "name": "access_control",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "access_control_roles",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_access_control_user_id": {
+          "name": "idx_access_control_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_access_control_project_id": {
+          "name": "idx_access_control_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "access_control_user_id_system_users_id_fk": {
+          "name": "access_control_user_id_system_users_id_fk",
+          "tableFrom": "access_control",
+          "tableTo": "system_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "access_control_project_id_projects_id_fk": {
+          "name": "access_control_project_id_projects_id_fk",
+          "tableFrom": "access_control",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_config": {
+      "name": "app_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key_name": {
+          "name": "key_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_encrypted": {
+          "name": "is_encrypted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "encoding_type": {
+          "name": "encoding_type",
+          "type": "encoding_types",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "app_config_data_types",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'string'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_app_config_key_name": {
+          "name": "idx_app_config_key_name",
+          "columns": [
+            {
+              "expression": "key_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_app_config_project_id": {
+          "name": "idx_app_config_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_app_config_is_encrypted": {
+          "name": "idx_app_config_is_encrypted",
+          "columns": [
+            {
+              "expression": "is_encrypted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_app_config_encoding_type": {
+          "name": "idx_app_config_encoding_type",
+          "columns": [
+            {
+              "expression": "encoding_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_app_config_key_name_fts": {
+          "name": "idx_app_config_key_name_fts",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', \"key_name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_app_config_desc_fts": {
+          "name": "idx_app_config_desc_fts",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', coalesce(\"description\", ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_config_project_id_projects_id_fk": {
+          "name": "app_config_project_id_projects_id_fk",
+          "tableFrom": "app_config",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocks": {
+      "name": "blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_id": {
+          "name": "route_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_block_id": {
+          "name": "custom_block_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_type": {
+          "name": "parent_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "CASE WHEN custom_block_id IS NOT NULL THEN 'custom_block' ELSE 'route' END",
+            "type": "stored"
+          }
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "COALESCE(route_id, custom_block_id)",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "idx_blocks_route_id": {
+          "name": "idx_blocks_route_id",
+          "columns": [
+            {
+              "expression": "route_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_blocks_custom_block_id": {
+          "name": "idx_blocks_custom_block_id",
+          "columns": [
+            {
+              "expression": "custom_block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_blocks_parent": {
+          "name": "idx_blocks_parent",
+          "columns": [
+            {
+              "expression": "parent_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blocks_route_id_routes_id_fk": {
+          "name": "blocks_route_id_routes_id_fk",
+          "tableFrom": "blocks",
+          "tableTo": "routes",
+          "columnsFrom": [
+            "route_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "blocks_custom_block_id_custom_blocks_list_id_fk": {
+          "name": "blocks_custom_block_id_custom_blocks_list_id_fk",
+          "tableFrom": "blocks",
+          "tableTo": "custom_blocks_list",
+          "columnsFrom": [
+            "custom_block_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_blocks_list": {
+      "name": "custom_blocks_list",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "custom_block_icon_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_params": {
+          "name": "input_params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "custom_block_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user-defined'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_custom_blocks_list_project_id": {
+          "name": "idx_custom_blocks_list_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_custom_blocks_list_name": {
+          "name": "idx_custom_blocks_list_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "custom_blocks_list_project_id_projects_id_fk": {
+          "name": "custom_blocks_list_project_id_projects_id_fk",
+          "tableFrom": "custom_blocks_list",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.edges": {
+      "name": "edges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "from": {
+          "name": "from",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to": {
+          "name": "to",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_handle": {
+          "name": "from_handle",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_handle": {
+          "name": "to_handle",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_id": {
+          "name": "route_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_block_id": {
+          "name": "custom_block_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_type": {
+          "name": "parent_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "CASE WHEN custom_block_id IS NOT NULL THEN 'custom_block' ELSE 'route' END",
+            "type": "stored"
+          }
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "COALESCE(route_id, custom_block_id)",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "idx_edges_from": {
+          "name": "idx_edges_from",
+          "columns": [
+            {
+              "expression": "from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_edges_to": {
+          "name": "idx_edges_to",
+          "columns": [
+            {
+              "expression": "to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_edges_route_id": {
+          "name": "idx_edges_route_id",
+          "columns": [
+            {
+              "expression": "route_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_edges_custom_block_id": {
+          "name": "idx_edges_custom_block_id",
+          "columns": [
+            {
+              "expression": "custom_block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_edges_parent": {
+          "name": "idx_edges_parent",
+          "columns": [
+            {
+              "expression": "parent_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "edges_from_blocks_id_fk": {
+          "name": "edges_from_blocks_id_fk",
+          "tableFrom": "edges",
+          "tableTo": "blocks",
+          "columnsFrom": [
+            "from"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edges_to_blocks_id_fk": {
+          "name": "edges_to_blocks_id_fk",
+          "tableFrom": "edges",
+          "tableTo": "blocks",
+          "columnsFrom": [
+            "to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edges_route_id_routes_id_fk": {
+          "name": "edges_route_id_routes_id_fk",
+          "tableFrom": "edges",
+          "tableTo": "routes",
+          "columnsFrom": [
+            "route_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edges_custom_block_id_custom_blocks_list_id_fk": {
+          "name": "edges_custom_block_id_custom_blocks_list_id_fk",
+          "tableFrom": "edges",
+          "tableTo": "custom_blocks_list",
+          "columnsFrom": [
+            "custom_block_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.http_route_config": {
+      "name": "http_route_config",
+      "schema": "",
+      "columns": {
+        "route_id": {
+          "name": "route_id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_config": {
+          "name": "route_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_http_route_config_project_id": {
+          "name": "idx_http_route_config_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "http_route_config_route_id_routes_id_fk": {
+          "name": "http_route_config_route_id_routes_id_fk",
+          "tableFrom": "http_route_config",
+          "tableTo": "routes",
+          "columnsFrom": [
+            "route_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "http_route_config_project_id_projects_id_fk": {
+          "name": "http_route_config_project_id_projects_id_fk",
+          "tableFrom": "http_route_config",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instance_settings": {
+      "name": "instance_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "instance_setting_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "instance_settings_key_unique": {
+          "name": "instance_settings_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integrations": {
+      "name": "integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group": {
+          "name": "group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_integrations_name": {
+          "name": "idx_integrations_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integrations_group": {
+          "name": "idx_integrations_group",
+          "columns": [
+            {
+              "expression": "group",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integrations_variant": {
+          "name": "idx_integrations_variant",
+          "columns": [
+            {
+              "expression": "variant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integrations_tags": {
+          "name": "idx_integrations_tags",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integrations_project_id": {
+          "name": "idx_integrations_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integrations_name_fts": {
+          "name": "idx_integrations_name_fts",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', \"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_integrations_meta_fts": {
+          "name": "idx_integrations_meta_fts",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', coalesce(\"group\", '') || ' ' || coalesce(\"variant\", '') || ' ' || coalesce(\"tags\", ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integrations_project_id_projects_id_fk": {
+          "name": "integrations_project_id_projects_id_fk",
+          "tableFrom": "integrations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_settings": {
+      "name": "project_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_project_settings_project_id": {
+          "name": "idx_project_settings_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_settings_key": {
+          "name": "idx_project_settings_key",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_settings_project_id_projects_id_fk": {
+          "name": "project_settings_project_id_projects_id_fk",
+          "tableFrom": "project_settings",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_projects_id": {
+          "name": "idx_projects_id",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_projects_name": {
+          "name": "idx_projects_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_projects_updated_at": {
+          "name": "idx_projects_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.routes": {
+      "name": "routes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "NULL"
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_schema": {
+          "name": "body_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query_schema": {
+          "name": "query_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "params_schema": {
+          "name": "params_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeout_seconds": {
+          "name": "timeout_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "tracing_enabled": {
+          "name": "tracing_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "record_execution": {
+          "name": "record_execution",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_routes_project_id": {
+          "name": "idx_routes_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_routes_path": {
+          "name": "idx_routes_path",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_routes_name_fts": {
+          "name": "idx_routes_name_fts",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', \"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_routes_path_fts": {
+          "name": "idx_routes_path_fts",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', translate(coalesce(\"path\", ''), '/:-_', '    '))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "routes_project_id_projects_id_fk": {
+          "name": "routes_project_id_projects_id_fk",
+          "tableFrom": "routes",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_runs": {
+      "name": "test_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "route_id": {
+          "name": "route_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "test_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "total_suites": {
+          "name": "total_suites",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "passed_count": {
+          "name": "passed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_test_runs_project_route": {
+          "name": "idx_test_runs_project_route",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "route_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_runs_project_id_projects_id_fk": {
+          "name": "test_runs_project_id_projects_id_fk",
+          "tableFrom": "test_runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_runs_route_id_routes_id_fk": {
+          "name": "test_runs_route_id_routes_id_fk",
+          "tableFrom": "test_runs",
+          "tableTo": "routes",
+          "columnsFrom": [
+            "route_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_suite_runs": {
+      "name": "test_suite_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "test_run_id": {
+          "name": "test_run_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "route_id": {
+          "name": "route_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_suite_id": {
+          "name": "test_suite_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "test_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_test_suite_runs_run": {
+          "name": "idx_test_suite_runs_run",
+          "columns": [
+            {
+              "expression": "test_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_test_suite_runs_project": {
+          "name": "idx_test_suite_runs_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_suite_runs_test_run_id_test_runs_id_fk": {
+          "name": "test_suite_runs_test_run_id_test_runs_id_fk",
+          "tableFrom": "test_suite_runs",
+          "tableTo": "test_runs",
+          "columnsFrom": [
+            "test_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_suite_runs_project_id_projects_id_fk": {
+          "name": "test_suite_runs_project_id_projects_id_fk",
+          "tableFrom": "test_suite_runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_suite_runs_route_id_routes_id_fk": {
+          "name": "test_suite_runs_route_id_routes_id_fk",
+          "tableFrom": "test_suite_runs",
+          "tableTo": "routes",
+          "columnsFrom": [
+            "route_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_suites": {
+      "name": "test_suites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_id": {
+          "name": "route_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "query_params": {
+          "name": "query_params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "route_params": {
+          "name": "route_params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "body": {
+          "name": "body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assertions": {
+          "name": "assertions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "integration_overrides": {
+          "name": "integration_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "app_config_overrides": {
+          "name": "app_config_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_suites_route_id_routes_id_fk": {
+          "name": "test_suites_route_id_routes_id_fk",
+          "tableFrom": "test_suites",
+          "tableTo": "routes",
+          "columnsFrom": [
+            "route_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_harness_artifacts": {
+      "name": "agent_harness_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_harness_artifacts_conv_id": {
+          "name": "idx_harness_artifacts_conv_id",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_harness_artifacts_run_id": {
+          "name": "idx_harness_artifacts_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_harness_artifacts_conversation_id_agent_harness_conversations_id_fk": {
+          "name": "agent_harness_artifacts_conversation_id_agent_harness_conversations_id_fk",
+          "tableFrom": "agent_harness_artifacts",
+          "tableTo": "agent_harness_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_harness_artifacts_run_id_agent_harness_runs_id_fk": {
+          "name": "agent_harness_artifacts_run_id_agent_harness_runs_id_fk",
+          "tableFrom": "agent_harness_artifacts",
+          "tableTo": "agent_harness_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_harness_conversations": {
+      "name": "agent_harness_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'New Chat'"
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_harness_conversation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "active_run_id": {
+          "name": "active_run_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_harness_conv_user_id": {
+          "name": "idx_harness_conv_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_harness_conv_project_id": {
+          "name": "idx_harness_conv_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_harness_conv_user_archived_pinned": {
+          "name": "idx_harness_conv_user_archived_pinned",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_harness_conversations_user_id_system_users_id_fk": {
+          "name": "agent_harness_conversations_user_id_system_users_id_fk",
+          "tableFrom": "agent_harness_conversations",
+          "tableTo": "system_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_harness_conversations_project_id_projects_id_fk": {
+          "name": "agent_harness_conversations_project_id_projects_id_fk",
+          "tableFrom": "agent_harness_conversations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_harness_hitl_actions": {
+      "name": "agent_harness_hitl_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_id": {
+          "name": "step_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "agent_harness_hitl_action_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_response": {
+          "name": "user_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_harness_hitl_run_id": {
+          "name": "idx_harness_hitl_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_harness_hitl_step_id": {
+          "name": "idx_harness_hitl_step_id",
+          "columns": [
+            {
+              "expression": "step_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_harness_hitl_actions_run_id_agent_harness_runs_id_fk": {
+          "name": "agent_harness_hitl_actions_run_id_agent_harness_runs_id_fk",
+          "tableFrom": "agent_harness_hitl_actions",
+          "tableTo": "agent_harness_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_harness_hitl_actions_step_id_agent_harness_steps_id_fk": {
+          "name": "agent_harness_hitl_actions_step_id_agent_harness_steps_id_fk",
+          "tableFrom": "agent_harness_hitl_actions",
+          "tableTo": "agent_harness_steps",
+          "columnsFrom": [
+            "step_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_harness_live_states": {
+      "name": "agent_harness_live_states",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_state": {
+          "name": "current_state",
+          "type": "agent_harness_live_state_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "active_step_id": {
+          "name": "active_step_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "working_memory": {
+          "name": "working_memory",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_harness_live_conv_id": {
+          "name": "idx_harness_live_conv_id",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_harness_live_states_run_id_agent_harness_runs_id_fk": {
+          "name": "agent_harness_live_states_run_id_agent_harness_runs_id_fk",
+          "tableFrom": "agent_harness_live_states",
+          "tableTo": "agent_harness_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_harness_live_states_conversation_id_agent_harness_conversations_id_fk": {
+          "name": "agent_harness_live_states_conversation_id_agent_harness_conversations_id_fk",
+          "tableFrom": "agent_harness_live_states",
+          "tableTo": "agent_harness_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_harness_runs": {
+      "name": "agent_harness_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_query": {
+          "name": "user_query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_response": {
+          "name": "ai_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_harness_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "usage": {
+          "name": "usage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interrupted_at": {
+          "name": "interrupted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_harness_runs_conv_id": {
+          "name": "idx_harness_runs_conv_id",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_harness_runs_status": {
+          "name": "idx_harness_runs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_harness_runs_integration_id": {
+          "name": "idx_harness_runs_integration_id",
+          "columns": [
+            {
+              "expression": "integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_harness_runs_conversation_id_agent_harness_conversations_id_fk": {
+          "name": "agent_harness_runs_conversation_id_agent_harness_conversations_id_fk",
+          "tableFrom": "agent_harness_runs",
+          "tableTo": "agent_harness_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_harness_runs_integration_id_integrations_id_fk": {
+          "name": "agent_harness_runs_integration_id_integrations_id_fk",
+          "tableFrom": "agent_harness_runs",
+          "tableTo": "integrations",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_harness_steps": {
+      "name": "agent_harness_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_type": {
+          "name": "step_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_order": {
+          "name": "step_order",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sub_agent_role": {
+          "name": "sub_agent_role",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sub_agent_id": {
+          "name": "sub_agent_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_harness_step_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_harness_steps_run_id": {
+          "name": "idx_harness_steps_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_harness_steps_sub_agent_id": {
+          "name": "idx_harness_steps_sub_agent_id",
+          "columns": [
+            {
+              "expression": "sub_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_harness_steps_run_sub_agent": {
+          "name": "uq_harness_steps_run_sub_agent",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sub_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_harness_steps_run_id_agent_harness_runs_id_fk": {
+          "name": "agent_harness_steps_run_id_agent_harness_runs_id_fk",
+          "tableFrom": "agent_harness_steps",
+          "tableTo": "agent_harness_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_harness_steps_conversation_id_agent_harness_conversations_id_fk": {
+          "name": "agent_harness_steps_conversation_id_agent_harness_conversations_id_fk",
+          "tableFrom": "agent_harness_steps",
+          "tableTo": "agent_harness_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_harness_sub_artifacts": {
+      "name": "agent_harness_sub_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sub_agent_id": {
+          "name": "sub_agent_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "depends_on": {
+          "name": "depends_on",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_harness_sub_artifacts_artifact_id": {
+          "name": "idx_harness_sub_artifacts_artifact_id",
+          "columns": [
+            {
+              "expression": "artifact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_harness_sub_artifacts_run_id": {
+          "name": "idx_harness_sub_artifacts_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_harness_sub_artifacts_artifact_id_agent_harness_artifacts_id_fk": {
+          "name": "agent_harness_sub_artifacts_artifact_id_agent_harness_artifacts_id_fk",
+          "tableFrom": "agent_harness_sub_artifacts",
+          "tableTo": "agent_harness_artifacts",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_harness_sub_artifacts_conversation_id_agent_harness_conversations_id_fk": {
+          "name": "agent_harness_sub_artifacts_conversation_id_agent_harness_conversations_id_fk",
+          "tableFrom": "agent_harness_sub_artifacts",
+          "tableTo": "agent_harness_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_harness_sub_artifacts_run_id_agent_harness_runs_id_fk": {
+          "name": "agent_harness_sub_artifacts_run_id_agent_harness_runs_id_fk",
+          "tableFrom": "agent_harness_sub_artifacts",
+          "tableTo": "agent_harness_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_users": {
+      "name": "system_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system_admin": {
+          "name": "is_system_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "system_users_email_unique": {
+          "name": "system_users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_id_system_users_id_fk": {
+          "name": "user_id_system_users_id_fk",
+          "tableFrom": "user",
+          "tableTo": "system_users",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.access_control_roles": {
+      "name": "access_control_roles",
+      "schema": "public",
+      "values": [
+        "viewer",
+        "creator",
+        "project_admin",
+        "system_admin"
+      ]
+    },
+    "public.app_config_data_types": {
+      "name": "app_config_data_types",
+      "schema": "public",
+      "values": [
+        "string",
+        "number",
+        "boolean"
+      ]
+    },
+    "public.custom_block_icon_type": {
+      "name": "custom_block_icon_type",
+      "schema": "public",
+      "values": [
+        "premade-list",
+        "custom"
+      ]
+    },
+    "public.custom_block_source_type": {
+      "name": "custom_block_source_type",
+      "schema": "public",
+      "values": [
+        "plugin",
+        "inhouse",
+        "user-defined"
+      ]
+    },
+    "public.encoding_types": {
+      "name": "encoding_types",
+      "schema": "public",
+      "values": [
+        "plaintext",
+        "base64",
+        "hex"
+      ]
+    },
+    "public.instance_setting_category": {
+      "name": "instance_setting_category",
+      "schema": "public",
+      "values": [
+        "auth"
+      ]
+    },
+    "public.test_run_status": {
+      "name": "test_run_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "passed",
+        "failed",
+        "timeout",
+        "error"
+      ]
+    },
+    "public.agent_harness_conversation_status": {
+      "name": "agent_harness_conversation_status",
+      "schema": "public",
+      "values": [
+        "idle",
+        "running",
+        "paused_hitl",
+        "interrupted",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.agent_harness_hitl_action_type": {
+      "name": "agent_harness_hitl_action_type",
+      "schema": "public",
+      "values": [
+        "plan_approval",
+        "plan_rejection",
+        "user_input",
+        "confirmation",
+        "cancellation",
+        "custom"
+      ]
+    },
+    "public.agent_harness_live_state_status": {
+      "name": "agent_harness_live_state_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "paused_hitl",
+        "interrupted",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.agent_harness_run_status": {
+      "name": "agent_harness_run_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "routing",
+        "verifying",
+        "planning",
+        "orchestrating",
+        "executing",
+        "awaiting_hitl",
+        "completed",
+        "interrupted",
+        "failed"
+      ]
+    },
+    "public.agent_harness_step_status": {
+      "name": "agent_harness_step_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "interrupted"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/server/src/db/migrations/meta/_journal.json
+++ b/apps/server/src/db/migrations/meta/_journal.json
@@ -379,6 +379,13 @@
       "when": 1786574878049,
       "tag": "0053_known_rick_jones",
       "breakpoints": true
+    },
+    {
+      "idx": 54,
+      "version": "7",
+      "when": 1787248646436,
+      "tag": "0054_sour_husk",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Closes #273. Builds on #276.

## The bug

A run's outputs are a DAG. The apply path treated them as a list, with the order written by hand:

```ts
const ordered = [...routes, ...customBlocks, ...canvases, ...rest];
```

Routes before custom blocks — the opposite of what a route invoking a block created in the same run needs. And a partial apply had no notion of a parent at all, so a user could apply the route while the block it calls was still an unapplied proposal, producing a route that cannot execute.

## The DAG already existed; it just wasn't persisted

Every sub-artifact row is stamped with the task that produced it (`subAgentId`), and the task carries its own edges (`dependsOnAgentId`). The only missing piece was the edges.

Migration `0054` adds `depends_on` to `agent_harness_sub_artifacts`, written by the summarizer. It stores **task ids, not row ids** — the rows are written in one pass and a dependency may not have a row yet, while `subAgentId` resolves the two at read time. No second pass, no extra writes.

## This deletes more than it adds

All four hardcoded mechanisms are gone, replaced by one module:

| Was | Now |
|---|---|
| `ordered = [...routes, ...customBlocks, ...]` | `topoOrder` |
| `assertParentRoutesReady` | `assertParentsApplied` |
| `pairInlineCanvases`, called twice | `inlineCanvasFor`, once |
| `failedRouteIds` | one `failed` map, any kind, any depth |

`applyBatch.ts` goes from **234 lines to 140**. Nothing in `dependencies.ts` branches on `kind`: a new resource kind that stores its planned id in the payload and is referenced by `targetId` gets ordering, pairing, gating and cascade for free.

### Edges come from two sources, unioned

Neither alone is complete:

- **The declared task edge** carries what no payload records — a route invokes a custom block *by name*, deep inside a canvas, not by an id any column holds.
- **The payload link** (`targetId` naming an id another row is creating) is ground truth: it is the same link the apply itself uses. The declared edge is a model's claim and can be missing.

The second source is also why **rows written before this column exists keep working**, and why the existing apply tests pass untouched.

## Gate, not cascade-apply

Applying a parent automatically because the user clicked its child creates a resource in their project that they never asked for and cannot easily undo. The single-artifact apply blocks and names the parent:

> This route output depends on the custom block 'Hash Password' this run created, which has not been applied yet. Apply it (sub-artifact `01a0…`) first.

## Name remap resolver

Storage namespaces a project block, so the name a caller's canvas has to invoke is not the bare one the run asked for. A canvas saved with the stale name looks fine and resolves to nothing. Every path that pushes a graph now goes through one `canvasFor`, so the remap cannot be forgotten on one of them.

## Portal

The apply button becomes **"Needs the custom block applied first"** with one click through to it, and the sidebar renders the dependency chain rather than showing an output with no indication of what it is waiting on. Both call the same `parentsOf` as the server, so the UI and the gate cannot drift.

## What survived, and why

`assertParentRoutesReady` was doing two unrelated jobs. The gating half is gone; proving that an **external** route from an earlier run still exists is a referential check, not a dependency one, and survives as `assertExternalRoutesExist`. It only ever shared the function.

## Verification

Unit: 12 tests on the graph itself (declared edge, payload fallback, self-reference, cycle termination, inline pairing), 7 new integration tests on the apply paths.

End to end against the **live NATS bus and postgres**, with a seeded artifact shaped exactly like the issue's example:

```
PASS  route apply is refused while its custom block is only a proposal
PASS  custom block is applied before the route that invokes it
      order = custom_block → canvas → route → canvas
PASS  nothing failed
PASS  the custom block landed under its namespaced name
PASS  the route's canvas invokes the block by the name storage actually used
      blocks = entrypoint, user_defined.project.vb_…, response, error_handler
PASS  no block is left referencing the pre-storage name
PASS  the route is skipped, naming the kind that could not be created
      "its custom block could not be created"
```

That canvas was seeded with the **bare** `custom:<name>` and came out namespaced — the remap, live. The last check re-applies the same artifact so the block create collides, proving the cascade.

Full monorepo suite green via the pre-commit hook: **819 pass / 0 fail**, lint clean across all 9 packages.

## One thing worth a look

`applyBatch.spec.ts` had cross-test leakage: `spyOn` persists, so a test that stubbed a bus call to throw left that stub in place for every test after it. My first run of the new tests failed because of it, not because of the code. Fixed in `beforeEach` rather than by ordering tests around it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
