### PR TITLE
feat(harness): add live run stats

### DIFF
--- a/apps/ai-gateway/src/harness/agents/discussion.ts
+++ b/apps/ai-gateway/src/harness/agents/discussion.ts
@@ -95,6 +95,7 @@ Q: "What can I access inside the script block?" -> a lead sentence, then a bulle
 			systemPrompt,
 			context: contextBlock,
 			messages: this.state.messages,
+			historyMessageCount: this.state.historyMessageCount,
 			userQuery: this.state.userQuery,
 			tools: tools,
 			agentNode: AgentNode.DISCUSSION,

--- a/apps/ai-gateway/src/harness/agents/planner.ts
+++ b/apps/ai-gateway/src/harness/agents/planner.ts
@@ -192,6 +192,7 @@ Plan carefully, thoroughly, and output excellent English craft for the user's pl
 			context,
 			tools,
 			messages: this.state.messages,
+			historyMessageCount: this.state.historyMessageCount,
 			userQuery: this.state.userQuery,
 			agentNode: AgentNode.PLANNER,
 		})) as z.infer<typeof plannerSchema>;

--- a/apps/ai-gateway/src/harness/agents/router.ts
+++ b/apps/ai-gateway/src/harness/agents/router.ts
@@ -122,6 +122,7 @@ CRITICAL INSTRUCTIONS:
 			systemPrompt,
 			context: contextBlock,
 			messages: this.state.messages,
+			historyMessageCount: this.state.historyMessageCount,
 			userQuery: this.state.userQuery,
 			agentNode: AgentNode.ROUTER,
 		})) as z.infer<typeof routerSchema>;

--- a/apps/ai-gateway/src/harness/callbacks.spec.ts
+++ b/apps/ai-gateway/src/harness/callbacks.spec.ts
@@ -4,6 +4,7 @@ import { AgentNode } from "./types";
 import type { HarnessStreamEvent } from "./streamTypes";
 import type { HarnessService } from "./internal/harnessService";
 import type { RedisService } from "./internal/redisService";
+import { RunBudget } from "./models/budget";
 
 /** Collects every event the callbacks emit, in order. */
 function harness() {
@@ -14,6 +15,7 @@ function harness() {
 		conversationId: "conv-1",
 		runId: "run-1",
 		userId: null, // skips the NATS publish
+		budget: new RunBudget(),
 		harnessService: {
 			upsertStep: async () => ({ id: "step-1" }),
 			saveLiveState: async (input: any) => {

--- a/apps/ai-gateway/src/harness/callbacks.ts
+++ b/apps/ai-gateway/src/harness/callbacks.ts
@@ -160,7 +160,7 @@ export class HarnessCallbacks {
 				conversationId: this.conversationId,
 				runId: this.runId,
 				toolCalls: this.toolCalls,
-				inputTokens: usage.inputTokens,
+				inputTokens: Math.max(0, usage.inputTokens - usage.historyInputTokens),
 				outputTokens: usage.outputTokens,
 				elapsedMs: usage.elapsedMs,
 				updatedAt: Date.now(),

--- a/apps/ai-gateway/src/harness/callbacks.ts
+++ b/apps/ai-gateway/src/harness/callbacks.ts
@@ -26,9 +26,10 @@ import {
 } from "./streamTypes";
 import type { HarnessService } from "./internal/harnessService";
 import type { RedisService } from "./internal/redisService";
-import { publishHarnessEvent } from "./notifications";
+import { publishHarnessEvent, publishHarnessStats } from "./notifications";
 import { explainErrorReason } from "./errors";
 import type { RetryWarningInfo } from "./models/base";
+import type { RunBudget } from "./models/budget";
 
 export async function dispatchAgentEvent(event: AgentCustomEvent): Promise<void> {
 	await dispatchCustomEvent(event.name, event.data);
@@ -62,6 +63,7 @@ export interface HarnessCallbackContext {
 	/** Conversation owner — the `conversations.<userId>` subject to publish to.
 	 *  Null when the conversation has no owner (e.g. the local demo). */
 	userId: string | null;
+	budget: RunBudget;
 }
 
 /**
@@ -80,6 +82,8 @@ export class HarnessCallbacks {
 	private harnessService: HarnessService;
 	private redisService: RedisService;
 	private userId: string | null;
+	private budget: RunBudget;
+	private toolCalls = 0;
 	/** Shallow-merged accumulation of node outputs for live-state snapshots. */
 	private mergedState: Partial<GlobalGraphState>;
 	/** Serialized, off-hot-path emit chain. Emitting must never block the
@@ -94,6 +98,7 @@ export class HarnessCallbacks {
 		this.harnessService = ctx.harnessService;
 		this.redisService = ctx.redisService;
 		this.userId = ctx.userId;
+		this.budget = ctx.budget;
 		this.mergedState = { ...ctx.state };
 	}
 
@@ -145,12 +150,35 @@ export class HarnessCallbacks {
 		});
 	}
 
+	/** Queue latest counters beside progress. Stats are ephemeral snapshots, so
+	 * they bypass Redis while preserving ordering with the surrounding event. */
+	private emitStats(): void {
+		this.emitChain = this.emitChain.then(async () => {
+			if (!this.userId) return;
+			const usage = this.budget.snapshot();
+			publishHarnessStats(this.userId, {
+				conversationId: this.conversationId,
+				runId: this.runId,
+				toolCalls: this.toolCalls,
+				inputTokens: usage.inputTokens,
+				outputTokens: usage.outputTokens,
+				elapsedMs: usage.elapsedMs,
+				updatedAt: Date.now(),
+			});
+		});
+	}
+
 	/** Awaits all scheduled emits. Called by the harness before finalizing. */
 	/** The state accumulated so far. The terminal handlers persist this when a
 	 *  run dies mid-build — the graph never returns a final state on that path,
 	 *  so this is the only surviving record of what the sub-agents produced. */
 	public snapshotState(): Partial<GlobalGraphState> {
 		return this.mergedState;
+	}
+
+	/** Count actual tool executions across every agent in this run pass. */
+	public toolCallCount(): number {
+		return this.toolCalls;
 	}
 
 	public async flush(): Promise<void> {
@@ -242,6 +270,7 @@ export class HarnessCallbacks {
 				message: nodeMessage(node, "started"),
 			}),
 		);
+		this.emitStats();
 	}
 
 	public async onAfter(node: AgentNodeName, eventData: any): Promise<void> {
@@ -292,6 +321,7 @@ export class HarnessCallbacks {
 				payload,
 			}),
 		);
+		this.emitStats();
 	}
 
 	public async onCustomEvent(
@@ -309,6 +339,7 @@ export class HarnessCallbacks {
 					message: eventData?.status ?? `Working on ${labelForNode(node)}`,
 				}),
 			);
+			this.emitStats();
 			return;
 		}
 
@@ -316,6 +347,7 @@ export class HarnessCallbacks {
 			const data = eventData as ToolCallEventData;
 			const node = data?.agent as AgentNodeName;
 			if (!GRAPH_NODES.has(node) || !data?.tool) return;
+			if (data.status === "started") this.toolCalls += 1;
 			this.emit(
 				this.makeEvent({
 					node,
@@ -328,6 +360,7 @@ export class HarnessCallbacks {
 					message: toolMessage(data.tool, data.status, data.summary, data.error),
 				}),
 			);
+			this.emitStats();
 			return;
 		}
 
@@ -346,6 +379,7 @@ export class HarnessCallbacks {
 					},
 				}),
 			);
+			this.emitStats();
 		}
 	}
 
@@ -364,5 +398,6 @@ export class HarnessCallbacks {
 				message: `The ${labelForNode(node)} hit a hiccup and is retrying (attempt ${info.attempt}/${info.maxAttempts}) — ${reason}`,
 			}),
 		);
+		this.emitStats();
 	}
 }

--- a/apps/ai-gateway/src/harness/clientContract.ts
+++ b/apps/ai-gateway/src/harness/clientContract.ts
@@ -24,6 +24,19 @@ export type {
 	HarnessSnapshot,
 } from "./streamTypes";
 
+/** Live, run-scoped counters sent separately from progress events. Kept out of
+ * the event log because they are snapshots, not durable timeline entries. */
+export interface HarnessRunStats {
+	conversationId: string;
+	runId: string;
+	toolCalls: number;
+	inputTokens: number;
+	outputTokens: number;
+	/** Elapsed wall-clock time at `updatedAt`, in milliseconds. */
+	elapsedMs: number;
+	updatedAt: number;
+}
+
 /** The synthetic node carrying run-level bookends. Declared here as a literal
  *  rather than re-exported: `streamTypes` pulls in the `AgentNode` enum (a
  *  runtime value), and this module must stay import-free for the browser. */
@@ -72,6 +85,7 @@ export type HarnessSocketMessage =
 			runId: string;
 			event: HarnessStreamEvent;
 	  }
+	| { type: "stats"; stats: HarnessRunStats }
 	| { type: "artifact_status"; status: ArtifactStatus };
 
 /**

--- a/apps/ai-gateway/src/harness/index.ts
+++ b/apps/ai-gateway/src/harness/index.ts
@@ -149,6 +149,7 @@ export class FluxifyHarness {
 	): Promise<Partial<GlobalGraphState>> {
 		const harnessService = new HarnessService(ctx.conversationId);
 		const messages = await harnessService.getConversationMessageHistory();
+		const historyMessageCount = messages.length;
 		// The composer sends @-mentions as raw `:resource{...}` markup. Nothing
 		// downstream parsed it, so agents saw markup, guessed a keyword, and told
 		// the user their own resource did not exist. Rewriting it here also keeps
@@ -186,6 +187,7 @@ export class FluxifyHarness {
 		return {
 			...workingMemory,
 			messages,
+			historyMessageCount,
 			userQuery: query,
 			action: ctx.action,
 			internal: {

--- a/apps/ai-gateway/src/harness/index.ts
+++ b/apps/ai-gateway/src/harness/index.ts
@@ -239,6 +239,10 @@ export class FluxifyHarness {
 			return undefined;
 		}
 
+		// Per-run deadline + token ceiling and usage accounting. The clock starts
+		// before callbacks so every live stats snapshot has the same origin.
+		const budget = new RunBudget();
+
 		const callbacks = new this.callbacksClass({
 			state,
 			conversationId: ctx.conversationId,
@@ -246,15 +250,13 @@ export class FluxifyHarness {
 			harnessService,
 			redisService: this.redisService,
 			userId,
+			budget,
 		});
 
 		// Per-run interrupt: the AbortController's signal cancels every model call;
 		// aborting it raises UserInterruptError out of the graph (caught below).
 		const abortController = new AbortController();
 		state.agentWrapper?.setAbortSignal(abortController.signal);
-		// Per-run deadline + token ceiling, and the run's usage accounting. The
-		// clock starts here, so provider-probe and queue time are excluded.
-		const budget = new RunBudget();
 		state.agentWrapper?.setRunBudget(budget);
 		// Covers the whole run — the tracer's own spans all end mid-stream, so the
 		// run's cost and outcome have nowhere else to live.
@@ -340,7 +342,14 @@ export class FluxifyHarness {
 			// blip inside it must not fall into the catch below and re-brand a
 			// finished run as failed — the user's build landed either way.
 			try {
-				await this.finalizeRun(ctx, harnessService, userId, budget, finalState);
+				await this.finalizeRun(
+					ctx,
+					harnessService,
+					userId,
+					budget,
+					callbacks.toolCallCount(),
+					finalState,
+				);
 			} catch (error) {
 				logger.error("[FluxifyHarness] Failed to finalize a completed run", {
 					conversationId: ctx.conversationId,
@@ -367,6 +376,7 @@ export class FluxifyHarness {
 					harnessService,
 					userId,
 					budget,
+					callbacks.toolCallCount(),
 					callbacks.snapshotState(),
 				);
 				return undefined;
@@ -388,6 +398,7 @@ export class FluxifyHarness {
 				describeFailure(error, lastNode),
 				lastNode,
 				budget,
+				callbacks.toolCallCount(),
 				callbacks.snapshotState(),
 			);
 			throw error;
@@ -454,9 +465,10 @@ export class FluxifyHarness {
 		harnessService: HarnessService,
 		userId: string | null,
 		budget: RunBudget,
+		toolCalls: number,
 		finalState?: Partial<GlobalGraphState>,
 	) {
-		const usage = logRunUsage(ctx, budget);
+		const usage = logRunUsage(ctx, budget, toolCalls);
 		const reachedHITL =
 			finalState?.currentAgent === AgentNode.HUMAN_IN_THE_LOOP;
 
@@ -568,11 +580,12 @@ export class FluxifyHarness {
 		aiResponse?: string,
 		node?: AgentNodeName,
 		budget?: RunBudget,
+		toolCalls = 0,
 		graphState?: Partial<GlobalGraphState>,
 	) {
 		const message =
 			error instanceof Error ? error.message : error ? String(error) : "failed";
-		const usage = budget && logRunUsage(ctx, budget);
+		const usage = budget && logRunUsage(ctx, budget, toolCalls);
 		try {
 			await harnessService.updateRun({
 				runId: ctx.runId,
@@ -625,11 +638,12 @@ export class FluxifyHarness {
 		harnessService: HarnessService,
 		userId: string | null,
 		budget: RunBudget,
+		toolCalls: number,
 		graphState?: Partial<GlobalGraphState>,
 	) {
 		const message =
 			"Conversation was interrupted by the user before it finished.";
-		const usage = logRunUsage(ctx, budget);
+		const usage = logRunUsage(ctx, budget, toolCalls);
 		try {
 			await harnessService.updateRun({
 				runId: ctx.runId,

--- a/apps/ai-gateway/src/harness/internal/historyCompaction.ts
+++ b/apps/ai-gateway/src/harness/internal/historyCompaction.ts
@@ -79,6 +79,9 @@ export function mergeRunUsage(
 		retries: nonNegative(left?.retries) + nonNegative(right?.retries),
 		inputTokens:
 			nonNegative(left?.inputTokens) + nonNegative(right?.inputTokens),
+		historyInputTokens:
+			nonNegative(left?.historyInputTokens) +
+			nonNegative(right?.historyInputTokens),
 		outputTokens:
 			nonNegative(left?.outputTokens) + nonNegative(right?.outputTokens),
 		cachedInputTokens:

--- a/apps/ai-gateway/src/harness/internal/historyCompaction.ts
+++ b/apps/ai-gateway/src/harness/internal/historyCompaction.ts
@@ -101,6 +101,8 @@ export function mergeRunUsage(
 
 	return {
 		...total,
+		toolCalls:
+			nonNegative(previous?.toolCalls) + nonNegative(current.toolCalls),
 		totalTokens: total.inputTokens + total.outputTokens,
 		elapsedMs:
 			nonNegative(previous?.elapsedMs) + nonNegative(current.elapsedMs),

--- a/apps/ai-gateway/src/harness/models/base.spec.ts
+++ b/apps/ai-gateway/src/harness/models/base.spec.ts
@@ -350,6 +350,21 @@ describe("run budget", () => {
 		expect(usage.byAgent.planner!.calls).toBe(1);
 	});
 
+	it("separates earlier conversation history from current-run input", async () => {
+		const wrapper = new BudgetedWrapper("test-model");
+		const budget = new RunBudget({ deadlineMs: 60_000, tokenBudget: 0 });
+		wrapper.setRunBudget(budget);
+
+		await wrapper.run({
+			messages: [new HumanMessage("12345678")],
+			historyMessageCount: 1,
+			userQuery: "current request",
+			agentNode: "planner",
+		});
+
+		expect(budget.snapshot().historyInputTokens).toBe(2);
+	});
+
 	it("refuses to spend past the ceiling instead of failing mid-call", async () => {
 		const wrapper = new BudgetedWrapper("test-model");
 		const budget = new RunBudget({ deadlineMs: 60_000, tokenBudget: 300 });

--- a/apps/ai-gateway/src/harness/models/base.ts
+++ b/apps/ai-gateway/src/harness/models/base.ts
@@ -67,6 +67,8 @@ export interface AgentInvokeOptions {
 	 *  ahead of `userQuery`. */
 	context?: string;
 	messages?: BaseMessage[];
+	/** Leading entries in `messages` loaded from earlier conversation turns. */
+	historyMessageCount?: number;
 	tools?: StructuredTool[];
 	config?: RunnableConfig;
 	maxToolIterations?: number;
@@ -187,8 +189,25 @@ export abstract class BaseAgentWrapper {
 		agentNode: string | undefined,
 		response: unknown,
 		startedAt: number,
+		historyInputTokens = 0,
 	): void {
-		this.budget?.record(agentNode, response, Date.now() - startedAt);
+		this.budget?.record(
+			agentNode,
+			response,
+			Date.now() - startedAt,
+			historyInputTokens,
+		);
+	}
+
+	/** Provider usage metadata has no history/current-run split. Estimate only
+	 * conversation-history text; provider-reported output tokens stay exact. */
+	private estimateHistoryTokens(messages: BaseMessage[], count: number): number {
+		return messages.slice(0, Math.max(0, count)).reduce((total, message) => {
+			const content = typeof message.content === "string"
+				? message.content
+				: JSON.stringify(message.content);
+			return total + Math.ceil(content.length / 4);
+		}, 0);
 	}
 
 	constructor(
@@ -287,6 +306,7 @@ export abstract class BaseAgentWrapper {
 			systemPrompt,
 			context,
 			messages = [],
+			historyMessageCount = 0,
 			tools,
 			config,
 			agentNode,
@@ -294,6 +314,10 @@ export abstract class BaseAgentWrapper {
 		} = options;
 
 		let finalMessages: BaseMessage[] = [...messages];
+		const historyInputTokens = this.estimateHistoryTokens(
+			messages,
+			historyMessageCount,
+		);
 
 		// A tool-using agent returns its answer through `submit_result` instead of
 		// writing it out and having it regenerated as JSON afterwards.
@@ -339,6 +363,7 @@ export abstract class BaseAgentWrapper {
 				finalMessages,
 				tools,
 				options,
+				historyInputTokens,
 			);
 			if (result.done) return result.value;
 
@@ -369,7 +394,7 @@ export abstract class BaseAgentWrapper {
 									finalMessages,
 									this.withSignal(config),
 								)) as { raw: AIMessage; parsed: T; parsingError?: Error };
-							this.recordUsage(agentNode, raw, startedAt);
+							this.recordUsage(agentNode, raw, startedAt, historyInputTokens);
 							// Without includeRaw this would have thrown out of `invoke`;
 							// rethrow so the retry and the prompt fallback below still see it.
 							if (parsingError) throw parsingError;
@@ -408,6 +433,7 @@ export abstract class BaseAgentWrapper {
 					zodSchema,
 					this.withSignal(config),
 					agentNode,
+					historyInputTokens,
 				)) as T;
 			}
 
@@ -426,7 +452,7 @@ export abstract class BaseAgentWrapper {
 					finalMessages,
 					this.withSignal(config),
 				);
-				this.recordUsage(agentNode, response, startedAt);
+				this.recordUsage(agentNode, response, startedAt, historyInputTokens);
 				return response;
 			},
 			{
@@ -451,6 +477,7 @@ export abstract class BaseAgentWrapper {
 		finalMessages: BaseMessage[],
 		tools: StructuredTool[],
 		options: AgentInvokeOptions,
+		historyInputTokens: number,
 	): Promise<{ done: true; value: T | AIMessage } | { done: false }> {
 		const { zodSchema, config, agentNode, agentId } = options;
 		const maxIterations =
@@ -469,7 +496,7 @@ export abstract class BaseAgentWrapper {
 						finalMessages,
 						this.withSignal(config),
 					);
-					this.recordUsage(agentNode, message, startedAt);
+					this.recordUsage(agentNode, message, startedAt, historyInputTokens);
 					return message;
 				},
 				{
@@ -603,6 +630,7 @@ export abstract class BaseAgentWrapper {
 		schema: z.ZodType<any>,
 		config?: RunnableConfig,
 		agentNode?: string,
+		historyInputTokens = 0,
 	): Promise<T> {
 		// zod-to-json-schema (v3) reads zod v3 `_def` internals and silently emits
 		// an empty schema against a zod v4 schema — the model then gets "match
@@ -648,7 +676,7 @@ ${JSON.stringify(jsonSchema, null, 2)}`;
 			try {
 				const startedAt = Date.now();
 				const response = await jsonModel.invoke(modifiedMessages, config);
-				this.recordUsage(agentNode, response, startedAt);
+				this.recordUsage(agentNode, response, startedAt, historyInputTokens);
 				rawResponse = response;
 				content = cleanJsonOutput(extractText(response));
 

--- a/apps/ai-gateway/src/harness/models/budget.spec.ts
+++ b/apps/ai-gateway/src/harness/models/budget.spec.ts
@@ -66,10 +66,20 @@ describe("RunBudget", () => {
 			calls: 2,
 			retries: 0,
 			inputTokens: 250,
+			historyInputTokens: 0,
 			outputTokens: 25,
 			cachedInputTokens: 150,
 			modelMs: 40,
 		});
+	});
+
+	it("tracks estimated conversation-history tokens separately", () => {
+		const budget = new RunBudget({ deadlineMs: 60_000, tokenBudget: 0 });
+		budget.record("planner", reply(100, 10), 20, 40);
+
+		const usage = budget.snapshot();
+		expect(usage.inputTokens).toBe(100);
+		expect(usage.historyInputTokens).toBe(40);
 	});
 
 	it("counts re-asks separately from calls", () => {

--- a/apps/ai-gateway/src/harness/models/budget.ts
+++ b/apps/ai-gateway/src/harness/models/budget.ts
@@ -47,6 +47,8 @@ export interface AgentUsage {
 }
 
 export interface RunUsage extends AgentUsage {
+	/** Actual tool executions requested by agents during this run. */
+	toolCalls: number;
 	totalTokens: number;
 	/** Wall clock for the whole run, including graph and tool time. */
 	elapsedMs: number;
@@ -131,6 +133,7 @@ export class RunBudget {
 	snapshot(): RunUsage {
 		return {
 			...this.total,
+			toolCalls: 0,
 			totalTokens: this.total.inputTokens + this.total.outputTokens,
 			elapsedMs: Date.now() - this.startedAt,
 			byAgent: Object.fromEntries(this.byAgent),
@@ -144,8 +147,9 @@ export class RunBudget {
 export function logRunUsage(
 	ids: { runId: string; conversationId: string },
 	budget: RunBudget,
+	toolCalls = 0,
 ): RunUsage {
-	const usage = budget.snapshot();
+	const usage = { ...budget.snapshot(), toolCalls };
 	logger.info("[FluxifyHarness] Run usage", { ...ids, ...usage });
 	return usage;
 }

--- a/apps/ai-gateway/src/harness/models/budget.ts
+++ b/apps/ai-gateway/src/harness/models/budget.ts
@@ -38,6 +38,9 @@ export interface AgentUsage {
 	 *  agent's prompt or the chosen model is a bad fit. */
 	retries: number;
 	inputTokens: number;
+	/** Estimated tokens from prior conversation history, tracked separately so
+	 * the UI can show only work attributable to the current run. */
+	historyInputTokens: number;
 	outputTokens: number;
 	/** Prompt tokens served from the provider's cache — the payoff of #148's
 	 *  cache-friendly prompt ordering, and the only way to see it working. */
@@ -60,6 +63,7 @@ function emptyUsage(): AgentUsage {
 		calls: 0,
 		retries: 0,
 		inputTokens: 0,
+		historyInputTokens: 0,
 		outputTokens: 0,
 		cachedInputTokens: 0,
 		modelMs: 0,
@@ -117,7 +121,12 @@ export class RunBudget {
 	}
 
 	/** Books one model call against the run and the agent that made it. */
-	record(agentNode: string | undefined, response: unknown, modelMs: number): void {
+	record(
+		agentNode: string | undefined,
+		response: unknown,
+		modelMs: number,
+		historyInputTokens = 0,
+	): void {
 		const usage = (response as AIMessage | undefined)?.usage_metadata;
 		const agent = this.bucketFor(agentNode);
 
@@ -125,6 +134,7 @@ export class RunBudget {
 			bucket.calls += 1;
 			bucket.modelMs += modelMs;
 			bucket.inputTokens += usage?.input_tokens ?? 0;
+			bucket.historyInputTokens += usage ? historyInputTokens : 0;
 			bucket.outputTokens += usage?.output_tokens ?? 0;
 			bucket.cachedInputTokens += usage?.input_token_details?.cache_read ?? 0;
 		}

--- a/apps/ai-gateway/src/harness/notifications.ts
+++ b/apps/ai-gateway/src/harness/notifications.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { logger } from "@fluxify/common";
 import { publishMessage, subscribeToChannel } from "@fluxify/server";
 import type { HarnessStreamEvent } from "./streamTypes";
-import type { ArtifactStatus } from "./clientContract";
+import type { ArtifactStatus, HarnessRunStats } from "./clientContract";
 
 /* ============================================================================
  * CONVERSATION PUB/SUB CONTRACT (NATS)
@@ -28,6 +28,7 @@ export function conversationSubject(userId: string): string {
 /** Discriminant for the conversation message union. */
 export const ConversationMsgType = {
 	HARNESS_EVENT: "harness_event",
+	HARNESS_STATS: "harness_stats",
 	ARTIFACT_STATUS: "artifact_status",
 } as const;
 
@@ -64,13 +65,28 @@ const artifactStatusMessageSchema = z.object({
 	),
 });
 
+const harnessStatsMessageSchema = z.object({
+	type: z.literal(ConversationMsgType.HARNESS_STATS),
+	userId: z.string(),
+	conversationId: z.string(),
+	runId: z.string(),
+	stats: z.custom<HarnessRunStats>(
+		(v) =>
+			typeof v === "object" &&
+			v !== null &&
+			typeof (v as { toolCalls?: unknown }).toolCalls === "number",
+	),
+});
+
 export const conversationMessageSchema = z.discriminatedUnion("type", [
 	harnessEventMessageSchema,
+	harnessStatsMessageSchema,
 	artifactStatusMessageSchema,
 ]);
 
 export type ConversationMessage = z.infer<typeof conversationMessageSchema>;
 export type HarnessEventMessage = z.infer<typeof harnessEventMessageSchema>;
+export type HarnessStatsMessage = z.infer<typeof harnessStatsMessageSchema>;
 export type ArtifactStatusMessage = z.infer<typeof artifactStatusMessageSchema>;
 
 /** Publishes a harness stream event to its owner's conversation subject. */
@@ -92,6 +108,25 @@ export function publishHarnessEvent(
 		logger.error("[Conversations] Failed to publish harness event", {
 			userId,
 			runId: event.runId,
+			error,
+		});
+	});
+}
+
+/** Publishes current in-memory run counters. These are intentionally ephemeral:
+ * the terminal usage record remains the durable accounting source. */
+export function publishHarnessStats(userId: string, stats: HarnessRunStats): void {
+	const message: HarnessStatsMessage = {
+		type: ConversationMsgType.HARNESS_STATS,
+		userId,
+		conversationId: stats.conversationId,
+		runId: stats.runId,
+		stats,
+	};
+	void publishMessage(conversationSubject(userId), message).catch((error) => {
+		logger.error("[Conversations] Failed to publish harness stats", {
+			userId,
+			runId: stats.runId,
 			error,
 		});
 	});

--- a/apps/ai-gateway/src/harness/socketGateway.ts
+++ b/apps/ai-gateway/src/harness/socketGateway.ts
@@ -209,6 +209,11 @@ export async function initializeHarnessSocket(): Promise<HarnessSocketHandler> {
 			return;
 		}
 
+		if (incoming.type === ConversationMsgType.HARNESS_STATS) {
+			io.to(room).emit(HARNESS_SOCKET_EVENT, { type: "stats", stats: incoming.stats });
+			return;
+		}
+
 		if (incoming.type !== ConversationMsgType.HARNESS_EVENT) return;
 		const message: HarnessSocketMessage = {
 			type: "update",

--- a/apps/ai-gateway/src/harness/types.ts
+++ b/apps/ai-gateway/src/harness/types.ts
@@ -229,6 +229,12 @@ export const GraphState = Annotation.Root({
 		reducer: (oldState, newState) => newState ?? oldState,
 		default: () => undefined,
 	}),
+	/** Number of leading `messages` entries loaded from earlier conversation
+	 * turns. Kept separate from this run's query for usage accounting. */
+	historyMessageCount: Annotation<number>({
+		reducer: (oldState, newState) => newState ?? oldState,
+		default: () => 0,
+	}),
 	action: Annotation<HitlPlanAction | undefined>({
 		reducer: (oldState, newState) => newState ?? oldState,
 		default: () => undefined,

--- a/apps/portal/src/components/ai/AiMessage.tsx
+++ b/apps/portal/src/components/ai/AiMessage.tsx
@@ -1,6 +1,7 @@
 import { MarkdownViewer } from "./MarkdownViewer";
+import { HarnessUsageSummary, type HarnessUsage } from "./HarnessUsageSummary";
 
-export function AiMessage({ response, status }: { response?: string | null; status?: string }) {
+export function AiMessage({ response, status, usage }: { response?: string | null; status?: string; usage?: HarnessUsage | null }) {
 	const isCompleted = !status || status.toLowerCase() === "completed";
 
 	if (!response && !status) return null;
@@ -15,6 +16,7 @@ export function AiMessage({ response, status }: { response?: string | null; stat
 			{response && (
 				<div className="w-full">
 					<MarkdownViewer content={response} />
+					{isCompleted && <HarnessUsageSummary usage={usage} />}
 				</div>
 			)}
 		</div>

--- a/apps/portal/src/components/ai/ConversationPage.tsx
+++ b/apps/portal/src/components/ai/ConversationPage.tsx
@@ -14,6 +14,7 @@ import { ScrollToBottomButton } from "./ScrollToBottomButton";
 import { ChatTitleEditor } from "./ChatTitleEditor";
 import { AgentTaskStatus } from "./AgentTaskStatus";
 import { HarnessStatusAccordion } from "./HarnessStatusAccordion";
+import { HarnessLiveStats } from "./HarnessLiveStats";
 import { ArtifactsSidebar } from "./ArtifactsSidebar";
 import type { HarnessConversation } from "./types";
 import { PlanReviewModal } from "./PlanReviewModal";
@@ -297,7 +298,7 @@ export function ConversationPage() {
 									) : (
 										<div className="flex w-full flex-col gap-2">
 											{isRunActive && <HarnessStatusAccordion conversationId={conversationId} />}
-											<AiMessage response={msg.aiResponse} status={isRunActive ? undefined : displayStatus} />
+											<AiMessage response={msg.aiResponse} status={isRunActive ? undefined : displayStatus} usage={msg.usage} />
 										</div>
 									)}
 								</div>
@@ -345,6 +346,7 @@ export function ConversationPage() {
 						/>
 					)}
 				</div>
+				<HarnessLiveStats conversationId={conversationId} />
 			</div>
 			{isPlanReviewMode && planText && (
 				<PlanReviewModal

--- a/apps/portal/src/components/ai/HarnessLiveStats.tsx
+++ b/apps/portal/src/components/ai/HarnessLiveStats.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "react";
+import { useConversationRun } from "@/store/aiHarness";
+
+function formatNumber(value: number): string {
+	if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+	if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+	return String(value);
+}
+
+function formatElapsed(milliseconds: number): string {
+	const seconds = Math.floor(milliseconds / 1_000);
+	const minutes = Math.floor(seconds / 60);
+	return minutes > 0 ? `${minutes}m ${seconds % 60}s` : `${seconds}s`;
+}
+
+/** Compact live counters for current harness run. */
+export function HarnessLiveStats({ conversationId }: { conversationId: string }) {
+	const run = useConversationRun(conversationId);
+	const stats = run?.stats;
+	const [now, setNow] = useState(Date.now());
+
+	useEffect(() => {
+		if (!stats || run?.isTerminal) return;
+		const interval = window.setInterval(() => setNow(Date.now()), 1_000);
+		return () => window.clearInterval(interval);
+	}, [stats, run?.isTerminal]);
+
+	if (!stats || run?.isTerminal) return null;
+	const elapsedMs = stats.elapsedMs + Math.max(0, now - (run.statsReceivedAt ?? now));
+
+	return (
+		<div className="mx-auto mt-2 w-full max-w-[65%] text-center text-xs font-medium tracking-wide text-muted">
+			TOOL CALLS: {formatNumber(stats.toolCalls)} <span aria-hidden="true">|</span>{" "}
+			TIME ELAPSED: {formatElapsed(elapsedMs)} <span aria-hidden="true">|</span>{" "}
+			TOKENS I/O: {formatNumber(stats.inputTokens)}/{formatNumber(stats.outputTokens)}
+		</div>
+	);
+}

--- a/apps/portal/src/components/ai/HarnessLiveStats.tsx
+++ b/apps/portal/src/components/ai/HarnessLiveStats.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { TbArrowDown, TbArrowUp } from "react-icons/tb";
 import { useConversationRun } from "@/store/aiHarness";
 
 function formatNumber(value: number): string {
@@ -29,10 +30,12 @@ export function HarnessLiveStats({ conversationId }: { conversationId: string })
 	const elapsedMs = stats.elapsedMs + Math.max(0, now - (run.statsReceivedAt ?? now));
 
 	return (
-		<div className="mx-auto mt-2 w-full max-w-[65%] text-center text-xs font-medium tracking-wide text-muted">
+		<div className="mx-auto mt-2 flex w-full max-w-[65%] items-center justify-center gap-2 text-xs font-medium tracking-wide text-muted">
 			TOOL CALLS: {formatNumber(stats.toolCalls)} <span aria-hidden="true">|</span>{" "}
 			TIME ELAPSED: {formatElapsed(elapsedMs)} <span aria-hidden="true">|</span>{" "}
-			TOKENS I/O: {formatNumber(stats.inputTokens)}/{formatNumber(stats.outputTokens)}
+			<span>TOKENS:</span>
+			<span className="flex items-center gap-0.5"><TbArrowDown size={14} /> {formatNumber(stats.inputTokens)}</span>
+			<span className="flex items-center gap-0.5"><TbArrowUp size={14} /> {formatNumber(stats.outputTokens)}</span>
 		</div>
 	);
 }

--- a/apps/portal/src/components/ai/HarnessUsageSummary.tsx
+++ b/apps/portal/src/components/ai/HarnessUsageSummary.tsx
@@ -1,0 +1,34 @@
+import { TbBolt, TbClock, TbTools } from "react-icons/tb";
+
+export interface HarnessUsage {
+	elapsedMs?: number;
+	inputTokens?: number;
+	outputTokens?: number;
+	toolCalls?: number;
+}
+
+function formatNumber(value: number): string {
+	if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+	if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+	return String(value);
+}
+
+function formatElapsed(milliseconds: number): string {
+	const seconds = Math.floor(milliseconds / 1_000);
+	const minutes = Math.floor(seconds / 60);
+	return minutes > 0 ? `${minutes}m ${seconds % 60}s` : `${seconds}s`;
+}
+
+/** Whole-run accounting displayed beneath a completed harness response. */
+export function HarnessUsageSummary({ usage }: { usage?: HarnessUsage | null }) {
+	if (!usage) return null;
+	const tokens = Math.max(0, usage.inputTokens ?? 0) + Math.max(0, usage.outputTokens ?? 0);
+
+	return (
+		<div className="flex items-center gap-3 px-1 text-xs font-medium text-muted">
+			<span className="flex items-center gap-1"><TbClock size={14} /> {formatElapsed(usage.elapsedMs ?? 0)}</span>
+			<span className="flex items-center gap-1"><TbBolt size={14} /> {formatNumber(tokens)} tokens</span>
+			<span className="flex items-center gap-1"><TbTools size={14} /> {formatNumber(usage.toolCalls ?? 0)} tools</span>
+		</div>
+	);
+}

--- a/apps/portal/src/components/ai/HarnessUsageSummary.tsx
+++ b/apps/portal/src/components/ai/HarnessUsageSummary.tsx
@@ -1,8 +1,9 @@
-import { TbBolt, TbClock, TbTools } from "react-icons/tb";
+import { TbArrowDown, TbArrowUp, TbClock, TbTools } from "react-icons/tb";
 
 export interface HarnessUsage {
 	elapsedMs?: number;
 	inputTokens?: number;
+	historyInputTokens?: number;
 	outputTokens?: number;
 	toolCalls?: number;
 }
@@ -22,13 +23,16 @@ function formatElapsed(milliseconds: number): string {
 /** Whole-run accounting displayed beneath a completed harness response. */
 export function HarnessUsageSummary({ usage }: { usage?: HarnessUsage | null }) {
 	if (!usage) return null;
-	const tokens = Math.max(0, usage.inputTokens ?? 0) + Math.max(0, usage.outputTokens ?? 0);
+	const inputTokens = Math.max(0, (usage.inputTokens ?? 0) - (usage.historyInputTokens ?? 0));
+	const outputTokens = Math.max(0, usage.outputTokens ?? 0);
 
 	return (
 		<div className="flex items-center gap-3 px-1 text-xs font-medium text-muted">
 			<span className="flex items-center gap-1"><TbClock size={14} /> {formatElapsed(usage.elapsedMs ?? 0)}</span>
-			<span className="flex items-center gap-1"><TbBolt size={14} /> {formatNumber(tokens)} tokens</span>
 			<span className="flex items-center gap-1"><TbTools size={14} /> {formatNumber(usage.toolCalls ?? 0)} tools</span>
+			<span className="flex items-center gap-1">Tokens:</span>
+			<span className="flex items-center gap-1"><TbArrowDown size={14} /> {formatNumber(inputTokens)}</span>
+			<span className="flex items-center gap-1"><TbArrowUp size={14} /> {formatNumber(outputTokens)}</span>
 		</div>
 	);
 }

--- a/apps/portal/src/components/ai/PromptEditor.tsx
+++ b/apps/portal/src/components/ai/PromptEditor.tsx
@@ -5,7 +5,6 @@ import { Input, Spinner } from "@fluxify/components";
 import { ModelSelect, type AiModel } from "./ModelSelect";
 import { ApplyModeSelect } from "./ApplyModeSelect";
 import { STARTERS } from "./starters";
-import { integrationsQuery } from "@/query/integrationsQuery";
 import { useAiHarnessStore } from "@/store/aiHarness";
 import { useDebounce } from "@/hooks/useDebounce";
 import { findResourceQuery } from "@/query/findResourceQuery";
@@ -22,6 +21,7 @@ import { KEY_ENTER_COMMAND, KEY_DOWN_COMMAND, COMMAND_PRIORITY_EDITOR, COMMAND_P
 import { ResourceNode } from "./lexical/ResourceNode";
 import { ResourcePlugin, INSERT_RESOURCE_COMMAND } from "./lexical/ResourcePlugin";
 import { markdownToLexical, lexicalToMarkdown, insertMarkdownAtSelection } from "./lexical/MarkdownTransformer";
+import { useModelConnectionTest } from "./useModelConnectionTest";
 
 const PLACEHOLDERS = [
 	"Generate a blog API with rate limiting, Redis cache...",
@@ -131,8 +131,7 @@ export function PromptEditor({
 
 	const [model, setModel] = useState<string>(selectedModelId || defaultModelId || "");
 
-	const testConn = integrationsQuery.testExistingConnection.mutation(projectId);
-	const [connStatus, setConnStatus] = useState<"testing" | "success" | "error" | "idle">("idle");
+	const connStatus = useModelConnectionTest(projectId, model);
 
 	// Popover & Search State
 	const [popoverOpen, setPopoverOpen] = useState(false);
@@ -210,20 +209,6 @@ export function PromptEditor({
 			}
 		}
 	}, [defaultModelId, model, models, setSelectedModelId]);
-
-	useEffect(() => {
-		if (!model) return;
-		setConnStatus("testing");
-		testConn.mutate(model, {
-			onSuccess: (res) => {
-				setConnStatus(res.success ? "success" : "error");
-			},
-			onError: () => {
-				setConnStatus("error");
-			}
-		});
-	// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [model, projectId]);
 
 	const trimmed = value.trim();
 	// `!isRunning` matters for Enter, not the button — the button is swapped for

--- a/apps/portal/src/components/ai/useModelConnectionTest.ts
+++ b/apps/portal/src/components/ai/useModelConnectionTest.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from "react";
+import { toast } from "@fluxify/components";
+import { integrationsQuery } from "@/query/integrationsQuery";
+
+export type ConnectionStatus = "testing" | "success" | "error" | "idle";
+
+/** Verifies the selected model and exposes its send-ready state. */
+export function useModelConnectionTest(projectId: string, model: string): ConnectionStatus {
+	const testConn = integrationsQuery.testExistingConnection.mutation(projectId);
+	const [status, setStatus] = useState<ConnectionStatus>("idle");
+
+	useEffect(() => {
+		if (!model) return;
+		let isCurrent = true;
+		setStatus("testing");
+		const connectionTest = testConn.mutateAsync(model).then((res) => {
+			if (!res.success) throw new Error("Model connection failed");
+			return res;
+		});
+
+		toast.promise(connectionTest, {
+			loading: "Testing model connection…",
+			success: "Model connection ready",
+			error: (error) => error.message || "Model connection failed",
+		});
+
+		connectionTest.then(
+			() => {
+				if (isCurrent) setStatus("success");
+			},
+			() => {
+				if (isCurrent) setStatus("error");
+			},
+		);
+
+		return () => {
+			isCurrent = false;
+		};
+	// The mutation hook is stable for a project; only a project or model change
+	// should start another verification.
+	// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [model, projectId]);
+
+	return status;
+}

--- a/apps/portal/src/store/aiHarness.spec.ts
+++ b/apps/portal/src/store/aiHarness.spec.ts
@@ -242,3 +242,39 @@ test("full_state merges without clobbering newer live updates, and never drops a
 	applyMessage(state, { type: "full_state", conversations: [] });
 	expect(state.runs[CONV]).toBeDefined();
 });
+
+test("live stats attach only to their matching run", () => {
+	const state = blankState();
+	feed(state, event({ timestamp: 1 }));
+	applyMessage(state, {
+		type: "stats",
+		stats: {
+			conversationId: CONV,
+			runId: RUN,
+			toolCalls: 3,
+			inputTokens: 1_250,
+			outputTokens: 75,
+			elapsedMs: 9_000,
+			updatedAt: 10_000,
+		},
+	});
+	expect(state.runs[CONV].stats).toMatchObject({
+		toolCalls: 3,
+		inputTokens: 1_250,
+		outputTokens: 75,
+	});
+
+	applyMessage(state, {
+		type: "stats",
+		stats: {
+			conversationId: CONV,
+			runId: "stale-run",
+			toolCalls: 99,
+			inputTokens: 99,
+			outputTokens: 99,
+			elapsedMs: 99,
+			updatedAt: 20_000,
+		},
+	});
+	expect(state.runs[CONV].stats?.toolCalls).toBe(3);
+});

--- a/apps/portal/src/store/aiHarness.ts
+++ b/apps/portal/src/store/aiHarness.ts
@@ -11,6 +11,7 @@ import {
 	type HarnessNodePayload,
 	type HarnessNodeStatus,
 	type HarnessRunResult,
+	type HarnessRunStats,
 	type HarnessRunStatus,
 	type HarnessSnapshot,
 	type HarnessSocketMessage,
@@ -86,6 +87,10 @@ export interface ConversationUIState {
 	hitl?: { reason: string; markdownPlan?: string };
 	/** Set once by the run-level `ended` event — the final outcome + result. */
 	result?: HarnessRunResult;
+	/** Latest live counters for this run. */
+	stats?: HarnessRunStats;
+	/** Browser receipt time for elapsed-time ticking without server-clock skew. */
+	statsReceivedAt?: number;
 }
 
 export interface SelectedArtifact {
@@ -284,6 +289,21 @@ export function applyMessage(
 		// Merge, never replace: a run missing from a later snapshot has simply
 		// aged out of Redis (60s TTL after it finishes), not ceased to exist.
 		for (const snapshot of message.conversations) applySnapshot(state, snapshot);
+		return;
+	}
+	if (message.type === "stats") {
+		const { stats } = message;
+		const run = (state.runs[stats.conversationId] ??= emptyRun(
+			stats.conversationId,
+			stats.runId,
+		));
+		if (
+			run.runId === stats.runId &&
+			(stats.updatedAt >= (run.stats?.updatedAt ?? 0))
+		) {
+			run.stats = stats;
+			run.statsReceivedAt = Date.now();
+		}
 		return;
 	}
 	// Artifact status is a toast, handled at the transport (`harnessSocket.ts`).

--- a/packages/components/src/providers.tsx
+++ b/packages/components/src/providers.tsx
@@ -7,7 +7,10 @@ import type { ReactNode } from "react";
 export function Providers({ children }: { children: ReactNode }) {
 	return (
 		<>
-			<ToastProvider placement="bottom end" />
+			<ToastProvider
+				placement="bottom end"
+				width="min(24rem, calc(100vw - 2rem))"
+			/>
 			{children}
 		</>
 	);


### PR DESCRIPTION
Streams per-run tool calls, elapsed time, and input/output token usage to the harness UI. Adds live and completed-response stats, excludes history input from displayed run tokens, and shows responsive model-connection test toasts. Closes #266. Validation: lint, complexity analysis, full test suite, portal build.