### PR TITLE
feat(harness): add project resource inventory

### DIFF
--- a/apps/ai-gateway/src/harness/agents/discussion.ts
+++ b/apps/ai-gateway/src/harness/agents/discussion.ts
@@ -31,6 +31,9 @@ About Fluxify:
 - **Flexible Deployments**: Can be deployed as a Docker container, or in Kubernetes.
 
 Capabilities & Tools:
+When the user asks what resources are available, use \`find_resource\` with
+\`searchQuery: "all"\` and the relevant resource type. It returns 20 records
+plus a \`nextCursor\` when another page exists; copy that cursor into the next call.
 1. "search_docs": Use this tool whenever the user asks about platform features, how a specific block works, or best practices. Pass ALL the topics you need as one array of keyword queries ('searchQueries') in a SINGLE call — do not call it once per topic.
 2. "get_route_details": Use this tool *only when necessary* if the user asks about the current route (the graph in canvas) they are viewing or working on — skip it if the "Current context" block below already gives you the details you need.
 3. "find_resource": Use this tool to find tables, databases, or API blocks within the workspace when the user queries about them. It also returns a route's or custom block's current canvas (its live block graph) when you pass its id. If you already hold a resource's exact id, pass \`searchBy: "id"\` — the default keyword search matches names and descriptions and will never find an id. Skip it for the resource already named in "Current context" below.

--- a/apps/ai-gateway/src/harness/agents/planner.ts
+++ b/apps/ai-gateway/src/harness/agents/planner.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 import { subAgents } from "./sub-agents";
 import { createFindResourceTool } from "../tools/findResource";
 import { createGetArtifactTool } from "../tools/getArtifact";
+import { renderProjectInventory } from "../internal/projectInventory";
 
 function buildSubAgentsTable(): string {
 	if (subAgents.length === 0) {
@@ -96,11 +97,16 @@ export class PlannerAgent extends BaseAgent {
 			: "";
 
 		const contextBlock = this.state.internal?.metadata?.contextBlock;
+		const projectInventory = renderProjectInventory(
+			this.state.internal?.metadata?.projectInventory,
+		);
 
 		// Both change every run, so they travel with the user's turn — see
 		// `AgentInvokeOptions.context`. The system prompt above is now identical
 		// across runs and can be served from the provider's prompt cache.
-		const context = [scratchPadText, contextBlock].filter(Boolean).join("\n\n");
+		const context = [scratchPadText, contextBlock, projectInventory]
+			.filter(Boolean)
+			.join("\n\n");
 
 		const systemPrompt = `You are the Expert Planner Agent for Fluxify — a No/Low-Code Backend Engine.
 Fluxify allows users to build, deploy, and scale APIs visually without writing boilerplate code. It uses a visual graph where "Blocks" (units of logic like DB fetching, AI generation, or JS VM execution) are connected by "Edges" (defining direct flow, decision paths, and error handling paths).
@@ -127,6 +133,11 @@ Other blocks may require secrets from **app configs**.
 - If an integration/config is missing based on context, DO NOT reject the request. Instead, add a prominent warning in your \`markdownPlan\` stating that the user must create it.
 
 ## Available Tools
+If a "Relevant project inventory" block appears below, it is authoritative for
+matching existing resources. Use its exact IDs rather than looking those rows up
+again. If the user asks what is available, call \`find_resource\` with
+\`searchQuery: "all"\` and a resource type; it returns 20 records and a
+\`nextCursor\` for another page.
 **\`find_resource\`** — Search the database for existing resources (e.g., routes, app configs, integrations, custom blocks) relevant to the user's request. If a "Current context" block below already names the target resource, use that id directly and do NOT call this tool to re-find it — only use it for resources the current context doesn't cover.
 - Always search for the exact resource ID if you are modifying, updating, or deleting an existing resource that isn't already given to you.
 - Store the found resource IDs (e.g., \`routeId\`) and relevant details in the \`scratchpadNote\` so downstream agents have the exact IDs needed to perform their tasks. Do NOT guess IDs.

--- a/apps/ai-gateway/src/harness/agents/taskGenerator.ts
+++ b/apps/ai-gateway/src/harness/agents/taskGenerator.ts
@@ -3,6 +3,7 @@ import { BaseAgent } from "./base";
 import { subAgents } from "./sub-agents";
 import { z } from "zod";
 import { dispatchAgentEvent } from "../callbacks";
+import { renderProjectInventory } from "../internal/projectInventory";
 
 function buildSubAgentsTable(): string {
 	if (subAgents.length === 0) {
@@ -261,6 +262,9 @@ export class TaskGeneratorAgent extends BaseAgent {
 		const scratchPadText = this.state.scratchpad?.length
 			? `## Context / Scratch Pad from Previous Agents\nHere is information gathered from previous steps:\n${this.state.scratchpad.map((s) => `- ${s}`).join("\n")}`
 			: "";
+		const projectInventory = renderProjectInventory(
+			this.state.internal?.metadata?.projectInventory,
+		);
 
 		const systemPrompt = `You are the Expert Task Generator Agent for Fluxify — an Agentic Low Code Backend Development Platform.
 Your role is to act as the task planner for the Orchestrator. You receive a verified plan (created by the Planner Agent) and must break it down into a list of tasks. 
@@ -291,7 +295,9 @@ If there are no sub-agents available, output an empty task list.`;
 		const response = (await this.state.agentWrapper.invokeAgent({
 			zodSchema: taskSchema,
 			systemPrompt,
-			context: scratchPadText,
+			context: [scratchPadText, projectInventory]
+				.filter(Boolean)
+				.join("\n\n"),
 			messages: [], // We only pass the plan to keep it strictly focused
 			userQuery: planText,
 			agentNode: AgentNode.TASK_GENERATOR,

--- a/apps/ai-gateway/src/harness/index.ts
+++ b/apps/ai-gateway/src/harness/index.ts
@@ -173,11 +173,16 @@ export class FluxifyHarness {
 		// Resolve the resource the user was viewing (if any) once, here, instead
 		// of letting the planner burn a find_resource tool call rediscovering an
 		// id the request already carried. One cheap DB hit, zero model tokens.
-		const contextBlock = await buildContextBlock(
-			this.dbService,
-			ctx.metadata?.projectId,
-			ctx.metadata?.location,
-		);
+		const [contextBlock, projectInventory] = await Promise.all([
+			buildContextBlock(
+				this.dbService,
+				ctx.metadata?.projectId,
+				ctx.metadata?.location,
+			),
+			// A HITL continuation already has the approved plan. Avoid loading a
+			// generic catalogue unless this pass has a fresh user request to match.
+			this.dbService.getProjectInventory(ctx.metadata?.projectId, query),
+		]);
 
 		return {
 			...workingMemory,
@@ -194,6 +199,7 @@ export class FluxifyHarness {
 					runId: ctx.runId,
 					conversationId: ctx.conversationId,
 					contextBlock,
+					projectInventory,
 				},
 			},
 			agentWrapper: this.agentFactory.createAgent(),

--- a/apps/ai-gateway/src/harness/internal/dbService.ts
+++ b/apps/ai-gateway/src/harness/internal/dbService.ts
@@ -8,10 +8,32 @@ import {
 	edgesEntity,
 	agentHarnessSubArtifactsEntity,
 } from "@fluxify/server";
-import { eq, ilike, or, and, sql, inArray, type SQL } from "drizzle-orm";
+import {
+	eq,
+	ilike,
+	or,
+	and,
+	sql,
+	inArray,
+	type SQL,
+} from "drizzle-orm";
 import type { PgColumn } from "drizzle-orm/pg-core";
 import { logger } from "@fluxify/common";
-import { FindResourceResult } from "../types";
+import type { FindResourceResult } from "../types";
+import {
+	getProjectInventory,
+	listAppConfigs,
+	listCustomBlocks,
+	listIntegrations,
+	listRoutes,
+} from "./resourceInventory";
+
+export {
+	decodeResourceCursor,
+	encodeResourceCursor,
+	RESOURCE_LIST_PAGE_SIZE,
+} from "./resourceInventory";
+export type { ResourceListPage } from "./resourceInventory";
 
 /**
  * Accepts either a single search string or an array of keywords, so the
@@ -331,6 +353,26 @@ export class DbService {
 			logger.error("[DbService] Error searching custom blocks", { error: e });
 			return [];
 		}
+	}
+
+	async getProjectInventory(projectId: string | undefined, query: string | undefined) {
+		return getProjectInventory(projectId, query);
+	}
+
+	async listRoutes(projectId: string, afterId?: string) {
+		return listRoutes(projectId, afterId);
+	}
+
+	async listAppConfigs(projectId: string, afterId?: number) {
+		return listAppConfigs(projectId, afterId);
+	}
+
+	async listIntegrations(projectId: string, afterId?: string) {
+		return listIntegrations(projectId, afterId);
+	}
+
+	async listCustomBlocks(projectId: string, afterId?: string) {
+		return listCustomBlocks(projectId, afterId);
 	}
 
 	async getRouteCanvas(

--- a/apps/ai-gateway/src/harness/internal/projectInventory.spec.ts
+++ b/apps/ai-gateway/src/harness/internal/projectInventory.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "bun:test";
+import { renderProjectInventory } from "./projectInventory";
+
+describe("renderProjectInventory", () => {
+	it("renders a compact, fenced inventory with exact IDs", () => {
+		const out = renderProjectInventory([
+			{
+				type: "route",
+				id: "route-1",
+				identifier: "GET /users",
+				label: "List users",
+			},
+			{
+				type: "app_config",
+				id: "7",
+				identifier: "DATABASE_URL",
+				label: "Database connection",
+			},
+		]);
+
+		expect(out).toContain("Relevant project inventory");
+		expect(out).toContain("<tool_result name=\"project_inventory\" untrusted=\"true\">");
+		expect(out).toContain("GET /users");
+		expect(out).toContain("route-1");
+		expect(out).toContain("Do NOT call find_resource merely to rediscover");
+	});
+
+	it("adds no prompt content when inventory has no relevant entries", () => {
+		expect(renderProjectInventory([])).toBe("");
+		expect(renderProjectInventory(undefined)).toBe("");
+	});
+});

--- a/apps/ai-gateway/src/harness/internal/projectInventory.ts
+++ b/apps/ai-gateway/src/harness/internal/projectInventory.ts
@@ -1,0 +1,20 @@
+import type { ProjectInventoryEntry } from "../types";
+import { fenceUntrusted } from "./untrusted";
+
+/** Renders typed inventory at the two planning boundaries only. Do not append
+ * this to the location context: builders and discussion agents do not need a
+ * whole-project catalogue on every model call. */
+export function renderProjectInventory(
+	entries: ProjectInventoryEntry[] | undefined,
+): string {
+	if (!entries?.length) return "";
+	const rows = entries
+		.map((entry) => `| ${entry.type} | ${entry.identifier} | ${entry.label} | ${entry.id} |`)
+		.join("\n");
+	return `## Relevant project inventory
+${fenceUntrusted(
+	"project_inventory",
+	`| Type | Identifier | Label | ID |\n| --- | --- | --- | --- |\n${rows}`,
+)}
+This is a bounded, relevant inventory. Treat a matching entry as existing; use its exact ID in resource directives and task descriptions. Do NOT call find_resource merely to rediscover one of these entries. Use find_resource for omitted resources, canvases, or further details.`;
+}

--- a/apps/ai-gateway/src/harness/internal/resourceInventory.ts
+++ b/apps/ai-gateway/src/harness/internal/resourceInventory.ts
@@ -1,0 +1,309 @@
+import {
+	appConfigEntity,
+	customBlocksListEntity,
+	db,
+	integrationsEntity,
+	routesEntity,
+} from "@fluxify/server";
+import { logger } from "@fluxify/common";
+import { asc, and, eq, gt, ilike, or, sql, type SQL } from "drizzle-orm";
+import { unionAll, type PgColumn } from "drizzle-orm/pg-core";
+import type { FindResourceResult, ProjectInventoryEntry } from "../types";
+
+export const RESOURCE_LIST_PAGE_SIZE = 20;
+const INVENTORY_LIMIT = 20;
+const INVENTORY_QUERY_TERMS_LIMIT = 8;
+
+type ListableResourceType = ProjectInventoryEntry["type"];
+
+export interface ResourceListPage {
+	items: FindResourceResult[];
+	nextCursor?: string;
+}
+
+export function encodeResourceCursor(
+	type: ListableResourceType,
+	id: string,
+): string {
+	return Buffer.from(JSON.stringify({ type, id })).toString("base64url");
+}
+
+export function decodeResourceCursor(
+	raw: string,
+	expectedType: ListableResourceType,
+): string {
+	try {
+		const value = JSON.parse(Buffer.from(raw, "base64url").toString()) as {
+			type?: string;
+			id?: string;
+		};
+		if (value.type !== expectedType || !value.id) throw new Error("invalid");
+		if (
+			expectedType === "app_config" &&
+			(!/^\d+$/.test(value.id) || !Number.isSafeInteger(Number(value.id)))
+		) {
+			throw new Error("invalid");
+		}
+		return value.id;
+	} catch {
+		throw new Error("Invalid cursor for this resource type.");
+	}
+}
+
+function inventoryTerms(query: string | undefined): string[] {
+	return [
+		...new Set(
+			(query ?? "")
+				.toLowerCase()
+				.match(/[a-z0-9]+/g)
+				?.filter((term) => term.length > 1)
+				.slice(0, INVENTORY_QUERY_TERMS_LIMIT) ?? [],
+		),
+	];
+}
+
+function page<T extends FindResourceResult>(
+	items: T[],
+	type: ListableResourceType,
+): ResourceListPage {
+	const current = items.slice(0, RESOURCE_LIST_PAGE_SIZE);
+	const last = current.at(-1);
+	return {
+		items: current,
+		nextCursor:
+			items.length > RESOURCE_LIST_PAGE_SIZE && last
+				? encodeResourceCursor(type, last.id)
+				: undefined,
+	};
+}
+
+/** Compact, typed startup inventory. The UNION keeps this to one database
+ * round trip; each arm is independently narrowed by user-request terms. */
+export async function getProjectInventory(
+	projectId: string | undefined,
+	query: string | undefined,
+): Promise<ProjectInventoryEntry[]> {
+	if (!projectId) return [];
+	try {
+		const terms = inventoryTerms(query);
+		if (terms.length === 0) return [];
+		const matches = (...columns: PgColumn[]): SQL | undefined => {
+			const predicates = terms.flatMap((term) =>
+				columns.map((column) => ilike(column, `%${term}%`)),
+			);
+			return predicates.length ? or(...predicates) : undefined;
+		};
+		const routes = db
+			.select({
+				type: sql<ProjectInventoryEntry["type"]>`'route'`.as("type"),
+				id: sql<string>`${routesEntity.id}::text`.as("id"),
+				identifier:
+					sql<string>`coalesce(${routesEntity.method}, '') || ' ' || coalesce(${routesEntity.path}, '')`.as(
+						"identifier",
+					),
+				label: sql<string>`coalesce(${routesEntity.name}, ${routesEntity.path}, '')`.as(
+					"label",
+				),
+			})
+			.from(routesEntity)
+			.where(
+				and(
+					eq(routesEntity.projectId, projectId),
+					matches(routesEntity.name, routesEntity.path),
+				),
+			);
+		const configs = db
+			.select({
+				type: sql<ProjectInventoryEntry["type"]>`'app_config'`.as("type"),
+				id: sql<string>`${appConfigEntity.id}::text`.as("id"),
+				identifier: sql<string>`${appConfigEntity.keyName}`.as("identifier"),
+				label: sql<string>`coalesce(${appConfigEntity.description}, ${appConfigEntity.keyName})`.as(
+					"label",
+				),
+			})
+			.from(appConfigEntity)
+			.where(
+				and(
+					eq(appConfigEntity.projectId, projectId),
+					matches(appConfigEntity.keyName, appConfigEntity.description),
+				),
+			);
+		const integrations = db
+			.select({
+				type: sql<ProjectInventoryEntry["type"]>`'integration'`.as("type"),
+				id: sql<string>`${integrationsEntity.id}::text`.as("id"),
+				identifier:
+					sql<string>`coalesce(${integrationsEntity.group}, '') || ':' || coalesce(${integrationsEntity.variant}, '')`.as(
+						"identifier",
+					),
+				label: sql<string>`coalesce(${integrationsEntity.name}, '')`.as("label"),
+			})
+			.from(integrationsEntity)
+			.where(
+				and(
+					eq(integrationsEntity.projectId, projectId),
+					matches(
+						integrationsEntity.name,
+						integrationsEntity.group,
+						integrationsEntity.variant,
+						integrationsEntity.tags,
+					),
+				),
+			);
+		const customBlocks = db
+			.select({
+				type: sql<ProjectInventoryEntry["type"]>`'custom_block'`.as("type"),
+				id: sql<string>`${customBlocksListEntity.id}::text`.as("id"),
+				identifier: sql<string>`${customBlocksListEntity.name}`.as("identifier"),
+				label: sql<string>`coalesce(${customBlocksListEntity.label}, ${customBlocksListEntity.name})`.as(
+					"label",
+				),
+			})
+			.from(customBlocksListEntity)
+			.where(
+				and(
+					eq(customBlocksListEntity.projectId, projectId),
+					matches(
+						customBlocksListEntity.name,
+						customBlocksListEntity.label,
+						customBlocksListEntity.description,
+					),
+				),
+			);
+
+		return await unionAll(routes, configs, integrations, customBlocks)
+			.orderBy(asc(sql`label`), asc(sql`id`))
+			.limit(INVENTORY_LIMIT);
+	} catch (error) {
+		logger.error("[DbService] Error loading project inventory", { error });
+		return [];
+	}
+}
+
+export async function listRoutes(
+	projectId: string,
+	afterId?: string,
+): Promise<ResourceListPage> {
+	const rows = await db
+		.select({
+			id: routesEntity.id,
+			name: routesEntity.name,
+			path: routesEntity.path,
+			method: routesEntity.method,
+		})
+		.from(routesEntity)
+		.where(
+			and(
+				eq(routesEntity.projectId, projectId),
+				afterId ? gt(routesEntity.id, afterId) : undefined,
+			),
+		)
+		.orderBy(asc(routesEntity.id))
+		.limit(RESOURCE_LIST_PAGE_SIZE + 1);
+	return page(
+		rows.map((row) => ({
+			type: "route",
+			id: row.id,
+			name: row.name || "",
+			path: row.path || "",
+			method: row.method || "",
+		})),
+		"route",
+	);
+}
+
+export async function listAppConfigs(
+	projectId: string,
+	afterId?: number,
+): Promise<ResourceListPage> {
+	const rows = await db
+		.select({
+			id: appConfigEntity.id,
+			name: appConfigEntity.keyName,
+			description: appConfigEntity.description,
+		})
+		.from(appConfigEntity)
+		.where(
+			and(
+				eq(appConfigEntity.projectId, projectId),
+				afterId !== undefined ? gt(appConfigEntity.id, afterId) : undefined,
+			),
+		)
+		.orderBy(asc(appConfigEntity.id))
+		.limit(RESOURCE_LIST_PAGE_SIZE + 1);
+	return page(
+		rows.map((row) => ({
+			type: "app_config",
+			id: row.id.toString(),
+			name: row.name || "",
+			description: row.description || "",
+		})),
+		"app_config",
+	);
+}
+
+export async function listIntegrations(
+	projectId: string,
+	afterId?: string,
+): Promise<ResourceListPage> {
+	const rows = await db
+		.select({
+			id: integrationsEntity.id,
+			name: integrationsEntity.name,
+			group: integrationsEntity.group,
+			variant: integrationsEntity.variant,
+		})
+		.from(integrationsEntity)
+		.where(
+			and(
+				eq(integrationsEntity.projectId, projectId),
+				afterId ? gt(integrationsEntity.id, afterId) : undefined,
+			),
+		)
+		.orderBy(asc(integrationsEntity.id))
+		.limit(RESOURCE_LIST_PAGE_SIZE + 1);
+	return page(
+		rows.map((row) => ({
+			type: "integration",
+			id: row.id,
+			name: row.name || "",
+			group: row.group || "",
+			variant: row.variant || "",
+		})),
+		"integration",
+	);
+}
+
+export async function listCustomBlocks(
+	projectId: string,
+	afterId?: string,
+): Promise<ResourceListPage> {
+	const rows = await db
+		.select({
+			id: customBlocksListEntity.id,
+			name: customBlocksListEntity.name,
+			label: customBlocksListEntity.label,
+			description: customBlocksListEntity.description,
+			inputParams: customBlocksListEntity.inputParams,
+		})
+		.from(customBlocksListEntity)
+		.where(
+			and(
+				eq(customBlocksListEntity.projectId, projectId),
+				afterId ? gt(customBlocksListEntity.id, afterId) : undefined,
+			),
+		)
+		.orderBy(asc(customBlocksListEntity.id))
+		.limit(RESOURCE_LIST_PAGE_SIZE + 1);
+	return page(
+		rows.map((row) => ({
+			type: "custom_block",
+			id: row.id,
+			name: row.name,
+			label: row.label || row.name,
+			description: row.description || "",
+			inputParams: Array.isArray(row.inputParams) ? row.inputParams : [],
+		})),
+		"custom_block",
+	);
+}

--- a/apps/ai-gateway/src/harness/tools/findResource.spec.ts
+++ b/apps/ai-gateway/src/harness/tools/findResource.spec.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import { createFindResourceTool } from "./findResource";
-import type { DbService } from "../internal/dbService";
+import {
+	encodeResourceCursor,
+	type DbService,
+} from "../internal/dbService";
 import type { WorkflowMetadata } from "../types";
 
 const metadata = { projectId: "proj-1" } as WorkflowMetadata;
@@ -57,5 +60,58 @@ describe("find_resource", () => {
 		});
 
 		expect(out).toContain("search by keyword");
+	});
+
+	it("lists a resource type for * or all and carries its cursor forward", async () => {
+		const calls: any[][] = [];
+		const tool = createFindResourceTool(
+			{
+				listCustomBlocks: async (...args: any[]) => {
+					calls.push(args);
+					return {
+						items: [
+							{
+								type: "custom_block",
+								id: "block-1",
+								name: "user_defined.project.audit",
+								label: "Audit",
+							},
+						],
+						nextCursor: encodeResourceCursor("custom_block", "block-1"),
+					};
+				},
+			} as unknown as DbService,
+			metadata,
+		);
+
+		const first = await tool.invoke({
+			searchQuery: "*",
+			resourceType: "custom_block",
+		});
+		const cursor = encodeResourceCursor("custom_block", "block-1");
+		const second = await tool.invoke({
+			searchQuery: "ALL",
+			resourceType: "custom_block",
+			cursor,
+		});
+
+		expect(first).toContain("Audit");
+		expect(first).toContain(cursor);
+		expect(second).toContain("More results exist");
+		expect(calls).toEqual([
+			["proj-1", undefined],
+			["proj-1", "block-1"],
+		]);
+	});
+
+	it("rejects a cursor for a different resource type", async () => {
+		const tool = createFindResourceTool({} as DbService, metadata);
+		const out = await tool.invoke({
+			searchQuery: "all",
+			resourceType: "custom_block",
+			cursor: encodeResourceCursor("route", "route-1"),
+		});
+
+		expect(out).toContain("Invalid cursor for this resource type.");
 	});
 });

--- a/apps/ai-gateway/src/harness/tools/findResource.ts
+++ b/apps/ai-gateway/src/harness/tools/findResource.ts
@@ -2,7 +2,11 @@ import { fencedTool } from "./fenced";
 import { z } from "zod";
 import { logger } from "@fluxify/common";
 import type { WorkflowMetadata } from "../types";
-import type { DbService, SearchMode } from "../internal/dbService";
+import {
+	decodeResourceCursor,
+	type DbService,
+	type SearchMode,
+} from "../internal/dbService";
 import { ResourceType } from "../types";
 
 /**
@@ -19,17 +23,48 @@ function renderCanvas(canvas: Array<Record<string, any>>): string {
 	);
 }
 
+function isListRequest(keywords: string[], mode: SearchMode): boolean {
+	return (
+		mode === "keyword" &&
+		keywords.length === 1 &&
+		["*", "all"].includes(keywords[0]?.trim().toLowerCase() ?? "")
+	);
+}
+
+function renderResults(results: any[], nextCursor?: string): string {
+	if (results.length === 0) return "No resources found.";
+	const keys = Object.keys(results[0]);
+	const header = `| ${keys.join(" | ")} |\n| ${keys.map(() => "---").join(" | ")} |`;
+	const rows = results
+		.map(
+			(row) =>
+				`| ${keys
+					.map((key) =>
+						(typeof row[key] === "object" && row[key] !== null
+							? JSON.stringify(row[key])
+							: String(row[key] ?? "")
+						)
+							.replace(/\|/g, "\\|")
+							.replace(/\n/g, " "),
+					)
+					.join(" | ")} |`,
+		)
+		.join("\n");
+	return `${header}\n${rows}${nextCursor ? `\n\nMore results exist. Call find_resource again with this exact cursor: \`${nextCursor}\`.` : ""}`;
+}
+
 export const createFindResourceTool = (
 	dbService: DbService,
 	metadata: WorkflowMetadata,
 ) => {
 	return fencedTool(
-		async ({ searchQuery, resourceType, searchBy, metadata: toolMetadata }) => {
+		async ({ searchQuery, resourceType, searchBy, cursor, metadata: toolMetadata }) => {
 			// Normalize to a keyword array; canvas/ID lookups use the first value.
 			const keywords = Array.isArray(searchQuery) ? searchQuery : [searchQuery];
 			const singleId = keywords[0] ?? "";
 			// `.nullish()` per the schema rules, so null has to collapse too.
 			const mode: SearchMode = searchBy === "id" ? "id" : "keyword";
+			const listRequest = isListRequest(keywords, mode);
 
 			logger.info(
 				`[Tools] ${mode === "id" ? "Fetching" : "Searching"} ${resourceType} by ${mode} '${keywords.join(", ")}' in project ${metadata.projectId}`,
@@ -56,6 +91,39 @@ export const createFindResourceTool = (
 					singleId,
 				);
 				return canvas ? renderCanvas(canvas) : "No canvas found.";
+			}
+
+			if (listRequest) {
+				if (
+					resourceType !== "route" &&
+					resourceType !== "app_config" &&
+					resourceType !== "integration" &&
+					resourceType !== "custom_block"
+				) {
+					return "Listing is supported for routes, app configs, integrations, and custom blocks; choose one of those resource types.";
+				}
+
+				let afterId: string | undefined;
+				try {
+					afterId = cursor
+						? decodeResourceCursor(cursor, resourceType)
+						: undefined;
+				} catch (error) {
+					return error instanceof Error ? error.message : "Invalid cursor.";
+				}
+
+				const page =
+					resourceType === "route"
+						? await dbService.listRoutes(metadata.projectId, afterId)
+						: resourceType === "app_config"
+							? await dbService.listAppConfigs(
+									metadata.projectId,
+									afterId === undefined ? undefined : Number(afterId),
+								)
+							: resourceType === "integration"
+								? await dbService.listIntegrations(metadata.projectId, afterId)
+								: await dbService.listCustomBlocks(metadata.projectId, afterId);
+				return renderResults(page.items, page.nextCursor);
 			}
 
 			let results: any[] = [];
@@ -96,28 +164,7 @@ export const createFindResourceTool = (
 					: "No resources found.";
 			}
 
-			// Format as Markdown table
-			const keys = Object.keys(results[0]);
-			const header = `| ${keys.join(" | ")} |\n| ${keys.map(() => "---").join(" | ")} |`;
-			const rows = results
-				.map(
-					(row) =>
-						`| ${keys
-							.map((key) =>
-								// `inputParams` is an array; String() on it gives the
-								// model nothing it can use
-								(typeof row[key] === "object" && row[key] !== null
-									? JSON.stringify(row[key])
-									: String(row[key] ?? "")
-								)
-									.replace(/\|/g, "\\|")
-									.replace(/\n/g, " "),
-							)
-							.join(" | ")} |`,
-				)
-				.join("\n");
-
-			return `${header}\n${rows}`;
+			return renderResults(results);
 		},
 		{
 			name: "find_resource",
@@ -129,12 +176,18 @@ export const createFindResourceTool = (
 					.describe(
 						"What to look up. With searchBy='keyword' (default), one or more keywords matched against name, path and description — pass an array of related terms (e.g. ['user', 'auth', 'login']) to widen matching and avoid multiple retries. With searchBy='id', the exact resource ID. For 'route_canvas' and 'custom_block_canvas', pass a single resource ID.",
 					),
-				searchBy: z
+			searchBy: z
 					.enum(["keyword", "id"])
 					.nullish()
 					.describe(
 						"'keyword' (default) fuzzy-searches names and descriptions. Use 'id' when you already have the resource's exact ID — from the plan, from your task description, or from an earlier tool result — and want that one record. An ID is not a keyword: fuzzy search will not find it.",
 					),
+			cursor: z
+				.string()
+				.nullish()
+				.describe(
+					"Opaque continuation cursor from a previous all/* listing. Omit for the first page; copy it exactly for the next 20 results.",
+				),
 				resourceType: z
 					.enum([
 						"route",

--- a/apps/ai-gateway/src/harness/types.ts
+++ b/apps/ai-gateway/src/harness/types.ts
@@ -26,6 +26,17 @@ export type ResourceType =
 	| "route_canvas"
 	| "custom_block_canvas";
 
+/** A compact, project-scoped record the planner can use to decide whether to
+ * create or modify a resource without first spending a model/tool round trip. */
+export interface ProjectInventoryEntry {
+	type: "route" | "app_config" | "integration" | "custom_block";
+	id: string;
+	/** Machine-useful identity: route method/path, config key, or stored name. */
+	identifier: string;
+	/** Human-useful display label. Never contains config values or credentials. */
+	label: string;
+}
+
 export interface FindResourceResult {
 	type: ResourceType;
 	id: string;


### PR DESCRIPTION
## Summary

- preload a project-scoped inventory of routes, app configs, integrations, and custom blocks for planner and task-generation agents
- add ind_resource support for * / ll, with opaque cursor pagination of 20 items per page
- keep inventory presentation typed and prevent untrusted resource data from entering high-authority prompts

## Validation

- un test apps/ai-gateway/src/harness
- un run --cwd apps/ai-gateway lint
- full pre-commit suite: lint, secret scan, FTA, and 828 unit tests

Closes #274