### PR TITLE
fix(ui): improve AI harness stats display layout and behavior

### DIFF
--- a/apps/portal/src/components/ai/AiMessage.tsx
+++ b/apps/portal/src/components/ai/AiMessage.tsx
@@ -16,7 +16,7 @@ export function AiMessage({ response, status, usage }: { response?: string | nul
 			{response && (
 				<div className="w-full">
 					<MarkdownViewer content={response} />
-					{isCompleted && <HarnessUsageSummary usage={usage} />}
+					<HarnessUsageSummary usage={usage} />
 				</div>
 			)}
 		</div>

--- a/apps/portal/src/components/ai/ConversationPage.tsx
+++ b/apps/portal/src/components/ai/ConversationPage.tsx
@@ -324,6 +324,7 @@ export function ConversationPage() {
 
 			<div className="sticky bottom-0 px-4 pb-2 pt-4 bg-background relative">
 				<ScrollToBottomButton isVisible={!isAtBottom} onClick={() => scrollToBottom("smooth")} />
+				<HarnessLiveStats conversationId={conversationId} />
 				<div className="mx-auto w-full max-w-[65%]">
 					{isArchived ? (
 						<div className="w-full rounded-2xl border border-border bg-surface p-4 text-center text-sm text-muted">
@@ -346,7 +347,6 @@ export function ConversationPage() {
 						/>
 					)}
 				</div>
-				<HarnessLiveStats conversationId={conversationId} />
 			</div>
 			{isPlanReviewMode && planText && (
 				<PlanReviewModal

--- a/apps/portal/src/components/ai/HarnessLiveStats.tsx
+++ b/apps/portal/src/components/ai/HarnessLiveStats.tsx
@@ -26,16 +26,16 @@ export function HarnessLiveStats({ conversationId }: { conversationId: string })
 		return () => window.clearInterval(interval);
 	}, [stats, run?.isTerminal]);
 
-	if (!stats || run?.isTerminal) return null;
-	const elapsedMs = stats.elapsedMs + Math.max(0, now - (run.statsReceivedAt ?? now));
+	const isVisible = stats && !run?.isTerminal;
+	const elapsedMs = stats ? stats.elapsedMs + Math.max(0, now - (run.statsReceivedAt ?? now)) : 0;
 
 	return (
-		<div className="mx-auto mt-2 flex w-full max-w-[65%] items-center justify-center gap-2 text-xs font-medium tracking-wide text-muted">
-			TOOL CALLS: {formatNumber(stats.toolCalls)} <span aria-hidden="true">|</span>{" "}
+		<div className={`mx-auto mb-2 flex w-full max-w-[65%] items-center justify-center gap-2 text-xs font-medium tracking-wide transition-opacity duration-300 ${isVisible ? 'opacity-100 text-muted' : 'opacity-0 pointer-events-none'}`}>
+			TOOL CALLS: {formatNumber(stats?.toolCalls ?? 0)} <span aria-hidden="true">|</span>{" "}
 			TIME ELAPSED: {formatElapsed(elapsedMs)} <span aria-hidden="true">|</span>{" "}
 			<span>TOKENS:</span>
-			<span className="flex items-center gap-0.5"><TbArrowDown size={14} /> {formatNumber(stats.inputTokens)}</span>
-			<span className="flex items-center gap-0.5"><TbArrowUp size={14} /> {formatNumber(stats.outputTokens)}</span>
+			<span className="flex items-center gap-0.5" title="Input tokens"><TbArrowUp size={14} /> {formatNumber(stats?.inputTokens ?? 0)}</span>
+			<span className="flex items-center gap-0.5" title="Output tokens"><TbArrowDown size={14} /> {formatNumber(stats?.outputTokens ?? 0)}</span>
 		</div>
 	);
 }

--- a/apps/portal/src/components/ai/HarnessUsageSummary.tsx
+++ b/apps/portal/src/components/ai/HarnessUsageSummary.tsx
@@ -31,8 +31,8 @@ export function HarnessUsageSummary({ usage }: { usage?: HarnessUsage | null }) 
 			<span className="flex items-center gap-1"><TbClock size={14} /> {formatElapsed(usage.elapsedMs ?? 0)}</span>
 			<span className="flex items-center gap-1"><TbTools size={14} /> {formatNumber(usage.toolCalls ?? 0)} tools</span>
 			<span className="flex items-center gap-1">Tokens:</span>
-			<span className="flex items-center gap-1"><TbArrowDown size={14} /> {formatNumber(inputTokens)}</span>
-			<span className="flex items-center gap-1"><TbArrowUp size={14} /> {formatNumber(outputTokens)}</span>
+			<span className="flex items-center gap-1" title="Input tokens"><TbArrowUp size={14} /> {formatNumber(inputTokens)}</span>
+			<span className="flex items-center gap-1" title="Output tokens"><TbArrowDown size={14} /> {formatNumber(outputTokens)}</span>
 		</div>
 	);
 }


### PR DESCRIPTION
This PR fixes the UI issues around the AI harness stats display in PromptEditor and AiMessage.

### What changed:
- Moved HarnessLiveStats to the top of PromptEditor instead of bottom.
- Modified the visibility toggle of HarnessLiveStats to use opacity-0 instead of unmounting from DOM, which prevents layout shifts.
- Removed the strict isCompleted requirement in AiMessage so stats are displayed even on failed or interrupted runs (as long as usage data is available).
- Swapped TbArrowDown and TbArrowUp icons in both summary and live stats so that input uses an up arrow and output uses a down arrow.
- Added tooltips to these icons for better UX.