### PR TITLE
fix(harness): stabilize artifact previews

### DIFF
--- a/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/normalize.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/normalize.ts
@@ -61,6 +61,7 @@ export type RouteConfigPayload = {
 		bodySchema?: unknown;
 		paramsSchema?: unknown;
 		querySchema?: unknown;
+		acceptedContentTypes?: string[] | null;
 	} | null;
 };
 
@@ -129,6 +130,7 @@ export function routeOpFromPayload(payload: RouteConfigPayload, projectId: strin
 				bodySchema: data.bodySchema,
 				querySchema: data.querySchema,
 				paramsSchema: data.paramsSchema,
+				acceptedContentTypes: data.acceptedContentTypes,
 			}),
 		},
 	};

--- a/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/service.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/service.ts
@@ -465,6 +465,9 @@ export async function applySubArtifact(
 ) {
 	const row = await getSubArtifactById(conversationId, subArtifactId);
 	if (!row) throw new NotFoundError("Sub-artifact not found");
+	// A route create may already have landed its paired canvas inline. Retrying
+	// that canvas must not generate a second set of block ids and save it again.
+	if (row.appliedAt) return row;
 
 	const ctx = newApplyContext(conversationId, projectId, userId);
 	const siblings = await getArtifactSubArtifacts(conversationId, row.artifactId);

--- a/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/tests/artifacts.spec.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/tests/artifacts.spec.ts
@@ -124,6 +124,19 @@ describe("Harness Artifacts Service", () => {
 		expect(result?.appliedAt).toBeInstanceOf(Date);
 	});
 
+	it("does not reapply an already-landed sub-artifact", async () => {
+		const appliedAt = new Date();
+		spyOn(repository, "getSubArtifactById").mockResolvedValue(
+			routeRow({ appliedAt }) as never,
+		);
+
+		const result = await applySubArtifact("user1", "conv1", "proj1", "route-sub");
+
+		expect(result?.appliedAt).toBe(appliedAt);
+		expect(bus).toHaveLength(0);
+		expect(repository.markSubArtifactsApplied).not.toHaveBeenCalled();
+	});
+
 	it("creates a route with its paired canvas inline", async () => {
 		spyOn(repository, "getSubArtifactById").mockResolvedValue(routeRow() as never);
 		spyOn(repository, "getArtifactSubArtifacts").mockResolvedValue([

--- a/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/agent.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/agent.ts
@@ -11,6 +11,7 @@ import { createGetBlockSchemasTool } from "../../../tools/getBlockSchemas";
 import { createGetAgentOutputTool } from "../../../tools/getAgentOutput";
 import { fenceUntrusted } from "../../../internal/untrusted";
 import { blockBuilderSchema } from "./schemas";
+import { validateBlockBuilderOutput } from "./validator";
 import {
 	pendingCustomBlocks,
 	type PendingCustomBlock,
@@ -35,7 +36,9 @@ export class BlockBuilderAgent extends BaseAgent {
 	 * knows the answer: if the id names no live route and this run configured
 	 * exactly one, that route is the target.
 	 */
-	private async reconcileRouteTarget<T extends { targetType?: string; targetId?: string }>(
+	private async reconcileRouteTarget<
+		T extends { targetType?: string | null; targetId?: string | null },
+	>(
 		result: T,
 		projectId: string,
 	): Promise<T> {
@@ -249,6 +252,8 @@ export class BlockBuilderAgent extends BaseAgent {
 			userQuery,
 			agentNode: AgentNode.BLOCK_BUILDER,
 			agentId: activeTask.id,
+			validateResult: (candidate) =>
+				validateBlockBuilderOutput(candidate, activeTask.id, this.state),
 		})) as z.infer<typeof blockBuilderSchema>;
 
 		const shortIdMap = new Map(
@@ -274,14 +279,10 @@ export class BlockBuilderAgent extends BaseAgent {
 			},
 		});
 
-		const currentResults = this.state.orchestratorState?.subAgentResults || {};
-
 		return {
 			currentAgent: AgentNode.BLOCK_BUILDER,
 			orchestratorState: {
-				...this.state.orchestratorState,
 				subAgentResults: {
-					...currentResults,
 					[activeTask.id]: processedResponse,
 				},
 			},

--- a/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/promptHelpers.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/promptHelpers.ts
@@ -130,7 +130,6 @@ ${CUSTOM_BLOCK_EXECUTION_CONTRACT}
      - 'fromEdge': The source block ID of the edge being changed.
      - 'fromHandle': The handle on the source block (e.g., 'source', 'success', 'failure').
      - 'toEdge': The new target block ID.
-     - 'toHandle': The handle on the new target block.
    - **'block_remove'**: Delete one or more blocks (and their associated edges) from the canvas.
      - 'blocks': Array of block IDs to remove.
      - 'reason': A short explanation for why the blocks are being removed.
@@ -148,7 +147,7 @@ ${CUSTOM_BLOCK_EXECUTION_CONTRACT}
 
 ### Output Contract
 
-Use these exact property names — do not rename or omit them:
+For a successful result, use these exact property names — do not rename or omit them:
 
 \`\`\`json
 {
@@ -171,7 +170,8 @@ Use these exact property names — do not rename or omit them:
 
 - The block's type goes in \`blockType\` (NOT \`type\`).
 - \`connections\` and \`canvasChanges\` are always present — use \`[]\` when empty.
-- Set \`status\` to 'impossible' (with a short \`reasoning\`) only when the canvas genuinely cannot be built.
+- For \`status: "success"\`, include targetType, targetId, blocks and canvasChanges; add at least one block or canvas change.
+- For \`status: "impossible"\`, include only a short \`reasoning\` explaining why the canvas cannot be built. It is terminal and will not be retried.
 
 ### Platform Reference (pre-loaded — do not search for any of this)
 

--- a/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/schemas.spec.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/schemas.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "bun:test";
+import { blockBuilderSchema } from "./schemas";
+
+describe("blockBuilderSchema", () => {
+	it("accepts an impossible result with only its reason", () => {
+		expect(
+			blockBuilderSchema.safeParse({
+				status: "impossible",
+				reasoning: "The requested provider is unavailable.",
+			}).success,
+		).toBe(true);
+	});
+
+	it("rejects a successful no-op", () => {
+		expect(
+			blockBuilderSchema.safeParse({
+				status: "success",
+				targetType: "route",
+				targetId: "route-1",
+				blocks: [],
+				canvasChanges: [],
+			}).success,
+		).toBe(false);
+	});
+});

--- a/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/schemas.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/schemas.ts
@@ -57,7 +57,6 @@ export const CanvasChangeSchema = z.discriminatedUnion("type", [
 					"Handle on the source block (e.g., 'source', 'success', 'failure').",
 				),
 			toEdge: z.string().describe("New target block ID."),
-			toHandle: z.string().describe("Handle on the new target block."),
 		}),
 	}),
 	z.object({
@@ -102,9 +101,11 @@ export const blockBuilderSchema = z.object({
 		),
 	targetType: z
 		.enum(["route", "custom_block"])
+		.nullish()
 		.describe("Whether this canvas belongs to a route or custom block"),
 	targetId: z
 		.string()
+		.nullish()
 		.describe("The ID of the route or custom block this canvas belongs to"),
 	canvasChanges: z
 		.array(CanvasChangeSchema)
@@ -116,6 +117,39 @@ export const blockBuilderSchema = z.object({
 		.array(BlockSchema)
 		.default([])
 		.describe("New blocks to add to the canvas"),
+}).superRefine((result, ctx) => {
+	if (result.status === "impossible") {
+		if (!result.reasoning?.trim()) {
+			ctx.addIssue({
+				code: "custom",
+				path: ["reasoning"],
+				message: "Explain why construction is impossible.",
+			});
+		}
+		return;
+	}
+
+	if (!result.targetType) {
+		ctx.addIssue({
+			code: "custom",
+			path: ["targetType"],
+			message: "A successful result must identify its target type.",
+		});
+	}
+	if (!result.targetId) {
+		ctx.addIssue({
+			code: "custom",
+			path: ["targetId"],
+			message: "A successful result must identify its target ID.",
+		});
+	}
+	if (result.blocks.length === 0 && result.canvasChanges.length === 0) {
+		ctx.addIssue({
+			code: "custom",
+			path: ["blocks"],
+			message: "A successful result must add a block or change the canvas.",
+		});
+	}
 });
 
 export type BlockBuilderResult = z.infer<typeof blockBuilderSchema>;

--- a/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/validator.spec.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/validator.spec.ts
@@ -68,4 +68,23 @@ describe("validateBlockBuilderOutput", () => {
 			),
 		).toContain('parameter "missing"');
 	});
+
+	it("checks parameters used in JS Runner bodies", async () => {
+		const output = {
+			...result("note"),
+			blocks: [
+				{
+					id: "runner",
+					blockType: "jsrunner",
+					position: { x: 0, y: 0 },
+					data: { value: "return params.missing;" },
+					connections: [],
+				},
+			],
+		};
+
+		expect(
+			await validateBlockBuilderOutput(output, "canvas", state()),
+		).toContain('parameter "missing"');
+	});
 });

--- a/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/validator.spec.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/validator.spec.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "bun:test";
+import { AgentNode, type GlobalGraphState } from "../../../types";
+import { validateBlockBuilderOutput } from "./validator";
+
+const state = () =>
+	({
+		orchestratorState: {
+			tasks: [
+				{
+					id: "config",
+					title: "config",
+					description: "",
+					status: "completed",
+					assignedAgentNode: AgentNode.CUSTOM_BLOCK_CONFIG_AGENT,
+					dependsOnAgentId: [],
+				},
+				{
+					id: "canvas",
+					title: "canvas",
+					description: "",
+					status: "running",
+					assignedAgentNode: AgentNode.BLOCK_BUILDER,
+					dependsOnAgentId: ["config"],
+				},
+			],
+			subAgentResults: {
+				config: {
+					customBlockId: "custom-1",
+					data: { name: "example", inputParams: [] },
+				},
+			},
+		},
+	}) as unknown as GlobalGraphState;
+
+const result = (notes: string) => ({
+	status: "success" as const,
+	targetType: "custom_block" as const,
+	targetId: "custom-1",
+	canvasChanges: [],
+	blocks: [
+		{
+			id: "note",
+			blockType: "sticky_note",
+			position: { x: 0, y: 0 },
+			data: { notes, color: "blue", size: { width: 200, height: 100 } },
+			connections: [],
+		},
+	],
+});
+
+describe("validateBlockBuilderOutput", () => {
+	it("does not treat literal params text as a caller parameter", async () => {
+		expect(
+			await validateBlockBuilderOutput(
+				result("Show params.missing"),
+				"canvas",
+				state(),
+			),
+		).toBeNull();
+	});
+
+	it("still checks parameters used in executable expressions", async () => {
+		expect(
+			await validateBlockBuilderOutput(
+				result("js:params.missing"),
+				"canvas",
+				state(),
+			),
+		).toContain('parameter "missing"');
+	});
+});

--- a/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/validator.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/validator.ts
@@ -136,14 +136,32 @@ function validateCustomBlockParameterReferences(
 		return [];
 	};
 	for (const block of blocks) {
-		for (const value of stringValues(block.data ?? {})) {
-			// `params.*` is executable only in a `js:` expression. A literal
-			// response body mentioning "params.foo" is not a caller reference.
-			const references = value.startsWith("js:")
-				? value.slice(3).matchAll(/(?<![\w.])params\.([a-zA-Z0-9_]+)/g)
-				: value.startsWith("param:")
-					? value.matchAll(/^param:([a-zA-Z0-9_]+)$/g)
-					: [];
+		const data = (block.data ?? {}) as Record<string, unknown>;
+		const executableValues = stringValues(data).filter((value) =>
+			value.startsWith("js:"),
+		);
+		// JS Runner bodies execute directly, unlike other dynamic field values
+		// which require the `js:` prefix.
+		if (block.blockType === BlockTypes.jsrunner && typeof data.value === "string") {
+			executableValues.push(data.value);
+		}
+
+		for (const value of stringValues(data)) {
+			if (!value.startsWith("param:")) continue;
+			const references = value.matchAll(/^param:([a-zA-Z0-9_]+)$/g);
+			for (const match of references) {
+				const name = match[1];
+				if (name && !params.has(name)) {
+					errors.push(`Block "${block.id}" references custom-block parameter "${name}", but it is absent from the paired Custom Block Config Agent output.`);
+				}
+			}
+		}
+
+		for (const value of new Set(executableValues)) {
+			const expression = value.startsWith("js:") ? value.slice(3) : value;
+			const references = expression.matchAll(
+				/(?<![\w.])params\.([a-zA-Z0-9_]+)/g,
+			);
 			for (const match of references) {
 				const name = match[1];
 				if (name && !params.has(name)) {

--- a/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/validator.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/validator.ts
@@ -127,16 +127,29 @@ function validateCustomBlockParameterReferences(
 ): string[] {
 	if (!params) return [];
 	const errors: string[] = [];
+	const stringValues = (value: unknown): string[] => {
+		if (typeof value === "string") return [value];
+		if (Array.isArray(value)) return value.flatMap(stringValues);
+		if (value && typeof value === "object") {
+			return Object.values(value).flatMap(stringValues);
+		}
+		return [];
+	};
 	for (const block of blocks) {
-		const serialized = JSON.stringify(block.data ?? {});
-		// The lookbehind matters: without it `input.params.id` or `data.params.x`
-		// — ordinary property access on a previous block's output — reads as a
-		// caller parameter and bounces a correct canvas back for a retry.
-		for (const match of serialized.matchAll(
-			/(?:(?<![\w.])params\.([a-zA-Z0-9_]+)|(?<![\w.])param:([a-zA-Z0-9_]+))/g,
-		)) {
-			const name = match[1] ?? match[2];
-			if (name && !params.has(name)) errors.push(`Block "${block.id}" references custom-block parameter "${name}", but it is absent from the paired Custom Block Config Agent output.`);
+		for (const value of stringValues(block.data ?? {})) {
+			// `params.*` is executable only in a `js:` expression. A literal
+			// response body mentioning "params.foo" is not a caller reference.
+			const references = value.startsWith("js:")
+				? value.slice(3).matchAll(/(?<![\w.])params\.([a-zA-Z0-9_]+)/g)
+				: value.startsWith("param:")
+					? value.matchAll(/^param:([a-zA-Z0-9_]+)$/g)
+					: [];
+			for (const match of references) {
+				const name = match[1];
+				if (name && !params.has(name)) {
+					errors.push(`Block "${block.id}" references custom-block parameter "${name}", but it is absent from the paired Custom Block Config Agent output.`);
+				}
+			}
 		}
 	}
 	return errors;
@@ -229,14 +242,20 @@ export const validateBlockBuilderOutput: AgentOutputValidator = async (
 		if (!typedResult.reasoning) {
 			return "Status is marked as 'impossible', but no reasoning provided explaining why construction is impossible.";
 		}
-		return typedResult.reasoning;
+		// Supervisor records an impossible result as terminal. It is not malformed
+		// canvas output, so it must not consume the retry budget.
+		return null;
 	}
 
 	if (!typedResult.targetType || !typedResult.targetId) {
 		return "Missing 'targetType' or 'targetId'. You must associate the canvas configuration with either a route or custom block ID.";
 	}
 
-	if (!typedResult.blocks && !typedResult.canvasChanges) {
+	if (!Array.isArray(typedResult.blocks) || !Array.isArray(typedResult.canvasChanges)) {
+		return "A successful result must provide 'blocks' and 'canvasChanges' as arrays.";
+	}
+
+	if (typedResult.blocks.length === 0 && typedResult.canvasChanges.length === 0) {
 		return "Result must contain either 'blocks' (new blocks to add) or 'canvasChanges' (mutations to existing blocks).";
 	}
 

--- a/apps/ai-gateway/src/harness/agents/sub-agents/customBlockConfig.spec.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/customBlockConfig.spec.ts
@@ -45,4 +45,19 @@ describe("validateCustomBlockConfigOutput", () => {
 			}),
 		).toBeNull();
 	});
+
+	it("rejects incomplete type-specific parameters", () => {
+		expect(
+		check({
+			action: "create",
+			data: { name: "choose_mode", label: "Choose Mode", inputParams: [{ type: "dropdown", name: "mode", label: "Mode", options: [] }] },
+		}),
+	).toBeTruthy();
+		expect(
+		check({
+			action: "create",
+			data: { name: "use_db", label: "Use DB", inputParams: [{ type: "integration_selector", name: "database", label: "Database", group: "" }] },
+		}),
+	).toBeTruthy();
+	});
 });

--- a/apps/ai-gateway/src/harness/agents/sub-agents/customBlockConfig.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/customBlockConfig.ts
@@ -98,7 +98,10 @@ ${CUSTOM_BLOCK_PARAMETER_CONTRACT}
 			response.data.name = await this.freeName(response.data.name);
 		}
 		await dispatchAgentEvent({ name: "agent_status", data: { status: "Custom block contract formulated", agent: AgentNode.CUSTOM_BLOCK_CONFIG_AGENT, agentId: activeTask.id, data: response } });
-		return { currentAgent: AgentNode.CUSTOM_BLOCK_CONFIG_AGENT, orchestratorState: { ...this.state.orchestratorState, subAgentResults: { ...(this.state.orchestratorState?.subAgentResults ?? {}), [activeTask.id]: response } } };
+		return {
+			currentAgent: AgentNode.CUSTOM_BLOCK_CONFIG_AGENT,
+			orchestratorState: { subAgentResults: { [activeTask.id]: response } },
+		};
 	}
 }
 

--- a/apps/ai-gateway/src/harness/agents/sub-agents/customBlockConfig.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/customBlockConfig.ts
@@ -13,12 +13,12 @@ import { BaseAgent } from "../base";
 import { CUSTOM_BLOCK_PARAMETER_CONTRACT } from "./customBlockContract";
 
 const inputParamSchema = z.discriminatedUnion("type", [
-	z.object({ type: z.literal("text_input"), name: z.string(), label: z.string(), description: z.string().nullish() }),
-	z.object({ type: z.literal("checkbox"), name: z.string(), label: z.string(), description: z.string().nullish() }),
-	z.object({ type: z.literal("array_editor"), name: z.string(), label: z.string(), description: z.string().nullish() }),
-	z.object({ type: z.literal("dropdown"), name: z.string(), label: z.string(), options: z.array(z.object({ label: z.string(), value: z.string() })), description: z.string().nullish() }),
-	z.object({ type: z.literal("integration_selector"), name: z.string(), label: z.string(), group: z.string(), variant: z.string().nullish(), tags: z.array(z.string()).default([]), description: z.string().nullish() }),
-	z.object({ type: z.literal("app_config_selector"), name: z.string(), label: z.string(), description: z.string().nullish() }),
+	z.object({ type: z.literal("text_input"), name: z.string().regex(/^[a-z0-9_]+$/), label: z.string().trim().min(1), description: z.string().nullish() }),
+	z.object({ type: z.literal("checkbox"), name: z.string().regex(/^[a-z0-9_]+$/), label: z.string().trim().min(1), description: z.string().nullish() }),
+	z.object({ type: z.literal("array_editor"), name: z.string().regex(/^[a-z0-9_]+$/), label: z.string().trim().min(1), description: z.string().nullish() }),
+	z.object({ type: z.literal("dropdown"), name: z.string().regex(/^[a-z0-9_]+$/), label: z.string().trim().min(1), options: z.array(z.object({ label: z.string().trim().min(1), value: z.string().trim().min(1) })).min(1), description: z.string().nullish() }),
+	z.object({ type: z.literal("integration_selector"), name: z.string().regex(/^[a-z0-9_]+$/), label: z.string().trim().min(1), group: z.string().trim().min(1), variant: z.string().nullish(), tags: z.array(z.string()).default([]), description: z.string().nullish() }),
+	z.object({ type: z.literal("app_config_selector"), name: z.string().regex(/^[a-z0-9_]+$/), label: z.string().trim().min(1), description: z.string().nullish() }),
 ]);
 
 const customBlockConfigSchema = z.object({
@@ -120,5 +120,17 @@ export const validateCustomBlockConfigOutput: import("../../types").AgentOutputV
 	// than the create DTO, and only at apply time, as "Malformed operation"
 	const badName = names.find((name) => !/^[a-z0-9_]+$/.test(name));
 	if (badName) return `Custom block inputParam name "${badName}" must be lowercase snake_case (letters, digits and underscores only).`;
+	for (const param of value.data?.inputParams ?? []) {
+		if (!param.label?.trim()) return `Custom block inputParam "${param.name}" requires a non-empty label.`;
+		if (param.type === "dropdown") {
+			if (!param.options?.length) return `Dropdown inputParam "${param.name}" requires at least one option.`;
+			if (param.options.some((option) => !option.label?.trim() || !option.value?.trim())) {
+				return `Dropdown inputParam "${param.name}" options require non-empty label and value.`;
+			}
+		}
+		if (param.type === "integration_selector" && !param.group?.trim()) {
+			return `Integration selector inputParam "${param.name}" requires a non-empty group.`;
+		}
+	}
 	return null;
 };

--- a/apps/ai-gateway/src/harness/agents/sub-agents/customBlockContract.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/customBlockContract.ts
@@ -4,8 +4,10 @@ export const CUSTOM_BLOCK_PARAMETER_CONTRACT = `
 Custom-block inputParams are public API supplied by caller blocks, not values produced inside callee graph.
 - Parameter names are lowercase snake_case (\`api_key\`, never \`apiKey\`).
 - Declare every value implementation reads as \`params.<name>\` or substitutes as \`param:<name>\`; names must match exactly.
-- \`text_input\`: string; \`checkbox\`: boolean; \`array_editor\`: array; \`dropdown\`: declared string options.
-- \`integration_selector\`: caller supplies integration id. \`app_config_selector\`: caller supplies app-config KEY, never secret/value; read it only with \`getConfig(params.<name>)\`.
+- \`text_input\`: string; \`checkbox\`: boolean; \`array_editor\`: array. Each needs non-empty \`name\` and \`label\`; \`description\` is optional.
+- \`dropdown\`: string selected from a non-empty \`options\` list. Every option is exactly \`{ label: string, value: string }\`, with both strings non-empty.
+- \`integration_selector\`: caller supplies integration id. It requires non-empty \`group\`; optional \`variant\` narrows the provider and optional \`tags\` narrows further.
+- \`app_config_selector\`: caller supplies app-config KEY, never secret/value; read it only with \`getConfig(params.<name>)\`.
 - Never put credentials, app-config values, or connection ids in custom-block definition or data.
 `;
 

--- a/apps/ai-gateway/src/harness/agents/sub-agents/routeConfig.spec.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/routeConfig.spec.ts
@@ -1,11 +1,20 @@
 import { describe, expect, it } from "bun:test";
-import { validateAgentOutput } from "./routeConfig";
+import { routeConfigOutputSchema, validateAgentOutput } from "./routeConfig";
 import type { GlobalGraphState, SubAgentResult } from "../../types";
 
 const check = (result: SubAgentResult) =>
 	validateAgentOutput(result, "t-1", {} as GlobalGraphState);
 
 describe("routeConfig validateAgentOutput", () => {
+	it("rejects malformed query-schema wire format before supervision", () => {
+		expect(routeConfigOutputSchema.safeParse({
+			action: "create",
+			data: {
+				name: "List Profiles",
+				querySchema: { dataType: "object", properties: { item: [] } },
+			},
+		}).success).toBe(false);
+	});
 	it("rejects a create that forgot the route name", () => {
 		expect(
 			check({ action: "create", data: { method: "POST", path: "/orders" } }),

--- a/apps/ai-gateway/src/harness/agents/sub-agents/routeConfig.spec.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/routeConfig.spec.ts
@@ -38,6 +38,13 @@ describe("routeConfig validateAgentOutput", () => {
 			},
 		}).success).toBe(false);
 	});
+
+	it("rejects nested form body schemas", () => {
+		expect(routeConfigOutputSchema.safeParse({ action: "create", data: {
+			name: "Upload", acceptedContentTypes: ["multipart/form-data"],
+			bodySchema: { dataType: "object", properties: [{ key: "meta", dataType: "object", properties: [] }] },
+		} }).success).toBe(false);
+	});
 	it("rejects a create that forgot the route name", () => {
 		expect(
 			check({ action: "create", data: { method: "POST", path: "/orders" } }),

--- a/apps/ai-gateway/src/harness/agents/sub-agents/routeConfig.spec.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/routeConfig.spec.ts
@@ -15,6 +15,29 @@ describe("routeConfig validateAgentOutput", () => {
 			},
 		}).success).toBe(false);
 	});
+
+	it("rejects the malformed profile-list query output", () => {
+		expect(routeConfigOutputSchema.safeParse({
+			action: "create",
+			data: {
+				name: "List Profiles",
+				method: "GET",
+				path: "/api/profiles",
+				querySchema: {
+					dataType: "object",
+					properties: {
+						item: [{
+							key: "page",
+							dataType: "int",
+							required: "false",
+							defaultValue: "1",
+							rules: { item: { type: "min", value: "1" } },
+						}],
+					},
+				},
+			},
+		}).success).toBe(false);
+	});
 	it("rejects a create that forgot the route name", () => {
 		expect(
 			check({ action: "create", data: { method: "POST", path: "/orders" } }),

--- a/apps/ai-gateway/src/harness/agents/sub-agents/routeConfig.spec.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/routeConfig.spec.ts
@@ -31,4 +31,29 @@ describe("routeConfig validateAgentOutput", () => {
 		).toBeNull();
 		expect(check({ action: "delete", routeId: "r-1" })).toBeNull();
 	});
+
+	it("requires a complete, supported path params schema", () => {
+		expect(
+			check({ action: "create", data: { name: "Get User", path: "/users/:id" } }),
+		).toContain("paramsSchema");
+		expect(
+			check({
+				action: "create",
+				data: {
+					name: "Get User",
+					path: "/users/:id",
+					paramsSchema: { dataType: "object", properties: [{ key: "id", dataType: "arr", required: true }] },
+				},
+			}),
+		).toContain("must use one of");
+	});
+
+	it("rejects unsupported query schema shapes", () => {
+		expect(
+			check({
+				action: "create",
+				data: { name: "List Users", path: "/users", querySchema: { dataType: "arr" } },
+			}),
+		).toContain("dataType \"object\"");
+	});
 });

--- a/apps/ai-gateway/src/harness/agents/sub-agents/routeConfig.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/routeConfig.ts
@@ -41,6 +41,25 @@ const querySchemaOutput = z.object({
 	properties: z.array(queryFieldSchema),
 }).strict();
 
+const BODY_TYPES = ["str", "int", "float", "bool", "object", "arr", "enum", "js", "file", "blob"] as const;
+const FORM_CONTENT_TYPES = new Set(["application/x-www-form-urlencoded", "multipart/form-data"]);
+const bodyFieldSchema: z.ZodType = z.lazy(() => z.object({
+	key: z.string(),
+	dataType: z.enum(BODY_TYPES),
+	required: z.boolean().optional(),
+	rules: z.array(ruleSchema).optional(),
+	js: z.string().optional(),
+	properties: z.array(bodyFieldSchema).optional(),
+	items: bodyFieldSchema.optional(),
+}).strict());
+const bodySchemaOutput = z.object({
+	dataType: z.enum(BODY_TYPES),
+	properties: z.array(bodyFieldSchema).optional(),
+	items: bodyFieldSchema.optional(),
+	rules: z.array(ruleSchema).optional(),
+	js: z.string().optional(),
+}).strict();
+
 export const routeConfigOutputSchema = z.object({
 	action: z
 		.enum(["create", "delete", "update-partial"])
@@ -59,12 +78,18 @@ export const routeConfigOutputSchema = z.object({
 				),
 			method: z.string().nullish(),
 			path: z.string().nullish(),
-			bodySchema: z.any().nullish(),
+			bodySchema: bodySchemaOutput.nullish(),
+			acceptedContentTypes: z.array(z.enum(["application/json", "application/x-www-form-urlencoded", "multipart/form-data", "application/octet-stream", "text/plain"])).min(1).nullish(),
 			paramsSchema: paramsSchemaOutput.nullish(),
 			querySchema: querySchemaOutput.nullish(),
 		})
 		.nullish()
 		.describe("The configuration of the route"),
+}).superRefine((value, ctx) => {
+	if (!value.data?.bodySchema || !value.data.acceptedContentTypes?.some((type) => FORM_CONTENT_TYPES.has(type))) return;
+	if ((value.data.bodySchema.properties ?? []).some((field: any) => field.properties || field.items)) {
+		ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["data", "bodySchema"], message: "Form body schemas support top-level fields only." });
+	}
 });
 
 const PARAM_DATA_TYPES = new Set(["str", "int", "float", "bool", "enum"]);
@@ -206,6 +231,7 @@ Fluxify uses a specific JSON format for schemas. DO NOT output standard JSON Sch
 ### Parameter Schema Rules
 - \`paramsSchema\` is required when \`path\` has \`:parameters\`; otherwise omit it. It is an object with exactly one required property for every path parameter, using only \`str\`, \`int\`, \`float\`, \`bool\`, or \`enum\`. No nested objects, arrays, files, blobs, or JS validators.
 - \`querySchema\`, when present, is an object. Its fields may use only \`str\`, \`int\`, \`float\`, \`bool\`, \`enum\`, or \`arr\`; query fields may be optional.
+- Include \`acceptedContentTypes\` whenever body format matters. For \`application/json\`, body schemas may nest objects and arrays. For form types (\`application/x-www-form-urlencoded\` or \`multipart/form-data\`), body schema properties are top-level only: no nested \`properties\` or \`items\`.
 
 ## Instructions
 1. Analyze the assigned task to understand the exact route modifications required.

--- a/apps/ai-gateway/src/harness/agents/sub-agents/routeConfig.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/routeConfig.ts
@@ -180,15 +180,10 @@ Determine the exact route configuration intent. Use your tools if you need more 
 			},
 		});
 
-		// Ensure we initialize subAgentResults if it's undefined
-		const currentResults = this.state.orchestratorState?.subAgentResults || {};
-
 		return {
 			currentAgent: AgentNode.ROUTE_CONFIG_AGENT,
 			orchestratorState: {
-				...this.state.orchestratorState,
 				subAgentResults: {
-					...currentResults,
 					[activeTask.id]: response,
 				},
 			},

--- a/apps/ai-gateway/src/harness/agents/sub-agents/routeConfig.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/routeConfig.ts
@@ -6,7 +6,42 @@ import { searchDocsTool } from "../../tools/searchDocs";
 import { createGetRouteDetailsTool } from "../../tools/getRouteDetails";
 import { generateID } from "@fluxify/lib";
 
-const routeConfigSchema = z.object({
+const ruleSchema = z.object({
+	type: z.string(),
+	value: z.any().optional(),
+	message: z.string().optional(),
+}).strict();
+
+const paramFieldSchema = z.object({
+	key: z.string().min(1),
+	dataType: z.enum(["str", "int", "float", "bool", "enum"]),
+	required: z.boolean(),
+	rules: z.array(ruleSchema).optional(),
+}).strict();
+
+const queryFieldSchema = z.object({
+	key: z.string().min(1),
+	dataType: z.enum(["str", "int", "float", "bool", "arr", "enum"]),
+	required: z.boolean().optional(),
+	rules: z.array(ruleSchema).optional(),
+	items: z.object({
+		key: z.string(),
+		dataType: z.enum(["str", "int", "float", "bool", "enum"]),
+		rules: z.array(ruleSchema).optional(),
+	}).strict().optional(),
+}).strict();
+
+const paramsSchemaOutput = z.object({
+	dataType: z.literal("object"),
+	properties: z.array(paramFieldSchema),
+}).strict();
+
+const querySchemaOutput = z.object({
+	dataType: z.literal("object"),
+	properties: z.array(queryFieldSchema),
+}).strict();
+
+export const routeConfigOutputSchema = z.object({
 	action: z
 		.enum(["create", "delete", "update-partial"])
 		.describe("The operation to perform"),
@@ -25,8 +60,8 @@ const routeConfigSchema = z.object({
 			method: z.string().nullish(),
 			path: z.string().nullish(),
 			bodySchema: z.any().nullish(),
-			paramsSchema: z.any().nullish(),
-			querySchema: z.any().nullish(),
+			paramsSchema: paramsSchemaOutput.nullish(),
+			querySchema: querySchemaOutput.nullish(),
 		})
 		.nullish()
 		.describe("The configuration of the route"),
@@ -199,7 +234,7 @@ Determine the exact route configuration intent. Use your tools if you need more 
 		];
 
 		const response = (await this.state.agentWrapper.invokeAgent({
-			zodSchema: routeConfigSchema,
+			zodSchema: routeConfigOutputSchema,
 			systemPrompt,
 			context: contextBlock,
 			tools,
@@ -207,7 +242,7 @@ Determine the exact route configuration intent. Use your tools if you need more 
 			userQuery: userQuery,
 			agentNode: AgentNode.ROUTE_CONFIG_AGENT,
 			agentId: activeTask.id,
-		})) as z.infer<typeof routeConfigSchema>;
+		})) as z.infer<typeof routeConfigOutputSchema>;
 
 		if (response.action === "create" && !response.routeId) {
 			response.routeId = generateID();

--- a/apps/ai-gateway/src/harness/agents/sub-agents/routeConfig.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/routeConfig.ts
@@ -32,6 +32,39 @@ const routeConfigSchema = z.object({
 		.describe("The configuration of the route"),
 });
 
+const PARAM_DATA_TYPES = new Set(["str", "int", "float", "bool", "enum"]);
+const QUERY_DATA_TYPES = new Set([...PARAM_DATA_TYPES, "arr"]);
+
+function parameterSchemaError(
+	schema: unknown,
+	label: "paramsSchema" | "querySchema",
+	allowedTypes: ReadonlySet<string>,
+): string | null {
+	if (!schema || typeof schema !== "object") {
+		return `${label} must be an object schema.`;
+	}
+	const value = schema as { dataType?: unknown; properties?: unknown };
+	if (value.dataType !== "object" || !Array.isArray(value.properties)) {
+		return `${label} must use dataType "object" with a properties array.`;
+	}
+	const seen = new Set<string>();
+	for (const property of value.properties) {
+		if (!property || typeof property !== "object") {
+			return `${label} contains an invalid property.`;
+		}
+		const field = property as { key?: unknown; dataType?: unknown };
+		if (typeof field.key !== "string" || !field.key.trim()) {
+			return `${label} properties require non-empty keys.`;
+		}
+		if (seen.has(field.key)) return `${label} cannot contain duplicate key "${field.key}".`;
+		seen.add(field.key);
+		if (typeof field.dataType !== "string" || !allowedTypes.has(field.dataType)) {
+			return `${label} property "${field.key}" must use one of: ${[...allowedTypes].join(", ")}.`;
+		}
+	}
+	return null;
+}
+
 export class RouteConfigAgent extends BaseAgent {
 	constructor(state: GlobalGraphState) {
 		super(state);
@@ -75,7 +108,7 @@ Fluxify uses a specific JSON format for schemas. DO NOT output standard JSON Sch
 {
   "dataType": "str",
   "rules": [
-    { "type": "min", "value": 3, "message": "String must be at least 3 characters" }
+    { "type": "minLength", "value": 3, "message": "String must be at least 3 characters" }
   ]
 }
 \`\`\`
@@ -121,13 +154,23 @@ Fluxify uses a specific JSON format for schemas. DO NOT output standard JSON Sch
         "dataType": "object",
         "properties": [
           { "key": "name", "dataType": "str", "required": true },
-          { "key": "role", "dataType": "enum", "rules": [ { "type": "enum", "value": ["admin", "user"] } ] }
+          { "key": "role", "dataType": "enum", "rules": [ { "type": "values", "value": ["admin", "user"] } ] }
         ]
       }
     }
   ]
 }
 \`\`\`
+
+### Supported Types and Rules
+- \`str\`: \`minLength\`, \`maxLength\`, \`regex\`, \`startsWith\`, \`endsWith\`, \`contains\`, \`notContains\`.
+- \`int\` / \`float\`: \`min\`, \`max\`. \`bool\` has no rules.
+- \`arr\`: \`items\` plus \`minItems\`, \`maxItems\`. \`enum\`: a \`values\` rule with an array of permitted values.
+- \`object\`: a \`properties\` array. \`js\`: validator source in \`js\`. \`file\` / \`blob\`: \`minSize\`, \`maxSize\`, \`mimeTypes\`.
+
+### Parameter Schema Rules
+- \`paramsSchema\` is required when \`path\` has \`:parameters\`; otherwise omit it. It is an object with exactly one required property for every path parameter, using only \`str\`, \`int\`, \`float\`, \`bool\`, or \`enum\`. No nested objects, arrays, files, blobs, or JS validators.
+- \`querySchema\`, when present, is an object. Its fields may use only \`str\`, \`int\`, \`float\`, \`bool\`, \`enum\`, or \`arr\`; query fields may be optional.
 
 ## Instructions
 1. Analyze the assigned task to understand the exact route modifications required.
@@ -219,6 +262,31 @@ export const validateAgentOutput: import("../../types").AgentOutputValidator = (
 	// rather than let the supervisor pass it.
 	if (typedResult.action === "create" && !typedResult.data?.name?.trim()) {
 		return "Action 'create' requires a non-empty 'data.name' — a short Title Case label for the route, e.g. 'Create Order'.";
+	}
+
+	const path = typedResult.data?.path;
+	if (typeof path === "string") {
+		const pathParams = Array.from(path.matchAll(/:([a-zA-Z0-9_]+)/g)).map((match) => match[1]!);
+		if (pathParams.length > 0) {
+			const error = parameterSchemaError(typedResult.data?.paramsSchema, "paramsSchema", PARAM_DATA_TYPES);
+			if (error) return error;
+			const properties = typedResult.data?.paramsSchema?.properties ?? [];
+			const keys = properties.map((property: { key: string }) => property.key);
+			const missing = pathParams.find((key) => !keys.includes(key));
+			if (missing) return `paramsSchema is missing path parameter "${missing}".`;
+			const extra = keys.find((key: string) => !pathParams.includes(key));
+			if (extra) return `paramsSchema contains "${extra}", which is not declared in the route path.`;
+			if (properties.some((property: { required?: unknown }) => property.required !== true)) {
+				return "Every paramsSchema property must set required: true.";
+			}
+		} else if (typedResult.data?.paramsSchema != null) {
+			return "Do not include paramsSchema when the route path has no :parameters.";
+		}
+	}
+
+	if (typedResult.data?.querySchema != null) {
+		const error = parameterSchemaError(typedResult.data.querySchema, "querySchema", QUERY_DATA_TYPES);
+		if (error) return error;
 	}
 
 	return null; // Valid

--- a/apps/ai-gateway/src/harness/agents/supervisor.spec.ts
+++ b/apps/ai-gateway/src/harness/agents/supervisor.spec.ts
@@ -60,4 +60,25 @@ describe("SupervisorAgent", () => {
 		expect(a.status).toBe("completed");
 		expect(a.attempts).toBeUndefined();
 	});
+
+	it("records an impossible block-builder result without retrying it", async () => {
+		const a = {
+			...task("a"),
+			assignedAgentNode: AgentNode.BLOCK_BUILDER,
+		};
+		await new SupervisorAgent({
+			orchestratorState: {
+				tasks: [a],
+				dispatchedTasks: [a],
+				subAgentResults: {
+					a: { status: "impossible", reasoning: "Missing required provider." },
+				},
+			},
+			scratchpad: [],
+		} as unknown as GlobalGraphState).execute();
+
+		expect(a.status).toBe("failed");
+		expect(a.attempts).toBe(1);
+		expect(a.supervisorReviews).toContain("Missing required provider");
+	});
 });

--- a/apps/ai-gateway/src/harness/agents/supervisor.ts
+++ b/apps/ai-gateway/src/harness/agents/supervisor.ts
@@ -43,17 +43,22 @@ export class SupervisorAgent extends BaseAgent {
 		// `pending` — the orchestrator re-dispatches it with the correction in
 		// context. Only once the attempts run out does the task fail terminally,
 		// and a terminal failure must take its dependents with it (orchestrator).
-		const reject = (i: number, task: Task, reason: string) => {
+		const reject = (
+			i: number,
+			task: Task,
+			reason: string,
+			terminal = false,
+		) => {
 			const entry = tasks.find((t) => t.id === task.id) ?? task;
 			entry.attempts = (entry.attempts ?? 0) + 1;
 			entry.supervisorReviews = reason;
 
-			const terminal = entry.attempts >= MAX_TASK_ATTEMPTS;
-			const status = terminal ? "failed" : "pending";
+			const isTerminal = terminal || entry.attempts >= MAX_TASK_ATTEMPTS;
+			const status = isTerminal ? "failed" : "pending";
 			dispatchedTasks[i].status = status;
 			setStatus(task.id, status);
 			scratchpad.push(
-				terminal
+				isTerminal
 					? `[Supervisor Error - Task ${task.id} (${task.assignedAgentNode})]: ${reason}`
 					: `[Supervisor Retry ${entry.attempts}/${MAX_TASK_ATTEMPTS} - Task ${task.id} (${task.assignedAgentNode})]: ${reason}`,
 			);
@@ -69,6 +74,24 @@ export class SupervisorAgent extends BaseAgent {
 
 			if (!result) {
 				reject(i, task, "No result provided by agent.");
+				continue;
+			}
+
+			const blockBuilderResult = result as {
+				status?: string;
+				reasoning?: string;
+			};
+			if (
+				task.assignedAgentNode === AgentNode.BLOCK_BUILDER &&
+				blockBuilderResult.status === "impossible" &&
+				blockBuilderResult.reasoning?.trim()
+			) {
+				reject(
+					i,
+					task,
+					blockBuilderResult.reasoning,
+					true,
+				);
 				continue;
 			}
 

--- a/apps/ai-gateway/src/harness/models/base.spec.ts
+++ b/apps/ai-gateway/src/harness/models/base.spec.ts
@@ -16,6 +16,7 @@ import {
 	asHistoryMessage,
 	compactToolHistory,
 	flattenToolMessages,
+	makeSubmitResultTool,
 } from "./toolLoop";
 import { OpenAIAgentWrapper } from "./openai";
 import { AnthropicAgentWrapper } from "./anthropic";
@@ -418,6 +419,10 @@ describe("fallbackStructuredOutput schema conversion", () => {
 		expect(jsonSchema.properties).toBeTruthy();
 		expect(Object.keys(jsonSchema.properties!).length).toBeGreaterThan(0);
 	});
+
+	it("keeps the block builder schema eligible for submit_result", () => {
+		expect(makeSubmitResultTool(blockBuilderSchema)).toBeDefined();
+	});
 });
 
 describe("describeFailure", () => {
@@ -464,83 +469,6 @@ describe("describeFailure", () => {
 
 	it("falls back to a generic explanation", () => {
 		expect(describeFailure(new Error("boom"))).toContain("unexpected error");
-	});
-});
-
-describe("submit_result", () => {
-	const pingTool = tool(async () => "pong", {
-		name: "ping",
-		description: "ping",
-		schema: z.object({}),
-	}) as unknown as StructuredTool;
-
-	/** Replays a scripted list of model responses through the real tool loop. */
-	class LoopWrapper extends BaseAgentWrapper {
-		calls: BaseMessage[][] = [];
-		boundTools: StructuredTool[] = [];
-
-		constructor(private responses: AIMessage[]) {
-			super("test-model");
-		}
-
-		protected createModel(): BaseChatModel {
-			let i = 0;
-			const model: any = {
-				bindTools: (tools: StructuredTool[]) => {
-					this.boundTools = tools;
-					return model;
-				},
-				invoke: async (messages: BaseMessage[]) => {
-					this.calls.push([...messages]);
-					return this.responses[Math.min(i++, this.responses.length - 1)];
-				},
-			};
-			return model as BaseChatModel;
-		}
-
-		run() {
-			return this.invokeAgent({
-				zodSchema: schema,
-				systemPrompt: "you are a builder",
-				userQuery: "build it",
-				tools: [pingTool],
-			});
-		}
-	}
-
-	const submitCall = (args: unknown, id = "call_1") =>
-		new AIMessage({
-			content: "",
-			tool_calls: [{ id, name: SUBMIT_RESULT_TOOL, args: args as any }],
-		});
-
-	it("returns the tool arguments as the answer in a single model call", async () => {
-		const wrapper = new LoopWrapper([submitCall({ blocks: ["a"] })]);
-		expect(await wrapper.run()).toEqual({ blocks: ["a"] });
-		// The whole point: no second generation of the same content.
-		expect(wrapper.calls.length).toBe(1);
-		expect(wrapper.boundTools.map((t) => t.name)).toContain(SUBMIT_RESULT_TOOL);
-	});
-
-	it("rejects invalid arguments in-loop and accepts the correction", async () => {
-		const wrapper = new LoopWrapper([
-			submitCall({ blocks: [1] }),
-			submitCall({ blocks: ["a"] }, "call_2"),
-		]);
-		expect(await wrapper.run()).toEqual({ blocks: ["a"] });
-		expect(wrapper.calls.length).toBe(2);
-
-		// The rejected call must still be answered — a tool_call with no matching
-		// result is rejected by the provider.
-		const answer = wrapper.calls[1]!.at(-1) as ToolMessage;
-		expect(answer.tool_call_id).toBe("call_1");
-		expect(String(answer.content)).toContain("blocks.0");
-	});
-
-	it("accepts an answer written as free text without regenerating it", async () => {
-		const wrapper = new LoopWrapper([new AIMessage('{"blocks":["a"]}')]);
-		expect(await wrapper.run()).toEqual({ blocks: ["a"] });
-		expect(wrapper.calls.length).toBe(1);
 	});
 });
 

--- a/apps/ai-gateway/src/harness/models/base.ts
+++ b/apps/ai-gateway/src/harness/models/base.ts
@@ -14,7 +14,6 @@ import { logger } from "@fluxify/common";
 import { withRetry } from "../../lib/retry";
 import { UserInterruptError, isCallTimeout } from "../errors";
 import {
-	summarizeToolResult,
 	parseJsonLoose,
 	describeSchemaError,
 	extractText,
@@ -28,8 +27,10 @@ import {
 	debugPrompt,
 	flattenToolMessages,
 	makeSubmitResultTool,
+	normalizedToolCalls,
 	parseAsSchema,
 } from "./toolLoop";
+import { executeToolCall } from "./toolExecution";
 import type { RunBudget } from "./budget";
 import { UNTRUSTED_DATA_RULE } from "../internal/untrusted";
 
@@ -79,6 +80,9 @@ export interface AgentInvokeOptions {
 	/** Task id when a sub-agent is calling — several instances of the same node
 	 *  run concurrently, so events need it to stay attributable. */
 	agentId?: string;
+	/** Optional domain validation after the transport schema parses. Returning an
+	 * error lets a tool-using model correct its result in the same conversation. */
+	validateResult?: (result: unknown) => Promise<string | null> | string | null;
 }
 
 /** A retryable error a caller may want to surface live (e.g. as a socket
@@ -434,6 +438,7 @@ export abstract class BaseAgentWrapper {
 					this.withSignal(config),
 					agentNode,
 					historyInputTokens,
+					options.validateResult,
 				)) as T;
 			}
 
@@ -479,7 +484,7 @@ export abstract class BaseAgentWrapper {
 		options: AgentInvokeOptions,
 		historyInputTokens: number,
 	): Promise<{ done: true; value: T | AIMessage } | { done: false }> {
-		const { zodSchema, config, agentNode, agentId } = options;
+		const { zodSchema, config, agentNode, agentId, validateResult } = options;
 		const maxIterations =
 			options.maxToolIterations ?? this.maxToolIterations ?? 8;
 
@@ -508,14 +513,19 @@ export abstract class BaseAgentWrapper {
 			)) as AIMessage;
 			finalMessages.push(response);
 
-			if (response.tool_calls && response.tool_calls.length > 0) {
+			const toolCalls = normalizedToolCalls(response);
+			if (toolCalls.length > 0) {
 				// `submit_result` is the answer, not work — if it validates, nothing
 				// else the model asked for in this batch is worth running.
 				const submit = zodSchema
-					? response.tool_calls.find((tc) => tc.name === SUBMIT_RESULT_TOOL)
+					? toolCalls.find((tc) => tc.name === SUBMIT_RESULT_TOOL)
 					: undefined;
 				const submitParsed = submit && zodSchema?.safeParse(submit.args);
-				if (submitParsed?.success)
+				const validationError =
+					submitParsed?.success && validateResult
+						? await validateResult(submitParsed.data)
+						: null;
+				if (submitParsed?.success && !validationError)
 					return { done: true, value: submitParsed.data as T };
 
 				// Models emit parallel tool calls precisely so they can run in
@@ -524,21 +534,27 @@ export abstract class BaseAgentWrapper {
 				// completion order — strict providers reject a batch whose
 				// ToolMessages don't line up with their tool_calls.
 				const results = await Promise.all(
-					response.tool_calls.map((tc) => {
-						if (submitParsed && !submitParsed.success && tc === submit) {
+					toolCalls.map((tc) => {
+						if (tc === submit && submitParsed) {
 							// Answer the call so the history stays valid (a tool_call with
 							// no result is rejected outright) and let the model correct
 							// itself on the next iteration.
 							return new ToolMessage({
-								tool_call_id: tc.id!,
+								tool_call_id: tc.id,
 								name: tc.name,
-								content: `Rejected — the result did not match the required schema.\n\n${describeSchemaError(submitParsed.error)}\n\nCall ${SUBMIT_RESULT_TOOL} again with the corrected values.`,
+								content: `Rejected — the result did not match the required contract.\n\n${
+									submitParsed.success
+										? validationError
+										: describeSchemaError(submitParsed.error)
+								}\n\nCall ${SUBMIT_RESULT_TOOL} again with the corrected values.`,
 							});
 						}
-						return this.executeToolCall(tc, tools, {
+						return executeToolCall(tc, tools, {
 							agent: agentNode,
 							agentId,
 							config,
+							withSignal: (toolConfig) => this.withSignal(toolConfig),
+							emitToolEvent: (event) => this.emitToolEvent(event),
 						});
 					}),
 				);
@@ -553,7 +569,18 @@ export abstract class BaseAgentWrapper {
 				// content; only fall through to the structured-output step if it
 				// really isn't the answer.
 				const parsed = parseAsSchema<T>(zodSchema, extractText(response));
-				if (parsed !== undefined) return { done: true, value: parsed };
+				if (parsed !== undefined) {
+					const validationError = validateResult
+						? await validateResult(parsed)
+						: null;
+					if (!validationError) return { done: true, value: parsed };
+					finalMessages.push(
+						new HumanMessage(
+							`Your JSON passed the transport schema but failed domain validation:\n\n${validationError}\n\nCall ${SUBMIT_RESULT_TOOL} with a corrected result.`,
+						),
+					);
+					continue;
+				}
 
 				finalMessages.pop();
 				return { done: false };
@@ -568,62 +595,6 @@ export abstract class BaseAgentWrapper {
 		return { done: false };
 	}
 
-	/**
-	 * Invokes a single tool call and returns its result (or error) as a
-	 * ToolMessage. It returns rather than appending so a batch can run
-	 * concurrently and still be appended in call order.
-	 */
-	private async executeToolCall(
-		tc: NonNullable<AIMessage["tool_calls"]>[number],
-		tools: StructuredTool[],
-		ctx: { agent?: string; agentId?: string; config?: RunnableConfig },
-	): Promise<ToolMessage> {
-		const tool = tools.find((t) => t.name === tc.name);
-		const toolEvent = { agent: ctx.agent, agentId: ctx.agentId, tool: tc.name };
-		await this.emitToolEvent({ ...toolEvent, status: "started" });
-
-		if (!tool) {
-			await this.emitToolEvent({
-				...toolEvent,
-				status: "ended",
-				error: `tool ${tc.name} not found`,
-			});
-			return new ToolMessage({
-				tool_call_id: tc.id!,
-				content: `Tool ${tc.name} not found.`,
-				name: tc.name,
-			});
-		}
-
-		try {
-			const toolResult = await tool.invoke(tc.args, this.withSignal(ctx.config));
-			await this.emitToolEvent({
-				...toolEvent,
-				status: "ended",
-				summary: summarizeToolResult(toolResult),
-			});
-			return new ToolMessage({
-				tool_call_id: tc.id!,
-				content:
-					typeof toolResult === "string"
-						? toolResult
-						: JSON.stringify(toolResult),
-				name: tc.name,
-			});
-		} catch (e) {
-			await this.emitToolEvent({
-				...toolEvent,
-				status: "ended",
-				error: e instanceof Error ? e.message : String(e),
-			});
-			return new ToolMessage({
-				tool_call_id: tc.id!,
-				content: `Error executing tool ${tc.name}: ${e}`,
-				name: tc.name,
-			});
-		}
-	}
-
 	protected async fallbackStructuredOutput<T>(
 		model: BaseChatModel | Runnable<any, any>,
 		messages: BaseMessage[],
@@ -631,6 +602,7 @@ export abstract class BaseAgentWrapper {
 		config?: RunnableConfig,
 		agentNode?: string,
 		historyInputTokens = 0,
+		validateResult?: (result: unknown) => Promise<string | null> | string | null,
 	): Promise<T> {
 		// zod-to-json-schema (v3) reads zod v3 `_def` internals and silently emits
 		// an empty schema against a zod v4 schema — the model then gets "match
@@ -688,7 +660,12 @@ ${JSON.stringify(jsonSchema, null, 2)}`;
 					);
 				}
 
-				return schema.parse(parseJsonLoose(content));
+				const parsed = schema.parse(parseJsonLoose(content));
+				const validationError = validateResult
+					? await validateResult(parsed)
+					: null;
+				if (validationError) throw new Error(validationError);
+				return parsed;
 			} catch (error) {
 				if (this.signal?.aborted) throw error;
 				// A call that timed out produced no output to correct. Re-asking just

--- a/apps/ai-gateway/src/harness/models/base.ts
+++ b/apps/ai-gateway/src/harness/models/base.ts
@@ -378,6 +378,7 @@ export abstract class BaseAgentWrapper {
 
 		if (zodSchema) {
 			let result: any;
+			let nativeResponse: AIMessage | undefined;
 			if (
 				this.supportsStructuredOutput() &&
 				originalModel.withStructuredOutput
@@ -399,6 +400,7 @@ export abstract class BaseAgentWrapper {
 									this.withSignal(config),
 								)) as { raw: AIMessage; parsed: T; parsingError?: Error };
 							this.recordUsage(agentNode, raw, startedAt, historyInputTokens);
+							nativeResponse = raw;
 							// Without includeRaw this would have thrown out of `invoke`;
 							// rethrow so the retry and the prompt fallback below still see it.
 							if (parsingError) throw parsingError;
@@ -425,6 +427,25 @@ export abstract class BaseAgentWrapper {
 						},
 					);
 				}
+			}
+			const validationError =
+				result && options.validateResult
+					? await options.validateResult(result)
+					: null;
+			if (validationError) {
+				// Native schema parsing cannot carry arbitrary domain errors back to the
+				// model. Preserve the attempted result, then use the corrective fallback
+				// so the next answer receives the same feedback as a tool-loop rejection.
+				finalMessages = [
+					...finalMessages,
+					...(nativeResponse
+						? [asHistoryMessage(nativeResponse, extractText(nativeResponse))]
+						: []),
+					new HumanMessage(
+						`Your structured result passed the JSON schema but failed domain validation:\n\n${validationError}\n\nRespond again with ONLY the corrected JSON object.`,
+					),
+				];
+				result = undefined;
 			}
 
 			if (!result) {

--- a/apps/ai-gateway/src/harness/models/nativeStructuredOutput.spec.ts
+++ b/apps/ai-gateway/src/harness/models/nativeStructuredOutput.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "bun:test";
+import { z } from "zod";
+import { BaseChatModel } from "@langchain/core/language_models/chat_models";
+import { AIMessage, type BaseMessage } from "@langchain/core/messages";
+import { BaseAgentWrapper } from "./base";
+
+const schema = z.object({ blocks: z.array(z.string()) });
+
+class NativeValidationWrapper extends BaseAgentWrapper {
+	nativeCalls: BaseMessage[][] = [];
+	fallbackCalls: BaseMessage[][] = [];
+
+	protected supportsStructuredOutput(): boolean {
+		return true;
+	}
+
+	protected createModel(): BaseChatModel {
+		const model = {
+			withStructuredOutput: () => ({
+				invoke: async (messages: BaseMessage[]) => {
+					this.nativeCalls.push([...messages]);
+					return {
+						raw: new AIMessage('{"blocks":["invalid"]}'),
+						parsed: { blocks: ["invalid"] },
+					};
+				},
+			}),
+			invoke: async (messages: BaseMessage[]) => {
+				this.fallbackCalls.push([...messages]);
+				return new AIMessage('{"blocks":["valid"]}');
+			},
+		};
+		return model as unknown as BaseChatModel;
+	}
+
+	run() {
+		return this.invokeAgent({
+			zodSchema: schema,
+			systemPrompt: "you are a builder",
+			userQuery: "build it",
+			validateResult: (result) =>
+				(result as { blocks: string[] }).blocks.includes("invalid")
+					? "Block configuration is invalid."
+					: null,
+		});
+	}
+}
+
+describe("native structured output", () => {
+	it("feeds a domain rejection into the corrective fallback", async () => {
+		const wrapper = new NativeValidationWrapper("test-model");
+		expect(await wrapper.run()).toEqual({ blocks: ["valid"] });
+		expect(wrapper.nativeCalls).toHaveLength(1);
+		expect(wrapper.fallbackCalls).toHaveLength(1);
+
+		const correction = wrapper.fallbackCalls[0]!.find(
+			(message) =>
+				message.getType() === "human" &&
+				String(message.content).includes("Block configuration is invalid."),
+		);
+		expect(correction).toBeDefined();
+	});
+});

--- a/apps/ai-gateway/src/harness/models/submitResult.spec.ts
+++ b/apps/ai-gateway/src/harness/models/submitResult.spec.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "bun:test";
+import { z } from "zod";
+import { BaseChatModel } from "@langchain/core/language_models/chat_models";
+import { AIMessage, ToolMessage, type BaseMessage } from "@langchain/core/messages";
+import { tool, type StructuredTool } from "@langchain/core/tools";
+import { BaseAgentWrapper } from "./base";
+import { SUBMIT_RESULT_TOOL } from "./toolLoop";
+
+const schema = z.object({ blocks: z.array(z.string()) });
+
+describe("submit_result", () => {
+	const pingTool = tool(async () => "pong", {
+		name: "ping",
+		description: "ping",
+		schema: z.object({}),
+	}) as unknown as StructuredTool;
+
+	/** Replays a scripted list of model responses through the real tool loop. */
+	class LoopWrapper extends BaseAgentWrapper {
+		calls: BaseMessage[][] = [];
+		boundTools: StructuredTool[] = [];
+
+		constructor(
+			private responses: AIMessage[],
+			private validateResult?: (result: unknown) => string | null,
+		) {
+			super("test-model");
+		}
+
+		protected createModel(): BaseChatModel {
+			let i = 0;
+			const model: any = {
+				bindTools: (tools: StructuredTool[]) => {
+					this.boundTools = tools;
+					return model;
+				},
+				invoke: async (messages: BaseMessage[]) => {
+					this.calls.push([...messages]);
+					return this.responses[Math.min(i++, this.responses.length - 1)];
+				},
+			};
+			return model as BaseChatModel;
+		}
+
+		run() {
+			return this.invokeAgent({
+				zodSchema: schema,
+				systemPrompt: "you are a builder",
+				userQuery: "build it",
+				tools: [pingTool],
+				validateResult: this.validateResult,
+			});
+		}
+	}
+
+	const submitCall = (args: unknown, id = "call_1") =>
+		new AIMessage({
+			content: "",
+			tool_calls: [{ id, name: SUBMIT_RESULT_TOOL, args: args as any }],
+		});
+	const rawSubmitCall = (args: unknown, id = "call_1") =>
+		new AIMessage({
+			content: "",
+			additional_kwargs: {
+				tool_calls: [
+					{
+						id,
+						type: "function",
+						function: {
+							name: SUBMIT_RESULT_TOOL,
+							arguments: JSON.stringify(args),
+						},
+					},
+				],
+			},
+		});
+
+	it("returns the tool arguments as the answer in a single model call", async () => {
+		const wrapper = new LoopWrapper([submitCall({ blocks: ["a"] })]);
+		expect(await wrapper.run()).toEqual({ blocks: ["a"] });
+		// The whole point: no second generation of the same content.
+		expect(wrapper.calls.length).toBe(1);
+		expect(wrapper.boundTools.map((t) => t.name)).toContain(SUBMIT_RESULT_TOOL);
+	});
+
+	it("accepts a provider-native submit_result call without regenerating it", async () => {
+		const wrapper = new LoopWrapper([rawSubmitCall({ blocks: ["a"] })]);
+		expect(await wrapper.run()).toEqual({ blocks: ["a"] });
+		expect(wrapper.calls.length).toBe(1);
+	});
+
+	it("rejects invalid arguments in-loop and accepts the correction", async () => {
+		const wrapper = new LoopWrapper([
+			submitCall({ blocks: [1] }),
+			submitCall({ blocks: ["a"] }, "call_2"),
+		]);
+		expect(await wrapper.run()).toEqual({ blocks: ["a"] });
+		expect(wrapper.calls.length).toBe(2);
+
+		// The rejected call must still be answered — a tool_call with no matching
+		// result is rejected by the provider.
+		const answer = wrapper.calls[1]!.at(-1) as ToolMessage;
+		expect(answer.tool_call_id).toBe("call_1");
+		expect(String(answer.content)).toContain("blocks.0");
+	});
+
+	it("returns domain validation feedback to the same tool loop", async () => {
+		const wrapper = new LoopWrapper(
+			[
+				submitCall({ blocks: ["invalid"] }),
+				submitCall({ blocks: ["valid"] }, "call_2"),
+			],
+			(result) =>
+				(result as { blocks: string[] }).blocks.includes("invalid")
+					? "Block configuration is invalid."
+					: null,
+		);
+
+		expect(await wrapper.run()).toEqual({ blocks: ["valid"] });
+		expect(wrapper.calls.length).toBe(2);
+		expect(String((wrapper.calls[1]!.at(-1) as ToolMessage).content)).toContain(
+			"Block configuration is invalid.",
+		);
+	});
+
+	it("accepts an answer written as free text without regenerating it", async () => {
+		const wrapper = new LoopWrapper([new AIMessage('{"blocks":["a"]}')]);
+		expect(await wrapper.run()).toEqual({ blocks: ["a"] });
+		expect(wrapper.calls.length).toBe(1);
+	});
+});

--- a/apps/ai-gateway/src/harness/models/toolExecution.ts
+++ b/apps/ai-gateway/src/harness/models/toolExecution.ts
@@ -1,0 +1,71 @@
+import { ToolMessage } from "@langchain/core/messages";
+import type { RunnableConfig } from "@langchain/core/runnables";
+import type { StructuredTool } from "@langchain/core/tools";
+import { summarizeToolResult } from "./jsonUtils";
+import type { NormalizedToolCall } from "./toolLoop";
+
+type ToolEvent = {
+	agent?: string;
+	agentId?: string;
+	tool: string;
+	status: "started" | "ended";
+	summary?: string;
+	error?: string;
+};
+
+type ToolExecutionContext = {
+	agent?: string;
+	agentId?: string;
+	config?: RunnableConfig;
+	withSignal: (config?: RunnableConfig) => RunnableConfig;
+	emitToolEvent: (data: ToolEvent) => Promise<void>;
+};
+
+/** Runs one tool call and produces the corresponding provider-valid result. */
+export async function executeToolCall(
+	tc: NormalizedToolCall,
+	tools: StructuredTool[],
+	ctx: ToolExecutionContext,
+): Promise<ToolMessage> {
+	const tool = tools.find((candidate) => candidate.name === tc.name);
+	const toolEvent = { agent: ctx.agent, agentId: ctx.agentId, tool: tc.name };
+	await ctx.emitToolEvent({ ...toolEvent, status: "started" });
+
+	if (!tool) {
+		await ctx.emitToolEvent({
+			...toolEvent,
+			status: "ended",
+			error: `tool ${tc.name} not found`,
+		});
+		return new ToolMessage({
+			tool_call_id: tc.id,
+			content: `Tool ${tc.name} not found.`,
+			name: tc.name,
+		});
+	}
+
+	try {
+		const toolResult = await tool.invoke(tc.args, ctx.withSignal(ctx.config));
+		await ctx.emitToolEvent({
+			...toolEvent,
+			status: "ended",
+			summary: summarizeToolResult(toolResult),
+		});
+		return new ToolMessage({
+			tool_call_id: tc.id,
+			content: typeof toolResult === "string" ? toolResult : JSON.stringify(toolResult),
+			name: tc.name,
+		});
+	} catch (error) {
+		await ctx.emitToolEvent({
+			...toolEvent,
+			status: "ended",
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return new ToolMessage({
+			tool_call_id: tc.id,
+			content: `Error executing tool ${tc.name}: ${error}`,
+			name: tc.name,
+		});
+	}
+}

--- a/apps/ai-gateway/src/harness/models/toolLoop.ts
+++ b/apps/ai-gateway/src/harness/models/toolLoop.ts
@@ -59,6 +59,15 @@ export function compactToolHistory(messages: BaseMessage[]): void {
 /** Tool the model calls to deliver its final structured answer. */
 export const SUBMIT_RESULT_TOOL = "submit_result";
 
+/** Provider-neutral shape used by the execution loop. OpenAI-compatible
+ * providers can leave calls in `additional_kwargs` instead of normalising them
+ * into `AIMessage.tool_calls`. */
+export type NormalizedToolCall = {
+	id: string;
+	name: string;
+	args: unknown;
+};
+
 export const SUBMIT_RESULT_INSTRUCTION = `When you have everything you need, deliver your final answer by calling the \`${SUBMIT_RESULT_TOOL}\` tool — its arguments are the answer. Do not write the answer out as text as well; that costs a full extra generation and is discarded.`;
 
 /**
@@ -130,6 +139,45 @@ export function toolCallsOf(message: unknown): unknown[] {
 			? m.additional_kwargs.tool_calls
 			: []),
 	];
+}
+
+/**
+ * Reads tool calls from both LangChain's normalised field and provider-native
+ * OpenAI-compatible metadata. A call can appear in both places, so id is the
+ * stable dedupe key.
+ */
+export function normalizedToolCalls(message: unknown): NormalizedToolCall[] {
+	const calls = new Map<string, NormalizedToolCall>();
+
+	for (const rawCall of toolCallsOf(message)) {
+		const call = rawCall as {
+			id?: unknown;
+			name?: unknown;
+			args?: unknown;
+			function?: { name?: unknown; arguments?: unknown };
+		};
+		const id = typeof call.id === "string" ? call.id : undefined;
+		const name =
+			typeof call.name === "string"
+				? call.name
+				: typeof call.function?.name === "string"
+					? call.function.name
+					: undefined;
+		if (!id || !name || calls.has(id)) continue;
+
+		let args = call.args ?? call.function?.arguments ?? {};
+		if (typeof args === "string") {
+			try {
+				args = JSON.parse(args);
+			} catch {
+				// Leave malformed arguments intact so the invoked tool can return its
+				// normal validation error to the model instead of silently changing it.
+			}
+		}
+		calls.set(id, { id, name, args });
+	}
+
+	return [...calls.values()];
 }
 
 /**

--- a/apps/ai-gateway/src/harness/types.spec.ts
+++ b/apps/ai-gateway/src/harness/types.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+import { AgentNode, mergeOrchestratorState, type Task } from "./types";
+
+const task = (id: string) =>
+	({
+		id,
+		title: id,
+		description: id,
+		dependsOnAgentId: [],
+		status: "running",
+		assignedAgentNode: AgentNode.BLOCK_BUILDER,
+	}) as Task;
+
+describe("mergeOrchestratorState", () => {
+	it("preserves results from concurrent sub-agent updates", () => {
+		const current = { tasks: [task("a"), task("b")] };
+		const afterA = mergeOrchestratorState(current, {
+			subAgentResults: { a: { blocks: [] } },
+		});
+		const afterB = mergeOrchestratorState(afterA, {
+			subAgentResults: { b: { blocks: [] } },
+		});
+
+		expect(afterB.subAgentResults).toEqual({
+			a: { blocks: [] },
+			b: { blocks: [] },
+		});
+	});
+});

--- a/apps/ai-gateway/src/harness/types.ts
+++ b/apps/ai-gateway/src/harness/types.ts
@@ -188,7 +188,8 @@ export type SubAgentResult =
  * @returns null if valid, or a string describing the error if invalid.
  */
 export type AgentOutputValidator = (
-	result: SubAgentResult,
+	/** Model output is untrusted until each validator narrows it. */
+	result: unknown,
 	taskId: string,
 	state: GlobalGraphState,
 ) => Promise<string | null> | string | null;
@@ -201,6 +202,43 @@ export interface OrchestratorState {
 	taskQueue?: string[][];
 	dispatchedTasks?: Task[]; // Tasks dispatched in the current tick
 	subAgentResults?: Record<string, SubAgentResult>;
+}
+
+function mergeTasks(
+	current: Task[] | undefined,
+	update: Task[] | undefined,
+): Task[] | undefined {
+	if (!current) return update;
+	if (!update) return current;
+
+	const byId = new Map(current.map((task) => [task.id, task]));
+	for (const task of update) {
+		byId.set(task.id, { ...byId.get(task.id), ...task });
+	}
+	return [
+		...current.map((task) => byId.get(task.id)!),
+		...update.filter(
+			(task) => !current.some((currentTask) => currentTask.id === task.id),
+		),
+	];
+}
+
+/** Dynamic sub-agent sends begin from the same state snapshot. Merge their
+ * independent task results by id instead of allowing the last branch to erase
+ * earlier branches through a shallow object spread. */
+export function mergeOrchestratorState(
+	current: OrchestratorState,
+	update: OrchestratorState,
+): OrchestratorState {
+	return {
+		...current,
+		...update,
+		tasks: mergeTasks(current.tasks, update.tasks),
+		subAgentResults: {
+			...current.subAgentResults,
+			...update.subAgentResults,
+		},
+	};
 }
 
 export const GraphState = Annotation.Root({
@@ -273,7 +311,7 @@ export const GraphState = Annotation.Root({
 		default: () => ({}),
 	}),
 	orchestratorState: Annotation<OrchestratorState>({
-		reducer: (oldState, newState) => ({ ...oldState, ...newState }),
+		reducer: mergeOrchestratorState,
 		default: () => ({}),
 	}),
 	summarizerState: Annotation<SummarizerState>({

--- a/apps/ai-gateway/src/harness/types.ts
+++ b/apps/ai-gateway/src/harness/types.ts
@@ -150,6 +150,7 @@ export interface RouteConfigAgentResult {
 		bodySchema?: any;
 		paramsSchema?: any;
 		querySchema?: any;
+		acceptedContentTypes?: string[];
 	};
 }
 

--- a/apps/portal/src/components/ai/artifacts/ApplyBar.tsx
+++ b/apps/portal/src/components/ai/artifacts/ApplyBar.tsx
@@ -192,13 +192,8 @@ export function RouteApplyBar({
 			</Button>
 		);
 
-	// A brand-new route has nothing useful without the canvas that defines it
-	// (it would be entrypoint/response/error-handler defaults, not the plan the
-	// agent produced), so for a create there is no "route only" alternative
-	// worth offering. Applying still lands as two calls (route, then canvas),
-	// but the server now reconciles a stale default entrypoint/error-handler
-	// against the incoming canvas instead of rejecting it as a duplicate — see
-	// `saveCanvas`'s `mergeAiDuplicates` path — so the sequence is safe.
+	// A route create carries its paired canvas in the same transaction. Sending
+	// the canvas again would mint another set of ids for its new blocks.
 	if (action === "create")
 		return (
 			<Button
@@ -207,7 +202,7 @@ export function RouteApplyBar({
 				isPending={isPending}
 				isDisabled={isPending}
 				className="cursor-pointer self-start"
-				onPress={() => void run([subArtifactId, canvasSubArtifactId])}
+				onPress={() => void run([subArtifactId])}
 			>
 				{verb} route with canvas
 			</Button>

--- a/apps/portal/src/components/ai/artifacts/RouteArtifact.tsx
+++ b/apps/portal/src/components/ai/artifacts/RouteArtifact.tsx
@@ -4,6 +4,7 @@ import { routesQuery } from "@/query/routesQuery";
 import { RouteApplyBar } from "./ApplyBar";
 import { CanvasPreview } from "./CanvasPreview";
 import { Field } from "./Field";
+import { SchemaField } from "./SchemaField";
 import {
 	useArtifactParams,
 	useBlockingParent,
@@ -101,13 +102,13 @@ export function RouteArtifact({ subArtifactId }: { subArtifactId: string }) {
 						<Field label="Path" current={route?.path} next={proposed.path} />
 					</Tabs.Panel>
 					<Tabs.Panel id="params">
-						<Field label="Path parameters" current={route?.paramsSchema} next={proposed.paramsSchema} />
+						<SchemaField label="Path parameters" current={route?.paramsSchema} next={proposed.paramsSchema} />
 					</Tabs.Panel>
 					<Tabs.Panel id="query">
-						<Field label="Query string" current={route?.querySchema} next={proposed.querySchema} />
+						<SchemaField label="Query string" current={route?.querySchema} next={proposed.querySchema} />
 					</Tabs.Panel>
 					<Tabs.Panel id="body">
-						<Field label="Request body" current={route?.bodySchema} next={proposed.bodySchema} />
+						<SchemaField label="Request body" current={route?.bodySchema} next={proposed.bodySchema} />
 					</Tabs.Panel>
 				</Tabs>
 			)}

--- a/apps/portal/src/components/ai/artifacts/SchemaField.tsx
+++ b/apps/portal/src/components/ai/artifacts/SchemaField.tsx
@@ -1,0 +1,91 @@
+import { useState } from "react";
+import {
+	Button,
+	CloseButton,
+	Modal,
+	SchemaEditor,
+} from "@fluxify/components";
+
+/**
+ * A field that opens a large schema in a modal instead of printing it inline,
+ * used for `route` and `query` params, as well as `bodySchema` in the artifacts sidebar.
+ */
+export function SchemaField({
+	label,
+	current,
+	next,
+}: {
+	label: string;
+	current?: unknown;
+	next?: unknown;
+}) {
+	const [isOpen, setIsOpen] = useState(false);
+
+	const text = (v: unknown) =>
+		v === undefined || v === null || v === ""
+			? ""
+			: typeof v === "string"
+				? v
+				: JSON.stringify(v, null, 2);
+
+	const before = text(current);
+	const after = text(next);
+	const changed = after !== "" && after !== before;
+
+	// Use `next` if changed, else `current`. Default to empty schema if neither.
+	const schemaToRender = changed ? next : current;
+	const isEmpty = !schemaToRender || Object.keys(schemaToRender as any).length === 0;
+
+	return (
+		<div>
+			<span className="text-[10px] text-muted uppercase font-bold tracking-wider">
+				{label}
+			</span>
+			<div className="mt-1 flex items-center justify-between gap-3 p-3 rounded-lg border border-border bg-surface-secondary">
+				<span className="text-sm font-medium text-foreground">
+					{isEmpty ? "Empty Schema" : changed ? "Schema (modified)" : "Schema (unchanged)"}
+				</span>
+				<Button
+					size="sm"
+					variant="outline"
+					isDisabled={isEmpty}
+					onPress={() => setIsOpen(true)}
+				>
+					View Schema
+				</Button>
+			</div>
+
+			<Modal isOpen={isOpen} onOpenChange={setIsOpen}>
+				<Modal.Backdrop>
+					<Modal.Container placement="center" size="lg" className="p-0">
+						<Modal.Dialog className="flex h-[80vh] w-full max-w-4xl flex-col overflow-hidden border border-border bg-background p-0 shadow-2xl shadow-black/50">
+							<Modal.Header className="flex shrink-0 flex-row items-center gap-3 border-b border-border px-5 py-3">
+								<div className="min-w-0">
+									<Modal.Heading className="text-sm font-semibold">
+										{label}
+									</Modal.Heading>
+									<p className="truncate font-mono text-xs text-muted">
+										{changed ? "Proposed changes" : "Current schema"}
+									</p>
+								</div>
+								<CloseButton
+									aria-label="Close schema viewer"
+									className="ml-auto"
+									onPress={() => setIsOpen(false)}
+								/>
+							</Modal.Header>
+							<Modal.Body className="min-h-0 flex-1 p-0 overflow-y-auto bg-surface-secondary">
+								<div className="p-5 h-full">
+									<SchemaEditor
+										value={schemaToRender as any}
+										isReadOnly={true}
+									/>
+								</div>
+							</Modal.Body>
+						</Modal.Dialog>
+					</Modal.Container>
+				</Modal.Backdrop>
+			</Modal>
+		</div>
+	);
+}

--- a/apps/portal/src/components/ai/artifacts/previewGraph.spec.ts
+++ b/apps/portal/src/components/ai/artifacts/previewGraph.spec.ts
@@ -35,4 +35,18 @@ describe("previewGraph", () => {
 	it("is a no-op preview when the agent proposed nothing", () => {
 		expect(previewGraph({}, existing).blocks).toHaveLength(2);
 	});
+
+	it("shows the live canvas after the proposal has been applied", () => {
+		const graph = previewGraph(
+			{
+				targetType: "route",
+				targetId: "r1",
+				blocks: [{ id: "block_1", blockType: "response" }],
+			},
+			existing,
+			true,
+		);
+
+		expect(graph.blocks).toHaveLength(2);
+	});
 });

--- a/apps/portal/src/components/ai/artifacts/previewGraph.ts
+++ b/apps/portal/src/components/ai/artifacts/previewGraph.ts
@@ -16,7 +16,25 @@ export type { BlockBuilderPayload };
 export function previewGraph(
 	payload: BlockBuilderPayload,
 	existing: CanvasItems,
+	isApplied = false,
 ): CanvasGraph {
+	// The proposal remains stored after apply, while `existing` has become the
+	// live result of that same proposal. Replaying it here mints fresh preview
+	// ids and renders a second visual copy, even though apply correctly no-ops.
+	if (isApplied) {
+		return {
+			blocks: existing.blocks.map((block) => ({
+				...block,
+				data: (block.data ?? {}) as BlockData,
+			})),
+			edges: existing.edges.map((edge) => ({
+				...edge,
+				fromHandle: edge.fromHandle ?? `${edge.from}-source`,
+				toHandle: edge.toHandle ?? `${edge.to}-target`,
+			})),
+		};
+	}
+
 	const { actionsToPerform, changes } = canvasChangesFromPayload(payload, existing);
 	const deleted = new Set(
 		actionsToPerform.blocks.filter((a) => a.action === "delete").map((a) => a.id),

--- a/apps/portal/src/components/ai/artifacts/useArtifact.ts
+++ b/apps/portal/src/components/ai/artifacts/useArtifact.ts
@@ -129,9 +129,9 @@ export function useCanvasArtifact(detail: SubArtifactDetail | undefined) {
 
 	const existing = canvasItems.data ?? EMPTY_CANVAS;
 	const graph = useMemo(
-		() => previewGraph(payload, existing),
+		() => previewGraph(payload, existing, Boolean(detail?.appliedAt)),
 		// payload identity is stable while the query cache holds it
-		[payload, existing],
+		[payload, existing, detail?.appliedAt],
 	);
 
 	return {
@@ -151,8 +151,13 @@ export function useCustomBlockCanvasArtifact(detail: SubArtifactDetail | undefin
 	const targetId = payload.targetId ?? "";
 	const existingCanvas = customBlocksQuery.canvasItems.useQuery(targetId);
 	const graph = useMemo(
-		() => previewGraph(payload, existingCanvas.data ?? EMPTY_CANVAS),
-		[payload, existingCanvas.data],
+		() =>
+			previewGraph(
+				payload,
+				existingCanvas.data ?? EMPTY_CANVAS,
+				Boolean(detail?.appliedAt),
+			),
+		[payload, existingCanvas.data, detail?.appliedAt],
 	);
 	return { graph, isLoading: existingCanvas.isLoading };
 }

--- a/apps/portal/src/components/canvas/panel/fields.tsx
+++ b/apps/portal/src/components/canvas/panel/fields.tsx
@@ -333,6 +333,7 @@ export function BlockIntegrationField({
 			selectedId={selectedId}
 			loadIntegrations={loadIntegrations}
 			injectedIntegrations={injectedIntegrations}
+			readonly={!editable}
 			onSelect={(id) => {
 				if (!editable) return;
 				updateNodeData(blockId, { [name]: id });

--- a/apps/server/src/api/v1/routes/schema-validator.ts
+++ b/apps/server/src/api/v1/routes/schema-validator.ts
@@ -38,6 +38,7 @@ export function validateRouteSchemas(data: {
 }) {
   const { path, bodySchema, querySchema, paramsSchema } = data;
   const errors: { path: string; message: string }[] = [];
+  const pathParams = extractPathParams(path);
 
   // Validate body schema structural correctness
   if (bodySchema) {
@@ -56,13 +57,13 @@ export function validateRouteSchemas(data: {
   }
 
   // Validate params schema structural correctness
-  if (paramsSchema) {
+  if (pathParams.length > 0 && !paramsSchema) {
+    errors.push({ path: "paramsSchema", message: "Route path parameters require a paramsSchema" });
+  } else if (paramsSchema) {
     const parsed = ValidationSchemaZod.safeParse(paramsSchema);
     if (!parsed.success) {
       errors.push({ path: "paramsSchema", message: "Invalid params schema format" });
     } else {
-      const pathParams = extractPathParams(path);
-
       const properties = paramsSchema.properties || [];
       const schemaParamKeys = properties.map((p: any) => p.key);
 

--- a/apps/server/src/api/v1/routes/tests/schema-validator.test.ts
+++ b/apps/server/src/api/v1/routes/tests/schema-validator.test.ts
@@ -42,6 +42,12 @@ describe("validateRouteSchemas", () => {
     expect(result.errors[0].message).toContain("missing from paramsSchema");
   });
 
+  test("requires paramsSchema when the path declares parameters", () => {
+    const result = validateRouteSchemas({ path: "/api/users/:userId" });
+    expect(result.success).toBe(false);
+    expect(result.errors[0].message).toContain("require a paramsSchema");
+  });
+
   test("fails if paramsSchema has extra params not in path", () => {
     const result = validateRouteSchemas({
       path: "/api/users/:userId",

--- a/packages/components/src/IntegrationSelector/IntegrationSelector.tsx
+++ b/packages/components/src/IntegrationSelector/IntegrationSelector.tsx
@@ -304,6 +304,7 @@ export function IntegrationSelector({
 	label,
 	description,
 	className,
+	readonly = false,
 }: IntegrationSelectorProps) {
 	const [loaded, setLoaded] = useState<Integration[]>([]);
 	// injected entries need no fetch and always come first
@@ -501,6 +502,7 @@ export function IntegrationSelector({
 										aria-label="Clear Integration"
 										onPress={handleClear}
 										className={iconBtnClass}
+										isDisabled={readonly}
 									/>
 								)}
 
@@ -515,7 +517,7 @@ export function IntegrationSelector({
 						<Button
 							variant="primary"
 							size="sm"
-							isDisabled={loadStatus === "loading" || loadStatus === "error"}
+							isDisabled={readonly || loadStatus === "loading" || loadStatus === "error"}
 							onPress={() => setPickerOpen(true)}
 						>
 							{selectBtnLabel}

--- a/packages/components/src/IntegrationSelector/types.ts
+++ b/packages/components/src/IntegrationSelector/types.ts
@@ -78,4 +78,6 @@ export interface IntegrationSelectorProps {
 	description?: string;
 	/** Additional CSS class applied to the root element. */
 	className?: string;
+	/** Disables the select and clear buttons, making it read-only. */
+	readonly?: boolean;
 }


### PR DESCRIPTION
## Summary
- validate and normalize route, custom-block, and canvas harness artifacts
- prevent repeated artifact application and duplicate applied-canvas previews
- render route schemas in a dedicated read-only viewer
- preserve integration selector read-only mode

## Verification
- pre-commit: lint, secret scan, FTA, 861 tests passed