### PR TITLE
fix: prevent duplicate canvas output edges

### DIFF
--- a/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/normalize.spec.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/normalize.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import {
+	canvasAfterChanges,
 	canvasChangesFromPayload,
 	customBlockOpFromPayload,
 	routeOpFromPayload,
@@ -304,6 +305,50 @@ describe("canvasChangesFromPayload", () => {
 
 		expect(result.changes.edges).toEqual([
 			{ id: "edge-1", from: "a", to: "c", fromHandle: "a-source", toHandle: "c-target" },
+		]);
+	});
+
+	it("replaces a changed block's stale edge on the same handle", () => {
+		const existing: CanvasItems = {
+			blocks: [
+				{ id: "a", type: "entrypoint", data: {}, position: { x: 0, y: 0 } },
+				{ id: "b", type: "response", data: {}, position: { x: 0, y: 100 } },
+				{ id: "c", type: "consolelog", data: {}, position: { x: 0, y: 200 } },
+			],
+			edges: [
+				{ id: "edge-old", from: "a", to: "b", fromHandle: "a-source", toHandle: "b-target" },
+			],
+		};
+
+		const result = canvasChangesFromPayload(
+			{
+				targetType: "route",
+				targetId: "r-1",
+				canvasChanges: [
+					{
+						type: "block_change",
+						data: {
+							blocksInfo: [
+								{
+									id: "a",
+									blockType: "entrypoint",
+									position: { x: 0, y: 0 },
+									connections: [{ blockId: "c", handle: "source" }],
+								},
+							],
+						},
+					},
+				],
+			},
+			existing,
+		);
+
+		expect(result.actionsToPerform.edges).toContainEqual({
+			id: "edge-old",
+			action: "delete",
+		});
+		expect(canvasAfterChanges(existing, result).edges).toEqual([
+			expect.objectContaining({ from: "a", to: "c", fromHandle: "a-source" }),
 		]);
 	});
 

--- a/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/normalize.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/normalize.ts
@@ -49,6 +49,18 @@ export type BlockBuilderPayload = {
 	targetId?: string;
 	blocks?: AgentBlock[] | null;
 	canvasChanges?: { type: string; data: any }[] | null;
+	/**
+	 * Materialized before persistence so the artifact preview shows the exact
+	 * graph proposed against the canvas the agent read, rather than replaying a
+	 * partial delta in the browser. Apply still re-materializes against the live
+	 * canvas, because it may have changed while the artifact waited for review.
+	 */
+	preparedCanvas?: PreparedCanvas;
+};
+
+export type PreparedCanvas = {
+	changes: CanvasChanges;
+	preview: CanvasItems;
 };
 
 export type RouteConfigPayload = {
@@ -313,6 +325,7 @@ export function canvasChangesFromPayload(
 		}));
 
 	const edges: CanvasChanges["changes"]["edges"] = [];
+	const deletedEdgeIds = new Set<string>();
 	const seen = new Set<string>();
 	const storedEdgeId = new Map(
 		existing.edges.map((e) => [`${e.from}|${e.fromHandle ?? ""}|${e.to}`, e.id]),
@@ -334,12 +347,30 @@ export function canvasChangesFromPayload(
 		});
 	}
 
+	/** A connection emitted for an existing source/handle replaces the old
+	 * connection on that handle. The save API applies deltas, not whole edge
+	 * lists, so omitting this deletion used to leave the old edge live beside the
+	 * new one. */
+	function replaceStoredHandle(from: string, handle: string, keepTo: string) {
+		const fromHandle = fullHandle(from, handle, "source");
+		for (const edge of existing.edges) {
+			if (edge.from !== from || (edge.fromHandle ?? "") !== fromHandle) continue;
+			if (edge.to !== keepTo) deletedEdgeIds.add(edge.id);
+		}
+	}
+
 	for (const block of declared) {
 		if (removed.has(block.id)) continue;
 		for (const connection of block.connections ?? []) {
 			if (!connection?.blockId || !known.has(connection.blockId)) continue;
 			if (removed.has(connection.blockId)) continue;
-			addEdge(idFor(block.id), idFor(connection.blockId), connection.handle ?? "source");
+			const from = idFor(block.id);
+			const to = idFor(connection.blockId);
+			const handle = connection.handle ?? "source";
+			// New blocks cannot have stale edges. For stored blocks, each declared
+			// connection is an explicit replacement for its output handle.
+			if (storedIds.has(from)) replaceStoredHandle(from, handle, to);
+			addEdge(from, to, handle);
 		}
 	}
 
@@ -354,6 +385,7 @@ export function canvasChangesFromPayload(
 		const previous = existing.edges.find(
 			(e) => e.from === from && (e.fromHandle ?? "") === handle,
 		);
+		replaceStoredHandle(from, fromHandle ?? "source", idFor(toEdge));
 		// `toHandle` is ignored on purpose: every block has exactly one inbound
 		// socket, so the target side is always `<to>-target`.
 		void toHandle;
@@ -396,12 +428,77 @@ export function canvasChangesFromPayload(
 				...blocks.map((b) => ({ id: b.id, action: "upsert" as const })),
 				...[...removed].map((id) => ({ id, action: "delete" as const })),
 			],
-			// edges of a removed block go with it (the FK cascades), so only
-			// upserts are ever listed here
-			edges: edges.map((e) => ({ id: e.id, action: "upsert" as const })),
+			// Edges of a removed block go with it (the FK cascades). Edges replaced
+			// on a stored output handle must be explicitly deleted, however.
+			edges: [
+				...edges.map((e) => ({ id: e.id, action: "upsert" as const })),
+				...[...deletedEdgeIds]
+					.filter((id) => !edges.some((edge) => edge.id === id))
+					.map((id) => ({ id, action: "delete" as const })),
+			],
 		},
 		changes: { blocks, edges },
 	};
+}
+
+/** Apply a canonical canvas delta in memory. Shared by artifact preparation
+ * and the frontend preview so both see the same post-apply graph. */
+export function canvasAfterChanges(
+	existing: CanvasItems,
+	changes: CanvasChanges,
+): CanvasItems {
+	const deletedBlocks = new Set(
+		changes.actionsToPerform.blocks
+			.filter((action) => action.action === "delete")
+			.map((action) => action.id),
+	);
+	const deletedEdges = new Set(
+		changes.actionsToPerform.edges
+			.filter((action) => action.action === "delete")
+			.map((action) => action.id),
+	);
+	const blocks = new Map(
+		existing.blocks
+			.filter((block) => !deletedBlocks.has(block.id))
+			.map((block) => [block.id, block]),
+	);
+	for (const block of changes.changes.blocks) blocks.set(block.id, block);
+
+	const edges = new Map(
+		existing.edges
+			.filter(
+				(edge) =>
+					!deletedEdges.has(edge.id) &&
+					!deletedBlocks.has(edge.from) &&
+					!deletedBlocks.has(edge.to),
+			)
+			.map((edge) => [edge.id, edge]),
+	);
+	for (const edge of changes.changes.edges) edges.set(edge.id, edge);
+
+	return { blocks: [...blocks.values()], edges: [...edges.values()] };
+}
+
+/** The runtime resolves only one edge per source handle. Keep this check close
+ * to artifact materialization so an invalid graph never becomes a preview that
+ * looks safe to approve. The canvas service repeats the invariant for all
+ * writers at apply time. */
+export function assertNoHandleFanOut(canvas: CanvasItems) {
+	const edgeByHandle = new Map<string, string>();
+	for (const edge of canvas.edges) {
+		const rawHandle = edge.fromHandle ?? "source";
+		const handle = rawHandle.startsWith(`${edge.from}-`)
+			? rawHandle.slice(edge.from.length + 1)
+			: rawHandle;
+		const key = `${edge.from}|${handle}`;
+		const first = edgeByHandle.get(key);
+		if (first) {
+			throw new Error(
+				`Canvas has multiple outgoing edges on ${edge.from}'s ${handle} handle (${first}, ${edge.id}).`,
+			);
+		}
+		edgeByHandle.set(key, edge.id);
+	}
 }
 
 /**
@@ -425,6 +522,11 @@ export async function formatCanvasChanges(
 			.filter((b) => b.action === "delete")
 			.map((b) => b.id),
 	);
+	const deletedEdges = new Set(
+		changes.actionsToPerform.edges
+			.filter((edge) => edge.action === "delete")
+			.map((edge) => edge.id),
+	);
 	const changedIds = new Set(changes.changes.blocks.map((b) => b.id));
 
 	const nodes = [
@@ -436,7 +538,11 @@ export async function formatCanvasChanges(
 	if (nodes.length === 0) return changes;
 
 	// Superseded edges are keyed by id, so the agent's version wins.
-	const edgeById = new Map(existing.edges.map((e) => [e.id, e]));
+	const edgeById = new Map(
+		existing.edges
+			.filter((edge) => !deletedEdges.has(edge.id))
+			.map((edge) => [edge.id, edge]),
+	);
 	for (const edge of changes.changes.edges) edgeById.set(edge.id, edge);
 	const edges = [...edgeById.values()].filter(
 		(e) => !removed.has(e.from) && !removed.has(e.to),
@@ -473,4 +579,15 @@ export async function formattedCanvasChanges(
 	existing: CanvasItems,
 ): Promise<CanvasChanges> {
 	return formatCanvasChanges(canvasChangesFromPayload(payload, existing), existing);
+}
+
+/** Build the stable artifact preview before persisting it. */
+export async function prepareCanvasArtifact(
+	payload: BlockBuilderPayload,
+	existing: CanvasItems,
+): Promise<PreparedCanvas> {
+	const changes = await formattedCanvasChanges(payload, existing);
+	const preview = canvasAfterChanges(existing, changes);
+	assertNoHandleFanOut(preview);
+	return { changes, preview };
 }

--- a/apps/ai-gateway/src/harness/agents/summarizer.ts
+++ b/apps/ai-gateway/src/harness/agents/summarizer.ts
@@ -7,6 +7,15 @@ import {
 	type ApplyFailure,
 } from "../../api/v1/harness-conversations/artifacts/service";
 import { applyArtifact } from "../../api/v1/harness-conversations/artifacts/applyBatch";
+import {
+	prepareCanvasArtifact,
+	type BlockBuilderPayload,
+	type CanvasItems,
+} from "../../api/v1/harness-conversations/artifacts/normalize";
+import {
+	callerFor,
+	readCanvas,
+} from "../../api/v1/harness-conversations/artifacts/opsClient";
 
 /** A single change the harness made, with its verbatim special-syntax token. */
 interface ChangeRef {
@@ -99,6 +108,36 @@ export class SummarizerAgent extends BaseAgent {
 		}
 	}
 
+	/** Materialize a canvas while the artifact is being created. The stored
+	 * preview is what review renders; applying later still rebuilds from the live
+	 * canvas so a stale artifact cannot overwrite intervening edits. */
+	private async prepareCanvasPayload(
+		result: BlockBuilderPayload,
+		plannedNewTargets: ReadonlySet<string>,
+	): Promise<Record<string, any>> {
+		const meta = this.state.internal?.metadata ?? {};
+		const targetType = result.targetType === "custom_block" ? "custom_block" : "route";
+		const targetId = result.targetId;
+		const targetKey = targetId ? `${targetType}:${targetId}` : "";
+		let existing: CanvasItems = { blocks: [], edges: [] };
+
+		if (targetId && !plannedNewTargets.has(targetKey)) {
+			if (!meta.userId || !meta.projectId) {
+				throw new Error("Canvas artifact has no project or user context for preparation.");
+			}
+			existing = await readCanvas(
+				callerFor(meta.userId, meta.projectId),
+				targetType,
+				targetId,
+			);
+		}
+
+		return {
+			...result,
+			preparedCanvas: await prepareCanvasArtifact(result, existing),
+		};
+	}
+
 	async execute(): Promise<Partial<GlobalGraphState>> {
 		await dispatchAgentEvent({
 			name: "agent_status",
@@ -111,6 +150,19 @@ export class SummarizerAgent extends BaseAgent {
 		const scratchpad = this.state.scratchpad ?? [];
 		const runId: string | undefined = this.state.internal?.metadata?.runId;
 		const harnessService = this.state.internal?.harnessService;
+		const plannedNewTargets = new Set<string>();
+		for (const result of Object.values(results) as any[]) {
+			if (isRouteConfigResult(result) && result.action === "create" && result.routeId) {
+				plannedNewTargets.add(`route:${result.routeId}`);
+			}
+			if (
+				isCustomBlockConfigResult(result) &&
+				result.action === "create" &&
+				result.customBlockId
+			) {
+				plannedNewTargets.add(`custom_block:${result.customBlockId}`);
+			}
+		}
 
 		// Persist the artifact + sub-artifacts (regular DB work, no AI involved).
 		const changes: ChangeRef[] = [];
@@ -167,6 +219,10 @@ export class SummarizerAgent extends BaseAgent {
 							token: `:route{type="${type}" sub_artifact_id="${subId}"}`,
 						});
 					} else if (isBlockBuilderResult(result)) {
+						const payload = await this.prepareCanvasPayload(
+							result as BlockBuilderPayload,
+							plannedNewTargets,
+						);
 						const subId = await harnessService.createSubArtifact({
 							artifactId,
 							runId,
@@ -174,7 +230,7 @@ export class SummarizerAgent extends BaseAgent {
 							dependsOn: task.dependsOnAgentId,
 							kind: "canvas",
 							action: "changes",
-							payload: result,
+							payload,
 						});
 						subArtifactIds[task.id] = subId;
 						let parentType: string;

--- a/apps/portal/src/components/ai/artifacts/previewGraph.spec.ts
+++ b/apps/portal/src/components/ai/artifacts/previewGraph.spec.ts
@@ -49,4 +49,23 @@ describe("previewGraph", () => {
 
 		expect(graph.blocks).toHaveLength(2);
 	});
+
+	it("renders the prepared preview saved with an unapplied artifact", () => {
+		const graph = previewGraph(
+			{
+				targetType: "route",
+				targetId: "r1",
+				preparedCanvas: {
+					changes: { actionsToPerform: { blocks: [], edges: [] }, changes: { blocks: [], edges: [] } },
+					preview: {
+						blocks: [{ id: "planned", type: "response", data: {}, position: { x: 5, y: 5 } }],
+						edges: [],
+					},
+				},
+			},
+			existing,
+		);
+
+		expect(graph.blocks.map((block) => block.id)).toEqual(["planned"]);
+	});
 });

--- a/apps/portal/src/components/ai/artifacts/previewGraph.ts
+++ b/apps/portal/src/components/ai/artifacts/previewGraph.ts
@@ -35,9 +35,32 @@ export function previewGraph(
 		};
 	}
 
+	// Canvas artifacts are materialized before persistence. Render that frozen
+	// plan during review so a later live-canvas read cannot make the artifact
+	// look different from what the user is approving.
+	if (payload.preparedCanvas?.preview) {
+		const preview = payload.preparedCanvas.preview;
+		return {
+			blocks: preview.blocks.map((block) => ({
+				...block,
+				data: (block.data ?? {}) as BlockData,
+			})),
+			edges: preview.edges.map((edge) => ({
+				...edge,
+				fromHandle: edge.fromHandle ?? `${edge.from}-source`,
+				toHandle: edge.toHandle ?? `${edge.to}-target`,
+			})),
+		};
+	}
+
 	const { actionsToPerform, changes } = canvasChangesFromPayload(payload, existing);
 	const deleted = new Set(
 		actionsToPerform.blocks.filter((a) => a.action === "delete").map((a) => a.id),
+	);
+	const deletedEdges = new Set(
+		actionsToPerform.edges
+			.filter((action) => action.action === "delete")
+			.map((action) => action.id),
 	);
 
 	const blocks = new Map(
@@ -48,7 +71,10 @@ export function previewGraph(
 	// an edge of a deleted block goes with it (the FK cascades)
 	const edges = new Map(
 		existing.edges
-			.filter((e) => !deleted.has(e.from) && !deleted.has(e.to))
+			.filter(
+				(e) =>
+					!deletedEdges.has(e.id) && !deleted.has(e.from) && !deleted.has(e.to),
+			)
 			.map((e) => [e.id, e]),
 	);
 	for (const edge of changes.edges) edges.set(edge.id, edge);

--- a/apps/server/src/modules/canvas/service.ts
+++ b/apps/server/src/modules/canvas/service.ts
@@ -30,6 +30,10 @@ import {
 } from "./cycleDetection";
 import type { CanvasChanges, CanvasParent } from "./types";
 
+type CanvasEdgeWithHandle = DirectedCanvasEdge & {
+	fromHandle?: string | null;
+};
+
 const CHANGE_CHANNEL = {
 	route: CHAN_ON_ROUTE_CHANGE,
 	custom_block: CHAN_ON_CUSTOM_BLOCK_CHANGE,
@@ -81,10 +85,14 @@ async function canvasEdgesAfterSave(
 	deleteEdgeIds: string[],
 	tx: DbTransactionType,
 ) {
-	const edges = new Map<string, DirectedCanvasEdge>(
-		(await getEdges(parent, tx)).map((edge) => [edge.id, edge]),
+	const edges = new Map<string, CanvasEdgeWithHandle>(
+		(await getEdges(parent, tx)).map((edge) => [
+			edge.id,
+			edge as CanvasEdgeWithHandle,
+		]),
 	);
-	for (const edge of data.changes.edges) edges.set(edge.id, edge);
+	for (const edge of data.changes.edges)
+		edges.set(edge.id, edge as CanvasEdgeWithHandle);
 	for (const edgeId of deleteEdgeIds) edges.delete(edgeId);
 
 	const deletedBlocks = new Set(deleteBlockIds);
@@ -114,6 +122,39 @@ async function assertCanvasHasNoCycles(
 	throw new ConflictError(
 		`Canvas cannot contain cycles. Remove connection(s): ${[...cycleEdgeIds].join(", ")}`,
 	);
+}
+
+/** The runtime takes the first edge it finds for an output handle. Rejecting
+ * fan-out here protects every canvas writer, not only the AI harness. */
+async function assertCanvasHasNoHandleFanOut(
+	parent: CanvasParent,
+	data: CanvasChanges,
+	deleteBlockIds: string[],
+	deleteEdgeIds: string[],
+	tx: DbTransactionType,
+) {
+	const seen = new Map<string, string>();
+	for (const edge of await canvasEdgesAfterSave(
+		parent,
+		data,
+		deleteBlockIds,
+		deleteEdgeIds,
+		tx,
+	)) {
+		if (!edge.from) continue;
+		const rawHandle = edge.fromHandle ?? "source";
+		const handle = rawHandle.startsWith(`${edge.from}-`)
+			? rawHandle.slice(edge.from.length + 1)
+			: rawHandle;
+		const key = `${edge.from}|${handle}`;
+		const first = seen.get(key);
+		if (first) {
+			throw new BadRequestError(
+				`Canvas has multiple outgoing edges on block ${edge.from}'s ${handle} handle (${first}, ${edge.id}).`,
+			);
+		}
+		seen.set(key, edge.id);
+	}
 }
 
 /**
@@ -287,6 +328,13 @@ export async function saveCanvas(
 		await assertNoCustomBlockRecursion(parent, data, deleteBlockIds, tx);
 		await assertEdgeTargetsExist(parent, data, deleteBlockIds, tx);
 		await assertCanvasHasNoCycles(
+			parent,
+			data,
+			deleteBlockIds,
+			deleteEdgeIds,
+			tx,
+		);
+		await assertCanvasHasNoHandleFanOut(
 			parent,
 			data,
 			deleteBlockIds,

--- a/apps/server/src/modules/canvas/tests/service.spec.ts
+++ b/apps/server/src/modules/canvas/tests/service.spec.ts
@@ -189,6 +189,34 @@ describe("canvas saveCanvas", () => {
 		expect(upsertEdges).not.toHaveBeenCalled();
 	});
 
+	it("rejects two edges from one output handle after merging the delta", async () => {
+		spyOn(repository, "getBlocks").mockResolvedValue([
+			{ id: "a" },
+			{ id: "b" },
+			{ id: "c" },
+		] as any);
+		getEdges.mockResolvedValue([
+			{ id: "old", from: "a", to: "b", fromHandle: "a-source", toHandle: "b-target" },
+		] as any);
+
+		await expect(
+			saveCanvas(
+				{ type: "route", id: "r-1" },
+				{
+					actionsToPerform: { blocks: [], edges: [] },
+					changes: {
+						blocks: [],
+						edges: [
+							{ id: "new", from: "a", to: "c", fromHandle: "a-source", toHandle: "c-target" },
+						],
+					},
+				},
+				["p1"],
+			),
+		).rejects.toThrow(/multiple outgoing edges/);
+		expect(upsertEdges).not.toHaveBeenCalled();
+	});
+
 	describe("custom block recursion", () => {
 		const project = [
 			{ id: "cb-1", name: "audit" },


### PR DESCRIPTION
## Summary

Canvas Block Builder artifacts could add a new connection from an existing block output without removing the old connection. The artifact-level verifier checked only the proposed delta, while applying that delta merged it with the stored canvas. This could leave two outgoing edges on one source handle even when the review artifact appeared to have one.

## What changed

- Materialize the merged canvas before storing a canvas artifact, validate its output-handle invariant, and persist the prepared preview with the artifact.
- Treat a declared connection from an existing source handle as a replacement: emit deletion actions for displaced stored edges.
- Render the persisted prepared preview during review, so frontend review shows the graph that was validated before storage.
- Enforce the same no-fan-out rule inside the server transaction after merging the live canvas with the requested delta. This protects AI artifacts, UI edits, and direct API writers.
- Add regression tests for stale-edge replacement, stored previews, and server-side merge rejection.

## Validation

- Pre-commit checks passed: lint, secret scan, code analysis, and 871 tests passed (2 skipped).
- Focused artifact, server, portal, and Block Builder tests also pass.