### PR TITLE
fix: record route telemetry

### DIFF
--- a/apps/portal/src/components/routes/RouteSettingsModal.tsx
+++ b/apps/portal/src/components/routes/RouteSettingsModal.tsx
@@ -30,6 +30,7 @@ import { ConfirmDialog } from "@/components/common/ConfirmDialog";
 import { routesQuery } from "@/query/routesQuery";
 import { projectSettingsKeysQuery } from "@/query/projectSettingsKeysQuery";
 import { showErrorNotification } from "@/lib/errorNotifier";
+import { RouteTelemetryHelp } from "./RouteTelemetryHelp";
 import {
 	CONTENT_TYPE_OPTIONS,
 	EMPTY_SCHEMA,
@@ -112,10 +113,9 @@ function RouteSettingsForm({
 	);
 
 	const settings = (projectSettings ?? {}) as Record<string, string>;
-	// Spans go to the project's traces destination; with none set a traced route
-	// records nothing, so the toggle is worth flagging rather than hiding.
-	const hasTracesDestination = Boolean(
-		settings["settings.telemetry.tracesConnectionId"],
+	const hasTelemetryDestination = Boolean(
+		settings["settings.telemetry.tracesConnectionId"] ||
+			settings["settings.telemetry.metricsConnectionId"],
 	);
 	// The per-route timeout is only enforced when the project opted into the
 	// experimental worker timeouts, so asking for a value otherwise is a lie.
@@ -390,24 +390,26 @@ function RouteSettingsForm({
 
 					<Tabs.Panel id="advanced" className="min-h-0 flex-1 overflow-y-auto p-5">
 						<Section
-							title="Tracing"
-							description="Each request is recorded as an OpenTelemetry trace and exported to the project's traces destination — nothing is stored here. Exporting costs time per request: leave it off when latency is the priority, turn it on when you want visibility into what a request did."
+							title="Telemetry"
+							description="Collect request telemetry for this route. Leave it off when latency is the priority; turn it on when you need visibility into what a request did."
 						>
 							<Switch
 								isSelected={tracingEnabled}
 								onChange={setTracingEnabled}
-								label={tracingEnabled ? "Tracing enabled" : "Tracing disabled"}
+								label={tracingEnabled ? "Telemetry enabled" : "Telemetry disabled"}
 							/>
-							{tracingEnabled && !hasTracesDestination && (
+							<RouteTelemetryHelp projectId={route.projectId} />
+							{tracingEnabled && !hasTelemetryDestination && (
 								<Alert status="warning">
 									<Alert.Indicator>
 										<TbAlertTriangle size={16} />
 									</Alert.Indicator>
 									<Alert.Content>
-										<Alert.Title>No traces destination</Alert.Title>
+										<Alert.Title>No telemetry destination</Alert.Title>
 										<Alert.Description>
-											This project has no traces integration, so traced requests
-											record no spans. Set one under Settings → Telemetry.
+											This project has no traces or metrics destination, so this
+											route's telemetry is not exported. Configure one in Project
+											Settings → Telemetry.
 										</Alert.Description>
 									</Alert.Content>
 								</Alert>

--- a/apps/portal/src/components/routes/RouteTelemetryHelp.tsx
+++ b/apps/portal/src/components/routes/RouteTelemetryHelp.tsx
@@ -1,0 +1,26 @@
+import { Link } from "@tanstack/react-router";
+import { TbExternalLink } from "react-icons/tb";
+
+/** Explains the relationship between the route switch and project destinations. */
+export function RouteTelemetryHelp({ projectId }: { projectId: string }) {
+	return (
+		<p className="text-xs text-muted">
+			Enabling telemetry collects a request trace. Fluxify exports it only to
+			destinations configured for this project: with one traces or metrics
+			destination, it exports only that signal; with both, it exports both. Logs
+			are configured separately and are not affected by this setting. {" "}
+			<Link
+				to="/$projectId/settings"
+				params={{ projectId }}
+				search={{ tab: "telemetry" }}
+				target="_blank"
+				rel="noreferrer"
+				aria-label="Configure telemetry destinations (opens in a new tab)"
+				className="font-medium text-accent underline underline-offset-2 hover:text-accent/80"
+			>
+				Configure telemetry destinations <TbExternalLink className="inline-block align-text-bottom" size={13} />
+			</Link>
+			.
+		</p>
+	);
+}

--- a/apps/portal/src/routes/_authed/$projectId/routes_.new.tsx
+++ b/apps/portal/src/routes/_authed/$projectId/routes_.new.tsx
@@ -23,6 +23,7 @@ import { routesQuery } from "@/query/routesQuery";
 import { projectSettingsKeysQuery } from "@/query/projectSettingsKeysQuery";
 import { showErrorNotification } from "@/lib/errorNotifier";
 import { createRouteHead } from "@/lib/seo";
+import { RouteTelemetryHelp } from "@/components/routes/RouteTelemetryHelp";
 import {
 	CONTENT_TYPE_OPTIONS,
 	EMPTY_SCHEMA,
@@ -57,10 +58,9 @@ function CreateRoutePage() {
 		projectSettingsKeysQuery.getAll.useQuery(projectId);
 
 	const settings = (projectSettings ?? {}) as Record<string, string>;
-	// Spans go to the project's traces destination; with none set a traced route
-	// records nothing, so the toggle is worth flagging rather than hiding.
-	const hasTracesDestination = Boolean(
-		settings["settings.telemetry.tracesConnectionId"],
+	const hasTelemetryDestination = Boolean(
+		settings["settings.telemetry.tracesConnectionId"] ||
+			settings["settings.telemetry.metricsConnectionId"],
 	);
 	// The per-route timeout is only enforced when the project opted into the
 	// experimental worker timeouts, so asking for a value otherwise is a lie.
@@ -343,7 +343,7 @@ function CreateRoutePage() {
 									</>
 								)}
 								<SummaryItem
-									label="Tracing"
+									label="Telemetry"
 									value={tracingEnabled ? "Enabled" : "Disabled"}
 								/>
 							</dl>
@@ -367,14 +367,15 @@ function CreateRoutePage() {
 								<Checkbox
 									isSelected={tracingEnabled}
 									onChange={setTracingEnabled}
-									label="Enable request tracing"
-									description="Each request is recorded as an OpenTelemetry trace and exported to the project's traces destination — nothing is stored here. Exporting costs time per request: leave it off when latency is the priority, turn it on when you want visibility into what a request did."
+									label="Enable route telemetry"
+									description="Collect request telemetry for this route."
 								/>
-								{!hasTracesDestination && (
+								<RouteTelemetryHelp projectId={projectId} />
+								{tracingEnabled && !hasTelemetryDestination && (
 									<p className="text-xs text-warning">
-										This project has no traces destination yet, so traced
-										requests record no spans. Set one under Settings →
-										Telemetry.
+										This project has no traces or metrics destination, so this
+										route's telemetry is not exported. Configure one in Project
+										Settings → Telemetry.
 									</p>
 								)}
 							</div>

--- a/apps/server/deployments/compiledWorker.ts
+++ b/apps/server/deployments/compiledWorker.ts
@@ -25,6 +25,7 @@ import { closeNats } from "../src/db/nats";
 import { startJobWorker } from "../src/modules/jobs/consumer";
 import { enqueueJob } from "../src/modules/jobs/publisher";
 import type { JobEnvelope } from "../src/modules/jobs/types";
+import { publishTraceRun } from "../src/modules/telemetry/publisher";
 import {
 	OTLP_AUTH_HEADER_NAME,
 	OTLP_AUTH_HEADER_VALUE,
@@ -206,6 +207,9 @@ function onExecutionEvent(event: ExecutionEvent) {
 					"WORKER.jobs",
 				),
 			);
+		case "trace-finished":
+			// The execution process holds untrusted route code, never NATS credentials.
+			return void publishTraceRun(event.run);
 		case "heartbeat":
 			return watchdog.heartbeat();
 		case "execution-started":

--- a/apps/server/deployments/telemetryWorker.ts
+++ b/apps/server/deployments/telemetryWorker.ts
@@ -1,5 +1,5 @@
 import { initializeLogger, logger } from "@fluxify/common";
-import { drizzleInit } from "../src/db";
+import { db, drizzleInit } from "../src/db";
 import { initializeNats, closeNats, natsConnected } from "../src/db/nats";
 // project settings are read through the redis-backed cache
 import { initializeRedis } from "../src/db/redis";
@@ -8,6 +8,7 @@ import { loadAppConfig } from "../src/loaders/appconfigLoader";
 import { startTelemetryWorker } from "../src/modules/telemetry/consumer";
 import { resetProviders } from "../src/modules/telemetry/destinations";
 import { getEnv } from "../src/lib/env";
+import { integrationsEntity } from "../src/db/schema";
 
 /**
  * Telemetry worker. Drains recorded runs off NATS and exports them to each
@@ -21,9 +22,29 @@ import { getEnv } from "../src/lib/env";
 
 const healthPort = Number(getEnv("TELEMETRY_HEALTH_PORT")) || 5700;
 
+/** The admin server owns migrations; wait on a fresh stack instead of exiting. */
+async function waitForSchema(maxAttempts = 60, delayMs = 2_000): Promise<void> {
+	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+		try {
+			await db.select({ id: integrationsEntity.id }).from(integrationsEntity).limit(1);
+			return;
+		} catch (error) {
+			const message = String((error as Error)?.message ?? error);
+			if (!message.includes("42P01") && !/does not exist/i.test(message)) throw error;
+			logger.info(
+				`waiting for database schema (attempt ${attempt}/${maxAttempts})`,
+				"TELEMETRY",
+			);
+			await Bun.sleep(delayMs);
+		}
+	}
+	throw new Error("database schema not ready after waiting for migrations");
+}
+
 initializeLogger({ serviceName: "fluxify.worker.telemetry" });
 
 await drizzleInit();
+await waitForSchema();
 initializeRedis();
 await initializeNats();
 await loadAppConfig();

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -21,6 +21,7 @@
 		"build:worker:compiled": "bun run build:worker:compiled:supervisor && bun run build:worker:compiled:thread",
 		"build:worker:compiled:supervisor": "bun build deployments/compiledWorker.ts --outdir=dist --bundle --target bun --minify --sourcemap=linked --conditions=module",
 		"build:worker:compiled:thread": "bun build src/modules/requestRouter/executionProcess.ts --outdir=dist --bundle --target bun --minify --sourcemap=linked --conditions=module",
+		"build:worker:telemetry": "bun build deployments/telemetryWorker.ts --outdir=dist --bundle --target bun --minify --sourcemap=linked --conditions=module",
 		"postbuild": "bun run ./scripts/buildExtras.ts",
 		"db:generate": "bun x drizzle-kit generate",
 		"db:push": "bun x drizzle-kit push"

--- a/apps/server/src/modules/requestRouter/dispatchSupport.ts
+++ b/apps/server/src/modules/requestRouter/dispatchSupport.ts
@@ -1,0 +1,38 @@
+import type { RequestPayload } from "./types";
+import { DEFAULT_CONTENT_TYPES } from "../../lib/routeConfig";
+
+export type RouteExecutionObserver = {
+	onRouteStart(route: {
+		routeId: string;
+		projectId: string;
+		timeoutSeconds: number;
+	}): (() => void) | void;
+};
+
+export async function runWithRouteObserver<T>(
+	observer: RouteExecutionObserver | undefined,
+	route: { id: string; projectId?: string; timeoutSeconds?: number },
+	defaultTimeoutSeconds: number,
+	run: () => Promise<T>,
+): Promise<T> {
+	const finish = observer?.onRouteStart({
+		routeId: route.id,
+		projectId: route.projectId!,
+		timeoutSeconds: route.timeoutSeconds ?? defaultTimeoutSeconds,
+	});
+	try {
+		return await run();
+	} finally {
+		finish?.();
+	}
+}
+
+export async function readRouteBody(
+	payload: RequestPayload,
+	acceptedContentTypes?: string[],
+) {
+	if (!payload.bodyReader) return payload.body;
+	return payload.bodyReader.parse(
+		acceptedContentTypes ?? DEFAULT_CONTENT_TYPES,
+	);
+}

--- a/apps/server/src/modules/requestRouter/envelope.ts
+++ b/apps/server/src/modules/requestRouter/envelope.ts
@@ -1,0 +1,29 @@
+import { Context } from "hono";
+import { MAX_REQUEST_BODY_BYTES } from "../../lib/env";
+import { bodyReader } from "./requestBody";
+import type { RequestEnvelope } from "./types";
+
+/** Convert an HTTP request into the transport-neutral route envelope. */
+export async function envelopeFromHttp(
+	ctx: Context,
+): Promise<RequestEnvelope> {
+	const reader = bodyReader(ctx.req, MAX_REQUEST_BODY_BYTES);
+	const envelope: RequestEnvelope = {
+		trigger: {
+			kind: "route",
+			source: "http",
+			reply: ctx.req.header("x-fluxify-reply") === "async" ? "async" : "sync",
+			id: ctx.req.header("x-fluxify-id"),
+		},
+		payload: {
+			method: ctx.req.method,
+			path: ctx.req.path,
+			headers: ctx.req.header(),
+			query: ctx.req.query(),
+			body: null,
+			bodyReader: reader,
+		},
+	};
+	if (reader && envelope.trigger.reply === "async") await reader.materialize();
+	return envelope;
+}

--- a/apps/server/src/modules/requestRouter/executionProcess.ts
+++ b/apps/server/src/modules/requestRouter/executionProcess.ts
@@ -20,6 +20,7 @@ import { projectSettingsCache } from "../../loaders/projectSettingsLoader";
 import { workerTimeoutsEnabled } from "./workerTimeouts";
 import { AsyncExecutor } from "./asyncExecutor";
 import { executionRuntimeEnvironment } from "./executionEnvironment";
+import { RouteTraceRecorder } from "../telemetry/routeRecorder";
 
 let boot: ExecutionBootstrap | undefined;
 let monitoringEnabled = false;
@@ -103,12 +104,32 @@ async function handle(request: Request): Promise<Response> {
 	const ctx = createHttpContext(request);
 	const env = await envelopeFromHttp(ctx as any);
 	const observer = createObserver();
+	const traceFactory = {
+		start(route: {
+			routeId: string;
+			projectId: string;
+			routeVersion: string;
+			method: string;
+			path: string;
+		}) {
+			return new RouteTraceRecorder(route, (run) =>
+				send({ type: "trace-finished", run }),
+			);
+		},
+	};
 
 	if (env.trigger.reply === "async") {
 		const accepted = asyncExecutor?.submit(async () => {
 			// The HTTP response is already a 202. Do not retain the HTTP context or
 			// attempt late cookie/header writes while the detached route runs.
-			await dispatch(env, parser!, undefined, observer, compiledRouteValidators);
+			await dispatch(
+				env,
+				parser!,
+				undefined,
+				observer,
+				compiledRouteValidators,
+				traceFactory,
+			);
 		});
 		if (!accepted) {
 			return json(
@@ -125,9 +146,10 @@ async function handle(request: Request): Promise<Response> {
 			env,
 			parser,
 			ctx as any,
-			observer,
-			compiledRouteValidators,
-		);
+		observer,
+		compiledRouteValidators,
+		traceFactory,
+	);
 		return json(response.data, response.status, ctx.responseHeaders);
 	} catch (error) {
 		return json(

--- a/apps/server/src/modules/requestRouter/service.ts
+++ b/apps/server/src/modules/requestRouter/service.ts
@@ -15,6 +15,7 @@ import {
 	BlockOutput,
 	ContextVarsType,
 	TriggerContext,
+	type BlockTrace,
 } from "@fluxify/blocks";
 import { Context } from "hono";
 import { ContentfulStatusCode } from "hono/utils/http-status";
@@ -39,24 +40,24 @@ import {
 } from "../../loaders/integrationsLoader";
 import * as zodLib from "zod";
 import { projectSettingsCache } from "../../loaders/projectSettingsLoader";
-import type { RequestEnvelope, RequestPayload } from "./types";
-import { bodyReader, RequestBodyError } from "./requestBody";
-import { DEFAULT_CONTENT_TYPES } from "../../lib/routeConfig";
-import { MAX_REQUEST_BODY_BYTES } from "../../lib/env";
+import type { RequestEnvelope } from "./types";
+import { RequestBodyError } from "./requestBody";
+import {
+	readRouteBody,
+	runWithRouteObserver,
+	type RouteExecutionObserver,
+} from "./dispatchSupport";
+import {
+	startRouteTrace,
+	traceCompleter,
+	type RouteTraceFactory,
+} from "./traceLifecycle";
 
 dayjs.extend(dayjsUtc);
 
 export type HandleRequestType = {
 	data?: any;
 	status: ContentfulStatusCode;
-};
-
-export type RouteExecutionObserver = {
-	onRouteStart(route: {
-		routeId: string;
-		projectId: string;
-		timeoutSeconds: number;
-	}): (() => void) | void;
 };
 
 export type RouteValidatorResolver = (routeId: string) => {
@@ -68,6 +69,9 @@ export type RouteValidatorResolver = (routeId: string) => {
 // defined in ./types so it has no import cycle with the envelope; re-exported
 // here because the test-suites runner imports it from this module.
 export type { RequestOverrides } from "./types";
+export type { RouteExecutionObserver } from "./dispatchSupport";
+export type { RouteTrace, RouteTraceFactory } from "./traceLifecycle";
+export { envelopeFromHttp } from "./envelope";
 import type { RequestOverrides } from "./types";
 
 export const DEFAULT_ROUTE_TIMEOUT_SECONDS = 30;
@@ -87,35 +91,6 @@ const DEFAULT_TRIGGER: TriggerContext = {
 };
 
 /**
- * HTTP transport adapter: turn an incoming Hono request into a generic
- * envelope. This is the ONLY Hono-aware ingestion path; a NATS/BullMQ consumer
- * would build the same envelope from its message and call dispatch() directly.
- * `reply` is opt-in async via header so schedulers/crons can fire-and-forget.
- */
-export async function envelopeFromHttp(ctx: Context): Promise<RequestEnvelope> {
-	const reader = bodyReader(ctx.req, MAX_REQUEST_BODY_BYTES);
-	const envelope: RequestEnvelope = {
-		trigger: {
-			kind: "route",
-			source: "http",
-			reply: ctx.req.header("x-fluxify-reply") === "async" ? "async" : "sync",
-			id: ctx.req.header("x-fluxify-id"),
-		},
-		payload: {
-			method: ctx.req.method,
-			path: ctx.req.path,
-			headers: ctx.req.header(),
-			query: ctx.req.query(),
-			body: null,
-			bodyReader: reader,
-		},
-	};
-	// an async reply is sent before the route runs; the stream may not survive it
-	if (reader && envelope.trigger.reply === "async") await reader.materialize();
-	return envelope;
-}
-
-/**
  * Transport-agnostic entry point of the worker. Matches the route from the
  * envelope's payload and runs it. `httpCtx` is only for HTTP side-effects
  * (response cookies/headers); non-HTTP sources omit it and those calls no-op.
@@ -126,6 +101,7 @@ export async function dispatch(
 	httpCtx?: Context,
 	observer?: RouteExecutionObserver,
 	resolveValidators?: RouteValidatorResolver,
+	traceFactory?: RouteTraceFactory,
 ): Promise<HandleRequestType> {
 	const { payload, trigger, overrides } = env;
 	const path = parser.getRouteId(
@@ -141,26 +117,15 @@ export async function dispatch(
 		};
 	}
 
-	let body = payload.body;
-	if (payload.bodyReader) {
-		try {
-			body = await payload.bodyReader.parse(
-				path.acceptedContentTypes ?? DEFAULT_CONTENT_TYPES,
-			);
-		} catch (error) {
-			if (!(error instanceof RequestBodyError)) throw error;
-			return { status: error.status, data: { message: error.message } };
-		}
-	}
-
-	const finish = observer?.onRouteStart({
-		routeId: path.id,
-		projectId: path.projectId!,
-		timeoutSeconds: path.timeoutSeconds ?? DEFAULT_ROUTE_TIMEOUT_SECONDS,
-	});
+	// Keep recorder creation after matching so untraced routes preserve the old
+	// zero-work path.
+	const trace = startRouteTrace(path, payload, traceFactory);
+	const completeTrace = traceCompleter(trace);
 	try {
-		return await executeRouteInternal(
-			{
+		const body = await readRouteBody(payload, path.acceptedContentTypes);
+		const response = await runWithRouteObserver(observer, path, DEFAULT_ROUTE_TIMEOUT_SECONDS, () =>
+			executeRouteInternal(
+				{
 				id: path.id,
 				projectId: path.projectId!,
 				projectName: path.projectName!,
@@ -170,6 +135,7 @@ export async function dispatch(
 				paramsSchema: path.paramsSchema,
 				timeoutSeconds: path.timeoutSeconds,
 				validators: resolveValidators?.(path.id),
+				trace,
 			},
 			{
 				method: payload.method,
@@ -180,11 +146,20 @@ export async function dispatch(
 				params: path.routeParams || payload.params || {},
 			},
 			httpCtx,
-			overrides,
-			trigger,
-		);
-	} finally {
-		finish?.();
+					overrides,
+					trigger,
+				),
+			);
+		completeTrace(response.status >= 400 ? "failure" : "success", response.status);
+		return response;
+	} catch (error) {
+		if (error instanceof RequestBodyError) {
+			const response = { status: error.status, data: { message: error.message } };
+			completeTrace("failure", response.status);
+			return response;
+		}
+		completeTrace("failure", 500);
+		throw error;
 	}
 }
 
@@ -198,6 +173,7 @@ export async function executeRouteInternal(
 		querySchema?: any;
 		paramsSchema?: any;
 		timeoutSeconds?: number;
+		trace?: BlockTrace;
 		validators?: {
 			body?: CompiledRequestSchema;
 			query?: CompiledRequestSchema;
@@ -300,6 +276,7 @@ export async function executeRouteInternal(
 		httpClient,
 		trigger,
 		routeInfo.timeoutSeconds ?? DEFAULT_ROUTE_TIMEOUT_SECONDS,
+		routeInfo.trace,
 	);
 
 	try {
@@ -435,6 +412,7 @@ function createContext(
 	httpClient: HttpClient,
 	trigger: TriggerContext,
 	timeoutSeconds: number,
+	trace?: BlockTrace,
 ): BlockContext {
 	return {
 		apiId: routeInfo.id,
@@ -446,6 +424,7 @@ function createContext(
 		dbFactory,
 		httpClient,
 		trigger,
+		trace,
 		// The cloud logs block picks its own integration per block, so it resolves
 		// through here rather than through the project's logs destination. Only the
 		// legacy interpreted path used to supply this, which left the block throwing

--- a/apps/server/src/modules/requestRouter/tests/dispatch.spec.ts
+++ b/apps/server/src/modules/requestRouter/tests/dispatch.spec.ts
@@ -104,6 +104,59 @@ describe("dispatch", () => {
 		expect(res.data).toEqual({ message: "Route not found" });
 	});
 
+	it("attaches and completes a trace only when the matched route enables tracing", async () => {
+		const started: any[] = [];
+		const completed: any[] = [];
+		const trace = {
+			recordSpan() {},
+			enterCustomBlock() {
+				return { trace, close() {} };
+			},
+			complete(outcome: "success" | "failure", statusCode?: number) {
+				completed.push({ outcome, statusCode });
+			},
+		};
+		const parser = {
+			getRouteId: () => ({
+				id: "route-1",
+				projectId: "project-1",
+				projectName: "Project",
+				routeVersion: "route-version",
+				tracingEnabled: true,
+			}),
+		} as unknown as HttpRouteParser;
+		setBlocksExecutor(async (_target, context) => {
+			expect(context.trace).toBe(trace);
+			return { successful: true, output: { body: "ok" } } as any;
+		});
+
+		const response = await dispatch(
+			await envelopeFromHttp(fakeCtx({ method: "GET", path: "/orders" })),
+			parser,
+			undefined,
+			undefined,
+			undefined,
+			{
+				start(route) {
+					started.push(route);
+					return trace;
+				},
+			},
+		);
+
+		expect(response.status).toBe(200);
+		expect(started).toEqual([
+			{
+				routeId: "route-1",
+				projectId: "project-1",
+				routeVersion: "route-version",
+				method: "GET",
+				path: "/orders",
+			},
+		]);
+		expect(completed).toEqual([{ outcome: "success", statusCode: 200 }]);
+	});
+
 	it("uses a supplied artifact-time validator before creating route resources", async () => {
 		let validations = 0;
 		const parser = {

--- a/apps/server/src/modules/requestRouter/threadTypes.ts
+++ b/apps/server/src/modules/requestRouter/threadTypes.ts
@@ -1,6 +1,7 @@
 import type { ArtifactEntry } from "./compiledRuntime";
 import type { AsyncExecutorLimits } from "./asyncExecutor";
 import type { JobEnvelope } from "../jobs/types";
+import type { TraceRunPayload } from "@fluxify/common/otlp";
 
 /** handed to the isolated execution process over Bun IPC at spawn */
 export type ExecutionBootstrap = {
@@ -40,6 +41,8 @@ export type ExecutionEvent =
 	| { type: "job-finished"; id: string; error?: string }
 	/** user code asked to queue work; only the supervisor can publish it */
 	| { type: "enqueue-job"; job: JobEnvelope }
+	/** completed in untrusted execution; supervisor owns the NATS hand-off */
+	| { type: "trace-finished"; run: TraceRunPayload }
 	| {
 			type: "execution-started";
 			requestId: string;

--- a/apps/server/src/modules/requestRouter/traceLifecycle.ts
+++ b/apps/server/src/modules/requestRouter/traceLifecycle.ts
@@ -1,0 +1,57 @@
+import type { BlockTrace } from "@fluxify/blocks";
+import type { RequestPayload } from "./types";
+
+/** A request-local recorder supplied by the isolated execution process. */
+export type RouteTrace = BlockTrace & {
+	complete(outcome: "success" | "failure", statusCode?: number): void;
+};
+
+export type RouteTraceFactory = {
+	start(route: {
+		routeId: string;
+		projectId: string;
+		routeVersion: string;
+		method: string;
+		path: string;
+	}): RouteTrace;
+};
+
+type TraceableRoute = {
+	tracingEnabled?: boolean;
+	id: string;
+	projectId?: string;
+	routeVersion?: string;
+};
+
+/** Keep recorder failures isolated from the route response path. */
+export function startRouteTrace(
+	route: TraceableRoute,
+	payload: RequestPayload,
+	traceFactory?: RouteTraceFactory,
+): RouteTrace | undefined {
+	if (!route.tracingEnabled) return;
+	try {
+		return traceFactory?.start({
+			routeId: route.id,
+			projectId: route.projectId!,
+			routeVersion: route.routeVersion ?? "",
+			method: payload.method,
+			path: payload.path,
+		});
+	} catch {
+		// Tracing is diagnostic data; a recorder bug must not fail traffic.
+	}
+}
+
+export function traceCompleter(trace?: RouteTrace) {
+	let complete = false;
+	return (outcome: "success" | "failure", statusCode?: number) => {
+		if (complete) return;
+		complete = true;
+		try {
+			trace?.complete(outcome, statusCode);
+		} catch {
+			// A failed IPC hand-off is telemetry loss, never a failed route.
+		}
+	};
+}

--- a/apps/server/src/modules/telemetry/publisher.ts
+++ b/apps/server/src/modules/telemetry/publisher.ts
@@ -1,0 +1,25 @@
+import { logger } from "@fluxify/common";
+import type { TraceRunPayload } from "@fluxify/common/otlp";
+import { StringCodec } from "nats";
+import { natsConnection } from "../../db/nats";
+import { traceRunSubject } from "./subjects";
+
+const sc = StringCodec();
+
+/**
+ * Best-effort by design: trace publication must not delay or fail a request.
+ * `msgID` makes an IPC resend of the same completed run idempotent in NATS.
+ */
+export async function publishTraceRun(run: TraceRunPayload): Promise<void> {
+	try {
+		const subject = traceRunSubject(run.projectId, run.runId);
+		await natsConnection()
+			.jetstream()
+			.publish(subject, sc.encode(JSON.stringify(run)), { msgID: run.runId });
+	} catch (error) {
+		logger.error(
+			`[telemetry] failed to publish route run ${run.runId}: ${String(error)}`,
+			"TELEMETRY.publish",
+		);
+	}
+}

--- a/apps/server/src/modules/telemetry/routeRecorder.spec.ts
+++ b/apps/server/src/modules/telemetry/routeRecorder.spec.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "bun:test";
+import { RouteTraceRecorder } from "./routeRecorder";
+
+const route = {
+	projectId: "project-1",
+	routeId: "route-1",
+	routeVersion: "2026-08-24T00:00:00.000Z",
+	method: "POST",
+	path: "/orders",
+};
+
+describe("RouteTraceRecorder", () => {
+	it("emits one bounded, serializable completed route run", () => {
+		const runs: any[] = [];
+		const recorder = new RouteTraceRecorder(route, (run) => runs.push(run));
+
+		recorder.recordSpan({
+			blockId: "entry",
+			blockType: "entrypoint",
+			input: { id: 42n },
+			output: { accepted: true },
+			startedAt: 10,
+			endedAt: 15,
+			outcome: "success",
+		});
+		recorder.complete("success", 201);
+		recorder.complete("failure", 500);
+
+		expect(runs).toHaveLength(1);
+		expect(runs[0]).toMatchObject({
+			...route,
+			statusCode: 201,
+			outcome: "success",
+			spans: [
+				{
+					seq: 0,
+					blockId: "entry",
+					input: { id: "42" },
+					output: { accepted: true },
+				},
+			],
+		});
+	});
+
+	it("links synchronous custom-block spans to their invoking block", () => {
+		const runs: any[] = [];
+		const recorder = new RouteTraceRecorder(route, (run) => runs.push(run));
+		const scope = recorder.enterCustomBlock({
+			blockId: "invoke",
+			name: "address_lookup",
+			detached: false,
+		});
+
+		scope.trace.recordSpan({
+			blockId: "custom-entry",
+			blockType: "entrypoint",
+			input: null,
+			output: null,
+			startedAt: 10,
+			endedAt: 12,
+			outcome: "success",
+		});
+		recorder.recordSpan({
+			blockId: "invoke",
+			blockType: "custom_block",
+			input: null,
+			output: null,
+			startedAt: 9,
+			endedAt: 13,
+			outcome: "success",
+		});
+		recorder.complete("success", 200);
+
+		expect(runs[0].spans).toEqual([
+			expect.objectContaining({
+				seq: 1,
+				parentSeq: 0,
+			}),
+			expect.objectContaining({ seq: 0, blockId: "invoke" }),
+		]);
+	});
+
+	it("publishes a detached custom block as a linked, independent run", () => {
+		const runs: any[] = [];
+		const recorder = new RouteTraceRecorder(route, (run) => runs.push(run));
+		const scope = recorder.enterCustomBlock({
+			blockId: "notify",
+			name: "send_email",
+			detached: true,
+		});
+		scope.trace.recordSpan({
+			blockId: "email",
+			blockType: "http_request",
+			input: null,
+			output: null,
+			startedAt: 10,
+			endedAt: 12,
+			outcome: "success",
+		});
+		scope.close("failure", new Error("mail provider unavailable"));
+		recorder.complete("success", 202);
+
+		expect(runs).toHaveLength(2);
+		expect(runs[0]).toMatchObject({
+			parentRunId: recorder.runId,
+			parentSeq: 0,
+			outcome: "failure",
+		});
+		expect(runs[1]).toMatchObject({ runId: recorder.runId, statusCode: 202 });
+	});
+});

--- a/apps/server/src/modules/telemetry/routeRecorder.ts
+++ b/apps/server/src/modules/telemetry/routeRecorder.ts
@@ -1,0 +1,244 @@
+import type { BlockTrace, BlockTraceSpan, CustomBlockScope } from "@fluxify/blocks";
+import type { TraceRunPayload, TraceSpanRecord } from "@fluxify/common/otlp";
+
+const MAX_SPANS_PER_RUN = 1_000;
+const MAX_RUN_BYTES = 256 * 1024;
+const MAX_VALUE_BYTES = 8 * 1024;
+
+export type RecordedRoute = {
+	projectId: string;
+	routeId: string;
+	routeVersion: string;
+	method: string;
+	path: string;
+};
+
+export type TraceOutcome = "success" | "failure";
+
+export type RequestTrace = BlockTrace & {
+	complete(outcome: TraceOutcome, statusCode?: number): void;
+};
+
+type TraceScope = {
+	parentSeq?: number;
+	customBlockId?: string;
+};
+
+type TraceState = {
+	nextSeq: number;
+	spans: TraceSpanRecord[];
+	pendingInvocations: Map<string, number[]>;
+	bytes: number;
+	droppedSpans: number;
+	truncated: boolean;
+};
+
+/**
+ * A request-local span buffer. It has no broker connection and no credentials:
+ * its only side effect is handing a completed, bounded payload to its owner.
+ */
+export class RouteTraceRecorder implements RequestTrace {
+	readonly runId = crypto.randomUUID();
+	private readonly startedAtWallMs = Date.now();
+	private readonly perfOrigin = performance.now();
+	private readonly state: TraceState = {
+		nextSeq: 0,
+		spans: [],
+		pendingInvocations: new Map(),
+		bytes: 0,
+		droppedSpans: 0,
+		truncated: false,
+	};
+	private completed = false;
+
+	constructor(
+		private readonly route: RecordedRoute,
+		private readonly onComplete: (run: TraceRunPayload) => void,
+		private readonly parent?: { runId: string; seq: number },
+	) {}
+
+	recordSpan(span: BlockTraceSpan): void {
+		this.record(span, {});
+	}
+
+	enterCustomBlock(invocation: {
+		blockId: string;
+		name: string;
+		detached: boolean;
+	}): CustomBlockScope {
+		return this.enter(invocation, {});
+	}
+
+	complete(outcome: TraceOutcome, statusCode?: number): void {
+		if (this.completed) return;
+		this.completed = true;
+
+		const run: TraceRunPayload = {
+			runId: this.runId,
+			projectId: this.route.projectId,
+			routeId: this.route.routeId,
+			routeVersion: this.route.routeVersion,
+			method: this.route.method,
+			path: this.route.path,
+			startedAtWallMs: this.startedAtWallMs,
+			perfOrigin: this.perfOrigin,
+			endedAt: performance.now(),
+			outcome,
+			...(statusCode === undefined ? {} : { statusCode }),
+			...(this.state.truncated ? { truncated: true } : {}),
+			...(this.state.droppedSpans > 0
+				? { droppedSpans: this.state.droppedSpans }
+				: {}),
+			...(this.parent
+				? { parentRunId: this.parent.runId, parentSeq: this.parent.seq }
+				: {}),
+			spans: this.state.spans,
+		};
+
+		try {
+			this.onComplete(run);
+		} catch {
+			// Sending telemetry must never affect a route response.
+		}
+	}
+
+	private enter(
+		invocation: { blockId: string; name: string; detached: boolean },
+		scope: TraceScope,
+	): CustomBlockScope {
+		const seq = this.state.nextSeq++;
+		const pending = this.state.pendingInvocations.get(invocation.blockId) ?? [];
+		pending.push(seq);
+		this.state.pendingInvocations.set(invocation.blockId, pending);
+
+		if (invocation.detached) {
+			const detached = new RouteTraceRecorder(
+				this.route,
+				this.onComplete,
+				{ runId: this.runId, seq },
+			);
+			return {
+				trace: detached,
+				close: (outcome: TraceOutcome = "success", error?: unknown) => {
+					void error;
+					detached.complete(outcome);
+				},
+			};
+		}
+
+		const nested = new NestedTrace(this, {
+			parentSeq: seq,
+		});
+		return { trace: nested, close: () => {} };
+	}
+
+	private record(span: BlockTraceSpan, scope: TraceScope): void {
+		if (this.completed || this.state.spans.length >= MAX_SPANS_PER_RUN) {
+			this.drop();
+			return;
+		}
+
+		const pending = this.state.pendingInvocations.get(span.blockId);
+		const seq = pending?.shift() ?? this.state.nextSeq++;
+		if (pending?.length === 0) this.state.pendingInvocations.delete(span.blockId);
+
+		const input = safeValue(span.input);
+		const output = safeValue(span.output);
+		const record: TraceSpanRecord = {
+			seq,
+			...(scope.parentSeq === undefined ? {} : { parentSeq: scope.parentSeq }),
+			blockId: span.blockId,
+			blockType: span.blockType,
+			...(scope.customBlockId ? { customBlockId: scope.customBlockId } : {}),
+			startedAt: span.startedAt,
+			endedAt: span.endedAt,
+			outcome: span.outcome,
+			...(span.branch ? { branch: span.branch } : {}),
+			...(input.value === undefined ? {} : { input: input.value }),
+			...(output.value === undefined ? {} : { output: output.value }),
+			...(span.error === undefined ? {} : { error: String(span.error) }),
+			...(input.truncated || output.truncated ? { truncated: true } : {}),
+		};
+		const bytes = byteLength(record);
+		if (this.state.bytes + bytes > MAX_RUN_BYTES) {
+			this.drop();
+			return;
+		}
+		this.state.bytes += bytes;
+		this.state.spans.push(record);
+		if (record.truncated) this.state.truncated = true;
+	}
+
+	private drop() {
+		this.state.droppedSpans++;
+		this.state.truncated = true;
+	}
+
+	/** Internal bridge for nested compiled custom blocks. */
+	_nestedRecord(span: BlockTraceSpan, scope: TraceScope) {
+		this.record(span, scope);
+	}
+
+	/** Internal bridge for nested compiled custom blocks. */
+	_nestedEnter(
+		invocation: { blockId: string; name: string; detached: boolean },
+		scope: TraceScope,
+	) {
+		return this.enter(invocation, scope);
+	}
+}
+
+class NestedTrace implements BlockTrace {
+	constructor(
+		private readonly owner: RouteTraceRecorder,
+		private readonly scope: TraceScope,
+	) {}
+
+	recordSpan(span: BlockTraceSpan): void {
+		this.owner._nestedRecord(span, this.scope);
+	}
+
+	enterCustomBlock(invocation: {
+		blockId: string;
+		name: string;
+		detached: boolean;
+	}): CustomBlockScope {
+		return this.owner._nestedEnter(invocation, this.scope);
+	}
+}
+
+function safeValue(value: unknown): { value: unknown; truncated: boolean } {
+	if (value === undefined) return { value: undefined, truncated: false };
+	const seen = new WeakSet<object>();
+	let text: string | undefined;
+	try {
+		text = JSON.stringify(value, (_key, item) => {
+			if (typeof item === "bigint") return item.toString();
+			if (item instanceof Error) return String(item);
+			if (typeof item === "function" || typeof item === "symbol") return String(item);
+			if (item && typeof item === "object") {
+				if (seen.has(item)) return "[Circular]";
+				seen.add(item);
+			}
+			return item;
+		});
+	} catch {
+		text = JSON.stringify(String(value));
+	}
+	if (text === undefined) return { value: String(value), truncated: false };
+	if (byteLength(text) > MAX_VALUE_BYTES) {
+		return {
+			value: `${text.slice(0, MAX_VALUE_BYTES)}…`,
+			truncated: true,
+		};
+	}
+	try {
+		return { value: JSON.parse(text), truncated: false };
+	} catch {
+		return { value: text, truncated: false };
+	}
+}
+
+function byteLength(value: unknown) {
+	return new TextEncoder().encode(JSON.stringify(value)).byteLength;
+}

--- a/docker/admin/Dockerfile
+++ b/docker/admin/Dockerfile
@@ -78,7 +78,7 @@ COPY scripts/setup-hooks.ts scripts/setup-hooks.ts
 RUN bun install --frozen-lockfile
 
 # ------------------------------------------------------------------------------
-# Stage 2: build — server (standalone), web, ai-gateway. No request worker.
+# Stage 2: build — server (standalone), telemetry worker, web, ai-gateway.
 # ------------------------------------------------------------------------------
 FROM deps AS build
 WORKDIR /app
@@ -91,6 +91,10 @@ RUN bun install --frozen-lockfile
 # Turbo builds workspace packages + server standalone (with schema.sql) + web
 # + ai-gateway.
 RUN bun run build
+
+# Telemetry is control-plane work: it resolves project destinations and exports
+# completed route runs without giving those credentials to execution processes.
+RUN bun run --cwd apps/server build:worker:telemetry
 
 # Next.js standalone output does not include these; copy them in.
 WORKDIR /app/apps/web

--- a/docker/admin/entrypoint.sh
+++ b/docker/admin/entrypoint.sh
@@ -6,6 +6,19 @@ echo "[admin] Starting Fluxify control plane..."
 pids=""
 start() { "$@" & pids="$pids $!"; }
 
+wait_until() {
+	_label="$1"
+	shift
+	_attempt=0
+	while [ "$_attempt" -lt 60 ]; do
+		if "$@" >/dev/null 2>&1; then return 0; fi
+		_attempt=$((_attempt + 1))
+		sleep 1
+	done
+	echo "[admin] $_label did not become ready" >&2
+	exit 1
+}
+
 # This shell is PID 1 (no tini), so it must both install a signal handler AND
 # forward it to the children — otherwise SIGTERM is dropped and `docker stop`
 # hangs until SIGKILL, leaving the services orphaned.
@@ -19,6 +32,14 @@ trap term TERM INT
 
 # Admin API server (control plane; no builtin worker)
 start bun --cwd=/app/server standalone.js
+
+# The admin server owns migrations. Do not let the telemetry worker query a
+# freshly created database before those tables exist.
+wait_until "admin server" wget -qO- http://127.0.0.1:5500/_/admin/api/public-settings
+
+# Route telemetry consumer. It shares the control plane's database and NATS
+# access, while compiled request workers only publish completed runs over IPC.
+start bun --cwd=/app/server telemetryWorker.js
 
 # Next.js admin UI
 start bun --cwd=/app/web apps/web/server.js

--- a/docker/kit/Dockerfile
+++ b/docker/kit/Dockerfile
@@ -132,6 +132,7 @@ RUN bun run build --filter=!@fluxify/web
 # it at runtime. compiledWorker.js looks for ./executionProcess.js beside itself,
 # so this flat sibling layout in dist/ is load-bearing — do not nest it.
 RUN bun run --cwd apps/server build:worker:compiled
+RUN bun run --cwd apps/server build:worker:telemetry
 
 # AI Gateway documentation search index.
 WORKDIR /app/apps/ai-gateway

--- a/docker/kit/entrypoint.sh
+++ b/docker/kit/entrypoint.sh
@@ -208,6 +208,10 @@ start server bun --cwd=/app/server standalone.js
 wait_until "admin server" \
 	wget -qO- "http://127.0.0.1:${SERVER_PORT:-5500}/_/admin/api/public-settings"
 
+# Telemetry is admin-plane work: it drains route runs from JetStream and exports
+# them using each project's configured destination.
+start telemetry bun --cwd=/app/server telemetryWorker.js
+
 # Compiled request worker — serves user API traffic from those artifacts.
 #
 # It serves exactly one project, so it cannot start before a project exists.

--- a/docs/blog/posts/local-setup.md
+++ b/docs/blog/posts/local-setup.md
@@ -183,9 +183,10 @@ You rarely need the full stack running. Start only what you're touching:
 
 | Focus area | Command | What it starts |
 | :--- | :--- | :--- |
-| **Full stack** | `bun run dev` | Server, worker, web, AI gateway, docs |
+| **Full stack** | `bun run dev` | Server, request worker, telemetry worker, web, AI gateway, docs |
 | **Backend server** | `bun run dev:server` | Admin control plane, watch mode |
 | **Request worker** | `bun run dev:worker` | Compiled worker (needs `WORKER_PROJECT_ID`) |
+| **Telemetry worker** | `bun run dev:telemetry` | Exports traced route runs to project destinations |
 | **Legacy worker** | `bun run dev:worker:dag` | Graph interpreter — for comparison only |
 | **Visual editor** | `bun run dev:web` | The dashboard app |
 | **AI gateway** | `bun run dev:ai` | AI agent harness and providers |

--- a/package.json
+++ b/package.json
@@ -3,10 +3,11 @@
 	"version": "1.0.0",
 	"type": "module",
 	"scripts": {
-		"dev": "bun --parallel 'bun run dev:server' 'bun run dev:worker' 'bun run dev:portal' 'bun run dev:ai' 'bun run dev:docs'",
+		"dev": "bun --parallel 'bun run dev:server' 'bun run dev:worker' 'bun run dev:telemetry' 'bun run dev:portal' 'bun run dev:ai' 'bun run dev:docs'",
 		"dev:server": "bun run --env-file=.env --watch ./apps/server/deployments/standalone.ts",
 		"dev:worker": "bun run --env-file=.env --watch ./apps/server/deployments/compiledWorker.ts",
 		"dev:worker:dag": "bun run --env-file=.env --watch ./apps/server/deployments/worker.ts",
+		"dev:telemetry": "bun run --env-file=.env --watch ./apps/server/deployments/telemetryWorker.ts",
 		"dev:portal": "turbo run dev --filter=@fluxify/portal",
 		"dev:ai": "bun run --env-file=.env --watch ./apps/ai-gateway/src/server.ts",
 		"dev:docs": "vitepress dev docs",

--- a/packages/blocks/baseBlock.ts
+++ b/packages/blocks/baseBlock.ts
@@ -44,7 +44,8 @@ export type BlockTraceSpan = {
 export type CustomBlockScope = {
 	/** the trace the nested graph records into */
 	trace: BlockTrace;
-	close(): void;
+	/** detached scopes use the settled invocation outcome for their own run */
+	close(outcome?: "success" | "failure", error?: unknown): void;
 };
 
 /**

--- a/packages/blocks/builtin/customBlock.ts
+++ b/packages/blocks/builtin/customBlock.ts
@@ -87,7 +87,11 @@ function traced(
 	// context — mutating the caller's would follow the request back out
 	const child =
 		scope.trace === context.trace ? context : { ...context, trace: scope.trace };
-	return { context: child, close: () => scope.close() };
+	return {
+		context: child,
+		close: (outcome?: "success" | "failure", error?: unknown) =>
+			scope.close(outcome, error),
+	};
 }
 
 /**
@@ -126,12 +130,15 @@ export function invokeCustomBlockAsync(
 ) {
 	const scope = traced(context, name, blockId, true);
 	lookup(name)(scope.context, args)
-		.catch((error) => {
-			logger.error(`Async custom block '${name}' failed`, "BLOCKS.customBlock", {
-				error,
-			});
-		})
-		.finally(() => scope.close());
+		.then(
+			() => scope.close("success"),
+			(error) => {
+				scope.close("failure", error);
+				logger.error(`Async custom block '${name}' failed`, "BLOCKS.customBlock", {
+					error,
+				});
+			},
+		)
 }
 
 /**


### PR DESCRIPTION
## Summary
- record bounded route trace runs and pass them from execution processes to the telemetry worker
- export route traces in OTLP batches and derive route metrics from the same completed run
- start the telemetry worker in local development and Docker deployments
- present one route-level Telemetry control with destination-aware help and a link to Project Settings

## Validation
- un run lint
- un run test:unit
- focused recorder, dispatcher, and compiler tracing tests
- production portal build

Fixes #207