### PR TITLE
perf(harness): cut Block Builder context and remove routine LLM work

### DIFF
--- a/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/canvasLayout.spec.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/canvasLayout.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "bun:test";
+import { formattedCanvasChanges } from "./canvasLayout";
+import type { CanvasItems } from "./normalize";
+
+describe("formattedCanvasChanges layout anchoring", () => {
+	/** A three-block route the user has already arranged on screen. */
+	const arranged: CanvasItems = {
+		blocks: [
+			{ id: "e1", type: "entrypoint", data: {}, position: { x: 900, y: 300 } },
+			{ id: "j1", type: "jsrunner", data: { value: "return 1" }, position: { x: 1132, y: 300 } },
+			{ id: "r1", type: "response", data: { httpCode: "200" }, position: { x: 1364, y: 300 } },
+		],
+		edges: [
+			{ id: "x1", from: "e1", to: "j1", fromHandle: "e1-source", toHandle: "j1-target" },
+			{ id: "x2", from: "j1", to: "r1", fromHandle: "j1-source", toHandle: "r1-target" },
+		],
+	};
+
+	it("keeps untouched blocks where the user put them when the agent re-emits the canvas", async () => {
+		// The contract asks for NEW blocks in `blocks`, but an agent editing one
+		// field routinely restates the whole canvas — with coordinates it invented
+		// for a canvas it cannot see. Every block then read as "changed", the
+		// layout had nothing to anchor on, and the whole route jumped to 0,0.
+		const out = await formattedCanvasChanges(
+			{
+				blocks: [
+					{ id: "e1", blockType: "entrypoint", data: {}, position: { x: 0, y: 0 }, connections: [{ blockId: "j1", handle: "source" }] },
+					{ id: "j1", blockType: "jsrunner", data: { value: "return 2" }, position: { x: 200, y: 0 }, connections: [{ blockId: "r1", handle: "source" }] },
+					{ id: "r1", blockType: "response", data: { httpCode: "200" }, position: { x: 400, y: 0 }, connections: [] },
+				],
+			},
+			arranged,
+		);
+
+		const at = (id: string) => out.changes.blocks.find((b) => b.id === id)?.position;
+		expect(at("e1")).toEqual({ x: 900, y: 300 });
+		expect(at("r1")).toEqual({ x: 1364, y: 300 });
+		// The one block it actually edited keeps its new configuration.
+		expect(out.changes.blocks.find((b) => b.id === "j1")?.data).toMatchObject({
+			value: "return 2",
+		});
+	});
+
+	it("still re-flows around a genuinely new block", async () => {
+		const out = await formattedCanvasChanges(
+			{
+				blocks: [
+					{ id: "new_1", blockType: "consolelog", data: { message: "hi" }, position: { x: 0, y: 0 }, connections: [{ blockId: "r1", handle: "source" }] },
+				],
+				canvasChanges: [
+					{ type: "edge_swap", data: { fromEdge: "j1", fromHandle: "source", toEdge: "new_1" } },
+				],
+			},
+			arranged,
+		);
+
+		const placed = out.changes.blocks.find((b) => b.type === "consolelog");
+		// Laid out relative to the arrangement it was inserted into, not at 0,0.
+		expect(placed?.position.x).toBeGreaterThan(900);
+	});
+});

--- a/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/canvasLayout.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/canvasLayout.ts
@@ -1,0 +1,157 @@
+import { layoutGraph } from "@fluxify/blocks/layout";
+import {
+	assertNoHandleFanOut,
+	canvasAfterChanges,
+	canvasChangesFromPayload,
+	type BlockBuilderPayload,
+	type CanvasChanges,
+	type CanvasItems,
+	type PreparedCanvas,
+} from "./normalize";
+
+/**
+ * Merging an agent's canvas output into the canvas it lands on, laying the
+ * result out, and previewing it. Split out of `normalize.ts`, which had grown
+ * past the complexity cap holding both this and the payload translation.
+ */
+
+/** Key order is not significance: the agent rebuilds `data` from what it read,
+ *  and a reordered object is the same configuration. */
+function stableJson(value: unknown): string {
+	return JSON.stringify(value ?? {}, (_key, item) =>
+		item && typeof item === "object" && !Array.isArray(item)
+			? Object.fromEntries(
+					Object.entries(item).sort(([a], [b]) => a.localeCompare(b)),
+				)
+			: item,
+	);
+}
+
+/**
+ * True when a declared block is the stored block restated — same type, same
+ * configuration, differing only in coordinates the agent made up.
+ *
+ * The output contract asks for NEW blocks in `blocks` and edits in
+ * `canvasChanges`, but an agent told to change one thing in a route routinely
+ * re-emits the whole canvas. Every re-emitted block then counts as changed, so
+ * `anchorOffset` finds no unchanged block to anchor on and re-flows the entire
+ * graph from the origin — which is the "it moved everything" a user sees after
+ * asking for a one-block edit.
+ */
+function echoesStored(
+	block: { id: string; type: string; data: unknown },
+	before: CanvasItems["blocks"][number] | undefined,
+): boolean {
+	if (!before || before.type !== block.type) return false;
+	return stableJson(before.data) === stableJson(block.data);
+}
+
+/**
+ * Lays the canvas out after the agent's changes are merged into it.
+ *
+ * The model writes coordinates for a canvas it cannot see, so inserting a block
+ * into an existing route left the following block sitting on top of another one.
+ * ELK re-flows the merged graph; `changedIds` keeps the blocks the agent did not
+ * touch as the frame of reference, so an edit nudges the graph instead of
+ * teleporting it, and only blocks that actually move are written back.
+ *
+ * An existing block that has to move is added to the change set — with its
+ * stored type and data, since a position-only upsert would blank the rest.
+ */
+export async function formatCanvasChanges(
+	changes: CanvasChanges,
+	existing: CanvasItems,
+): Promise<CanvasChanges> {
+	const removed = new Set(
+		changes.actionsToPerform.blocks
+			.filter((b) => b.action === "delete")
+			.map((b) => b.id),
+	);
+	const deletedEdges = new Set(
+		changes.actionsToPerform.edges
+			.filter((edge) => edge.action === "delete")
+			.map((edge) => edge.id),
+	);
+
+	const stored = new Map(existing.blocks.map((b) => [b.id, b]));
+	// An echo carries coordinates the agent invented for a canvas it cannot see;
+	// keeping the stored ones is what stops a block the user never touched from
+	// being written back somewhere else.
+	const blocksIn = changes.changes.blocks.map((block) =>
+		echoesStored(block, stored.get(block.id))
+			? { ...block, position: stored.get(block.id)!.position }
+			: block,
+	);
+	// Every declared block is deduped out of the layout input, but only a real
+	// edit counts as changed: an echo has to stay available as an anchor.
+	const declaredIds = new Set(blocksIn.map((b) => b.id));
+	const changedIds = new Set(
+		blocksIn
+			.filter((b) => !echoesStored(b, stored.get(b.id)))
+			.map((b) => b.id),
+	);
+
+	const nodes = [
+		...existing.blocks.filter(
+			(b) => !removed.has(b.id) && !declaredIds.has(b.id),
+		),
+		...blocksIn,
+	].map((b) => ({ id: b.id, type: b.type, position: b.position }));
+	if (nodes.length === 0) return changes;
+
+	// Superseded edges are keyed by id, so the agent's version wins.
+	const edgeById = new Map(
+		existing.edges
+			.filter((edge) => !deletedEdges.has(edge.id))
+			.map((edge) => [edge.id, edge]),
+	);
+	for (const edge of changes.changes.edges) edgeById.set(edge.id, edge);
+	const edges = [...edgeById.values()].filter(
+		(e) => !removed.has(e.from) && !removed.has(e.to),
+	);
+
+	const moved = await layoutGraph(nodes, edges, { changedIds });
+	if (Object.keys(moved).length === 0) {
+		return { ...changes, changes: { ...changes.changes, blocks: blocksIn } };
+	}
+
+	const blocks = blocksIn.map((b) =>
+		moved[b.id] ? { ...b, position: moved[b.id]! } : b,
+	);
+	const actions = [...changes.actionsToPerform.blocks];
+	for (const block of existing.blocks) {
+		const position = moved[block.id];
+		if (!position || removed.has(block.id) || declaredIds.has(block.id)) continue;
+		blocks.push({
+			id: block.id,
+			type: block.type,
+			data: (block.data ?? {}) as Record<string, unknown>,
+			position,
+		} as (typeof blocks)[number]);
+		actions.push({ id: block.id, action: "upsert" as const });
+	}
+
+	return {
+		actionsToPerform: { ...changes.actionsToPerform, blocks: actions },
+		changes: { ...changes.changes, blocks },
+	};
+}
+
+/** `canvasChangesFromPayload` + the layout pass, which is what applying wants. */
+export async function formattedCanvasChanges(
+	payload: BlockBuilderPayload,
+	existing: CanvasItems,
+): Promise<CanvasChanges> {
+	return formatCanvasChanges(canvasChangesFromPayload(payload, existing), existing);
+}
+
+/** Build the stable artifact preview before persisting it. */
+export async function prepareCanvasArtifact(
+	payload: BlockBuilderPayload,
+	existing: CanvasItems,
+): Promise<PreparedCanvas> {
+	const changes = await formattedCanvasChanges(payload, existing);
+	const preview = canvasAfterChanges(existing, changes);
+	assertNoHandleFanOut(preview);
+	return { changes, preview };
+}

--- a/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/normalize.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/normalize.ts
@@ -2,7 +2,6 @@
 // output, and both barrels pull in Node built-ins (`vm`, pino) that break the
 // browser build.
 import { BlockTypes } from "@fluxify/blocks/blockTypes";
-import { layoutGraph } from "@fluxify/blocks/layout";
 import { generateID } from "@fluxify/lib/random/id";
 import type { canvasChangesSchema } from "@fluxify/server/src/modules/canvas/types";
 import type { z } from "zod";
@@ -499,95 +498,4 @@ export function assertNoHandleFanOut(canvas: CanvasItems) {
 		}
 		edgeByHandle.set(key, edge.id);
 	}
-}
-
-/**
- * Lays the canvas out after the agent's changes are merged into it.
- *
- * The model writes coordinates for a canvas it cannot see, so inserting a block
- * into an existing route left the following block sitting on top of another one.
- * ELK re-flows the merged graph; `changedIds` keeps the blocks the agent did not
- * touch as the frame of reference, so an edit nudges the graph instead of
- * teleporting it, and only blocks that actually move are written back.
- *
- * An existing block that has to move is added to the change set — with its
- * stored type and data, since a position-only upsert would blank the rest.
- */
-export async function formatCanvasChanges(
-	changes: CanvasChanges,
-	existing: CanvasItems,
-): Promise<CanvasChanges> {
-	const removed = new Set(
-		changes.actionsToPerform.blocks
-			.filter((b) => b.action === "delete")
-			.map((b) => b.id),
-	);
-	const deletedEdges = new Set(
-		changes.actionsToPerform.edges
-			.filter((edge) => edge.action === "delete")
-			.map((edge) => edge.id),
-	);
-	const changedIds = new Set(changes.changes.blocks.map((b) => b.id));
-
-	const nodes = [
-		...existing.blocks.filter(
-			(b) => !removed.has(b.id) && !changedIds.has(b.id),
-		),
-		...changes.changes.blocks,
-	].map((b) => ({ id: b.id, type: b.type, position: b.position }));
-	if (nodes.length === 0) return changes;
-
-	// Superseded edges are keyed by id, so the agent's version wins.
-	const edgeById = new Map(
-		existing.edges
-			.filter((edge) => !deletedEdges.has(edge.id))
-			.map((edge) => [edge.id, edge]),
-	);
-	for (const edge of changes.changes.edges) edgeById.set(edge.id, edge);
-	const edges = [...edgeById.values()].filter(
-		(e) => !removed.has(e.from) && !removed.has(e.to),
-	);
-
-	const moved = await layoutGraph(nodes, edges, { changedIds });
-	if (Object.keys(moved).length === 0) return changes;
-
-	const blocks = changes.changes.blocks.map((b) =>
-		moved[b.id] ? { ...b, position: moved[b.id]! } : b,
-	);
-	const actions = [...changes.actionsToPerform.blocks];
-	for (const block of existing.blocks) {
-		const position = moved[block.id];
-		if (!position || removed.has(block.id) || changedIds.has(block.id)) continue;
-		blocks.push({
-			id: block.id,
-			type: block.type,
-			data: (block.data ?? {}) as Record<string, unknown>,
-			position,
-		} as (typeof blocks)[number]);
-		actions.push({ id: block.id, action: "upsert" as const });
-	}
-
-	return {
-		actionsToPerform: { ...changes.actionsToPerform, blocks: actions },
-		changes: { ...changes.changes, blocks },
-	};
-}
-
-/** `canvasChangesFromPayload` + the layout pass, which is what applying wants. */
-export async function formattedCanvasChanges(
-	payload: BlockBuilderPayload,
-	existing: CanvasItems,
-): Promise<CanvasChanges> {
-	return formatCanvasChanges(canvasChangesFromPayload(payload, existing), existing);
-}
-
-/** Build the stable artifact preview before persisting it. */
-export async function prepareCanvasArtifact(
-	payload: BlockBuilderPayload,
-	existing: CanvasItems,
-): Promise<PreparedCanvas> {
-	const changes = await formattedCanvasChanges(payload, existing);
-	const preview = canvasAfterChanges(existing, changes);
-	assertNoHandleFanOut(preview);
-	return { changes, preview };
 }

--- a/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/service.ts
+++ b/apps/ai-gateway/src/api/v1/harness-conversations/artifacts/service.ts
@@ -4,7 +4,6 @@ import { publishArtifactStatus } from "../../../../harness/notifications";
 import type { ArtifactStatus } from "../../../../harness/clientContract";
 import type { RpcCaller } from "@fluxify/server/src/db/natsRpc";
 import {
-	formattedCanvasChanges,
 	customBlockOpFromPayload,
 	remapCustomBlockNames,
 	routeOpFromPayload,
@@ -14,6 +13,7 @@ import {
 	type CustomBlockConfigPayload,
 	type RouteConfigPayload,
 } from "./normalize";
+import { formattedCanvasChanges } from "./canvasLayout";
 import {
 	inlineCanvasFor,
 	kindLabel,

--- a/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/agent.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/agent.ts
@@ -11,6 +11,7 @@ import { createGetCustomBlockSchemasTool } from "../../../tools/getBlockSchemas"
 import { createGetAgentOutputTool } from "../../../tools/getAgentOutput";
 import { fenceUntrusted } from "../../../internal/untrusted";
 import { buildAgentContext } from "../../../internal/agentContext";
+import { buildTargetCanvasContext } from "../../../internal/targetCanvas";
 import { blockBuilderSchema } from "./schemas";
 import { validateBlockBuilderOutput } from "./validator";
 import {
@@ -207,13 +208,25 @@ export class BlockBuilderAgent extends BaseAgent {
 		const projectId = this.state.internal?.metadata?.projectId || "NONE";
 		const { table: customBlocksTable, names: storedCustomBlockNames } =
 			await this.getCustomBlocksInfo(projectId);
+		// One DB read in place of the find_resource -> id -> get-canvas chain the
+		// agent used to walk before it could start. Runs alongside the doc fetch.
+		const [targetCanvas, prefetchedDocsResult] = await Promise.all([
+			buildTargetCanvasContext(
+				this.state.internal?.dbService,
+				this.state.internal?.metadata,
+				activeTask,
+				this.state.orchestratorState?.subAgentResults,
+			),
+			getDocsByTitle(PREFETCH_DOC_TITLES),
+		]);
 		const context = buildAgentContext({
 			currentContext: this.state.internal?.metadata?.contextBlock,
 			projectInventory: this.state.internal?.metadata?.projectInventory,
 			activeTask,
 			subAgentResults: this.state.orchestratorState?.subAgentResults,
+			targetCanvas,
 		});
-		const prefetchedDocs = (await getDocsByTitle(PREFETCH_DOC_TITLES))
+		const prefetchedDocs = prefetchedDocsResult
 			.map((doc) => doc.content)
 			.join("\n\n---\n\n");
 		const pending = pendingCustomBlocks(this.state, activeTask.id);

--- a/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/promptHelpers.spec.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/promptHelpers.spec.ts
@@ -6,12 +6,22 @@ import {
 
 describe("Block Builder built-in schema reference", () => {
 	it("preloads required data fields for built-in blocks", () => {
-		expect(BUILTIN_BLOCK_SCHEMAS_REFERENCE).toContain("### jsrunner");
-		expect(BUILTIN_BLOCK_SCHEMAS_REFERENCE).toContain('"value"');
-		expect(BUILTIN_BLOCK_SCHEMAS_REFERENCE).toContain("### getvar");
-		expect(BUILTIN_BLOCK_SCHEMAS_REFERENCE).toContain('"key"');
-		expect(BUILTIN_BLOCK_SCHEMAS_REFERENCE).toContain("### response");
-		expect(BUILTIN_BLOCK_SCHEMAS_REFERENCE).toContain('"httpCode"');
+		expect(BUILTIN_BLOCK_SCHEMAS_REFERENCE).toContain("jsrunner {");
+		expect(BUILTIN_BLOCK_SCHEMAS_REFERENCE).toContain("value: string;");
+		expect(BUILTIN_BLOCK_SCHEMAS_REFERENCE).toContain("getvar {");
+		expect(BUILTIN_BLOCK_SCHEMAS_REFERENCE).toContain("key: string;");
+		expect(BUILTIN_BLOCK_SCHEMAS_REFERENCE).toContain("response {");
+		expect(BUILTIN_BLOCK_SCHEMAS_REFERENCE).toContain("httpCode: string;");
+	});
+
+	it("teaches the notation it renders the contracts in", () => {
+		const prompt = createSystemPrompt("No custom blocks.", "Platform docs.");
+
+		// Without the legend the model has to guess what `?` and `|` mean, and
+		// a shared `type` name looks like a block it cannot find in the table.
+		expect(prompt).toContain("The notation is TypeScript");
+		expect(prompt).toContain("type DbWhereCondition = {");
+		expect(prompt).toContain("conditions: DbWhereCondition[];");
 	});
 
 	it("tells the agent that built-in contracts are already available", () => {

--- a/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/promptHelpers.ts
+++ b/apps/ai-gateway/src/harness/agents/sub-agents/blockBuilder/promptHelpers.ts
@@ -1,4 +1,7 @@
-import { blockAiDescriptions } from "@fluxify/blocks";
+import {
+	blockAiDescriptions,
+	COMPACT_BLOCK_SCHEMAS_REFERENCE,
+} from "@fluxify/blocks";
 import type { GlobalGraphState } from "../../../types";
 import {
 	CUSTOM_BLOCK_EXECUTION_CONTRACT,
@@ -35,18 +38,14 @@ export const BUILTIN_BLOCKS_TABLE = createBlocksTable(
  * static reference in the system prompt instead: it is shared by every run,
  * so providers can prefix-cache it, and it gives the model the contract before
  * it designs the graph.
+ *
+ * Rendered as TypeScript rather than the JSON Schema the blocks declare: it is
+ * the same 29 contracts derived from the same zod schemas, but JSON Schema
+ * spends most of its characters restating what the shape already shows, and
+ * repeats every shared condition type at each use site. See
+ * `packages/blocks/builtin/compactSchemas.ts`.
  */
-export const BUILTIN_BLOCK_SCHEMAS_REFERENCE = blockAiDescriptions
-	.filter(
-		(
-			block,
-		): block is (typeof blockAiDescriptions)[number] & { jsonSchema: string } =>
-			typeof block.jsonSchema === "string" && block.jsonSchema.length > 0,
-	)
-	.map(
-		({ name, jsonSchema }) => `### ${name}\n\`\`\`json\n${jsonSchema}\n\`\`\``,
-	)
-	.join("\n\n");
+export const BUILTIN_BLOCK_SCHEMAS_REFERENCE = COMPACT_BLOCK_SCHEMAS_REFERENCE;
 
 /**
  * Docs the block builder searched for on nearly every run \u2014 the JS API it has
@@ -75,10 +74,15 @@ Your responsibility is to build and modify the canvas of a workflow DAG, which c
 ${BUILTIN_BLOCKS_TABLE}
 
 #### Built-in Block Data Contracts
-Use these exact schemas when configuring a built-in block. Required fields are
-not optional: do not guess field names or omit them.
+Use these exact contracts when configuring a built-in block. Required fields are
+not optional: do not guess field names or omit them. The notation is TypeScript:
+\`?\` marks a field you may omit, \`|\` lists the only values accepted, and \`//\`
+describes the field. A \`type\` declared at the top is shared by several blocks —
+expand it inline wherever a contract names it.
 
+\`\`\`ts
 ${BUILTIN_BLOCK_SCHEMAS_REFERENCE}
+\`\`\`
 
 #### Custom Blocks
 ${customBlocksTable}

--- a/apps/ai-gateway/src/harness/agents/summarizer.spec.ts
+++ b/apps/ai-gateway/src/harness/agents/summarizer.spec.ts
@@ -18,6 +18,45 @@ function stateWith(harnessService: any): GlobalGraphState {
 	} as unknown as GlobalGraphState;
 }
 
+describe("summarizer without a model call", () => {
+	it("writes the summary itself when the run is clean", async () => {
+		const state = stateWith({
+			createArtifact: async () => "art-1",
+			createSubArtifact: async () => "sub-1",
+		});
+		// The model must not be reached at all — the whole point is the call
+		// never happens, not that its output is discarded.
+		(state as any).agentWrapper.invokeAgent = async () => {
+			throw new Error("summarizer invoked the model on a clean run");
+		};
+
+		const result = await new SummarizerAgent(state).execute();
+
+		expect(result.summarizerState?.markdown).toContain("Added the `/x` endpoint.");
+		expect(result.summarizerState?.markdown).toContain(
+			':route{type="add" sub_artifact_id="sub-1"}',
+		);
+	});
+
+	it("still asks the model when a task failed", async () => {
+		const state = stateWith({
+			createArtifact: async () => "art-1",
+			createSubArtifact: async () => "sub-1",
+		});
+		// A failure needs explaining in the user's language, and the deterministic
+		// path has nothing to say about it.
+		state.orchestratorState!.tasks!.push({
+			id: "t-2",
+			title: "Wire it up",
+			status: "failed",
+		} as any);
+
+		const result = await new SummarizerAgent(state).execute();
+
+		expect(result.summarizerState?.markdown).toBe("Built the route.");
+	});
+});
+
 describe("summarizer artifact persistence", () => {
 	it("still returns the summary when the artifact write fails", async () => {
 		// The build's results are already applied by the time this node runs —

--- a/apps/ai-gateway/src/harness/agents/summarizer.ts
+++ b/apps/ai-gateway/src/harness/agents/summarizer.ts
@@ -7,11 +7,11 @@ import {
 	type ApplyFailure,
 } from "../../api/v1/harness-conversations/artifacts/service";
 import { applyArtifact } from "../../api/v1/harness-conversations/artifacts/applyBatch";
-import {
-	prepareCanvasArtifact,
-	type BlockBuilderPayload,
-	type CanvasItems,
+import type {
+	BlockBuilderPayload,
+	CanvasItems,
 } from "../../api/v1/harness-conversations/artifacts/normalize";
+import { prepareCanvasArtifact } from "../../api/v1/harness-conversations/artifacts/canvasLayout";
 import {
 	callerFor,
 	readCanvas,
@@ -22,8 +22,34 @@ interface ChangeRef {
 	label: string;
 	actionLabel: string;
 	agentRole: string;
+	/** The summary line for this change, written where the change is built and
+	 *  the real data is still in hand. What the model would have paraphrased. */
+	line: string;
 	/** Exact token the LLM must place verbatim at the end of its line. */
 	token: string;
+}
+
+const ACTION_VERB: Record<string, string> = {
+	add: "Added",
+	delete: "Removed",
+	changes: "Updated",
+};
+
+/**
+ * The summary a clean run asks the model for is a bullet per change with a
+ * token appended — every part of which is already sitting in `changes`. The
+ * model adds no information there, only a chance to fabricate a token, so
+ * write it directly and skip the call.
+ *
+ * Only what the model is genuinely for — explaining a task that failed,
+ * turning a build hint into a creation chip — falls through to the model path.
+ */
+function deterministicSummary(changes: ChangeRef[]): string {
+	return [
+		"Here's what this run changed in your app:",
+		"",
+		...changes.map((c) => `- ${c.line} ${c.token}`),
+	].join("\n");
 }
 
 function isRouteConfigResult(r: any): boolean {
@@ -191,7 +217,8 @@ export class SummarizerAgent extends BaseAgent {
 						const type = result.action === "create" ? "add" : result.action === "delete" ? "delete" : "changes";
 						const subId = await harnessService.createSubArtifact({ artifactId, runId, subAgentId: task.id, dependsOn: task.dependsOnAgentId, kind: "custom_block", action: type, payload: result });
 						subArtifactIds[task.id] = subId;
-						changes.push({ label: result.data?.label ?? result.data?.name ?? task.title, actionLabel: type, agentRole: "Custom block configuration", token: `:customBlock{type="${type}" sub_artifact_id="${subId}"}` });
+						const blockLabel = result.data?.label ?? result.data?.name ?? task.title;
+						changes.push({ label: blockLabel, actionLabel: type, agentRole: "Custom block configuration", line: `${ACTION_VERB[type]} the "${blockLabel}" custom block.`, token: `:customBlock{type="${type}" sub_artifact_id="${subId}"}` });
 					} else if (isRouteConfigResult(result)) {
 						const type =
 							result.action === "create"
@@ -216,6 +243,7 @@ export class SummarizerAgent extends BaseAgent {
 							label: label || task.title,
 							actionLabel: type,
 							agentRole: "Route configuration",
+							line: `${ACTION_VERB[type]} the \`${label || task.title}\` endpoint.`,
 							token: `:route{type="${type}" sub_artifact_id="${subId}"}`,
 						});
 					} else if (isBlockBuilderResult(result)) {
@@ -251,6 +279,7 @@ export class SummarizerAgent extends BaseAgent {
 							label: task.title,
 							actionLabel: "changes",
 							agentRole: "Canvas builder",
+							line: `Built the logic for ${task.title.replace(/\.$/, "")}.`,
 							token: `:canvasChanges{parent_type="${parentType}" parent="${parentRef}" artifact_id="${subId}"}`,
 						});
 					}
@@ -293,6 +322,37 @@ export class SummarizerAgent extends BaseAgent {
 		const hintsText = scratchpad.length
 			? scratchpad.map((s) => `- ${s}`).join("\n")
 			: "None.";
+
+		// Nothing to explain and nothing to advise: every line of the summary is
+		// already written. `HARNESS_SUMMARY_MODE=llm` forces the model back on for
+		// comparing the two on a real run.
+		if (
+			changes.length > 0 &&
+			failedLines.length === 0 &&
+			scratchpad.length === 0 &&
+			process.env.HARNESS_SUMMARY_MODE !== "llm"
+		) {
+			logger.info("[Summarizer] Wrote summary without a model call", {
+				runId,
+				changes: changes.length,
+			});
+			await dispatchAgentEvent({
+				name: "agent_status",
+				data: {
+					status: "Summary ready",
+					agent: AgentNode.SUMMARIZER,
+					data: { artifactId },
+				},
+			});
+			return {
+				currentAgent: AgentNode.SUMMARIZER,
+				summarizerState: {
+					markdown: deterministicSummary(changes),
+					artifactId,
+					subArtifactIds,
+				},
+			};
+		}
 
 		const systemPrompt = `You are the Summarizer Agent for Fluxify — a No/Low-Code Backend Engine where users build REST APIs visually from "routes" (endpoints) and "canvases" (block graphs of logic).
 

--- a/apps/ai-gateway/src/harness/internal/agentContext.spec.ts
+++ b/apps/ai-gateway/src/harness/internal/agentContext.spec.ts
@@ -31,6 +31,7 @@ describe("buildAgentContext", () => {
 					data: { method: "GET", path: "/profiles" },
 				},
 			},
+			targetCanvas: "## Target canvas\ntargetId: new-route-1",
 		});
 
 		expect(context).toContain("Relevant project inventory");
@@ -38,11 +39,14 @@ describe("buildAgentContext", () => {
 		expect(context).toContain("Direct task dependencies");
 		expect(context).toContain('"taskId":"route-1"');
 		expect(context).toContain("do NOT call get_agent_output");
-		expect(context).toContain("Planned target canvas");
-		expect(context).toContain('"canvas":[]');
+		// The resolved target sits above the inventory, so the agent reads what it
+		// is editing before the catalogue of everything it is not.
+		expect(context!.indexOf("Target canvas")).toBeLessThan(
+			context!.indexOf("Relevant project inventory"),
+		);
 	});
 
-	it("does not create planned-canvas context for an existing route update", () => {
+	it("omits sections the caller could not resolve", () => {
 		const context = buildAgentContext({
 			activeTask: task(["route-1"]),
 			subAgentResults: {
@@ -51,6 +55,7 @@ describe("buildAgentContext", () => {
 		});
 
 		expect(context).toContain("Direct task dependencies");
-		expect(context).not.toContain("Planned target canvas");
+		expect(context).not.toContain("Target canvas");
+		expect(context).not.toContain("Relevant project inventory");
 	});
 });

--- a/apps/ai-gateway/src/harness/internal/agentContext.ts
+++ b/apps/ai-gateway/src/harness/internal/agentContext.ts
@@ -1,9 +1,4 @@
-import type {
-	ProjectInventoryEntry,
-	RouteConfigAgentResult,
-	SubAgentResult,
-	Task,
-} from "../types";
+import type { ProjectInventoryEntry, SubAgentResult, Task } from "../types";
 import { renderProjectInventory } from "./projectInventory";
 import { fenceUntrusted } from "./untrusted";
 
@@ -12,61 +7,40 @@ type AgentContextOptions = {
 	projectInventory?: ProjectInventoryEntry[];
 	activeTask?: Task;
 	subAgentResults?: Record<string, SubAgentResult>;
+	targetCanvas?: string;
 };
 
 function dependencyContext(
 	task: Task | undefined,
 	results: Record<string, SubAgentResult> | undefined,
-): { output?: string; values: SubAgentResult[] } {
+): string | undefined {
 	const values = [...new Set(task?.dependsOnAgentId ?? [])]
 		.flatMap((taskId) => {
 			const result = results?.[taskId];
 			return result === undefined ? [] : [{ taskId, result }];
 		});
-	if (values.length === 0) return { values: [] };
+	if (values.length === 0) return undefined;
 
-	return {
-		values: values.map(({ result }) => result),
-		output: `## Direct task dependencies
+	return `## Direct task dependencies
 ${fenceUntrusted("dependent_agent_outputs", JSON.stringify(values))}
-These completed outputs are authoritative for this task. Use their IDs and configuration directly; do NOT call get_agent_output to retrieve them again. A direct dependency takes precedence over an unrelated current canvas.`,
-	};
+These completed outputs are authoritative for this task. Use their IDs and configuration directly; do NOT call get_agent_output to retrieve them again. A direct dependency takes precedence over an unrelated current canvas.`;
 }
 
-function plannedNewRouteContext(values: SubAgentResult[]): string | undefined {
-	const route = values.find(
-		(value): value is RouteConfigAgentResult =>
-			(value as RouteConfigAgentResult).action === "create" &&
-			typeof (value as RouteConfigAgentResult).routeId === "string",
-	);
-	if (!route?.routeId) return undefined;
-
-	return `## Planned target canvas
-${fenceUntrusted(
-	"planned_route_canvas",
-	JSON.stringify({
-		targetType: "route",
-		targetId: route.routeId,
-		route: route.data,
-		canvas: [],
-	}),
-)}
-This route is new and is not in the database yet. Its canvas is empty: create its required initial blocks and do NOT fetch an unrelated existing route canvas.`;
-}
-
-/** Builds one volatile context bundle for agents that need workspace data. */
+/** Builds one volatile context bundle for agents that need workspace data.
+ *  `targetCanvas` is the canvas this task edits, when the caller could resolve
+ *  it without the model — see `buildTargetCanvasContext`. */
 export function buildAgentContext({
 	currentContext,
 	projectInventory,
 	activeTask,
 	subAgentResults,
+	targetCanvas,
 }: AgentContextOptions): string | undefined {
-	const dependencies = dependencyContext(activeTask, subAgentResults);
 	const sections = [
 		currentContext,
+		targetCanvas,
 		renderProjectInventory(projectInventory),
-		dependencies.output,
-		plannedNewRouteContext(dependencies.values),
+		dependencyContext(activeTask, subAgentResults),
 	].filter((section): section is string => Boolean(section));
 	return sections.length ? sections.join("\n\n") : undefined;
 }

--- a/apps/ai-gateway/src/harness/internal/contextBlock.spec.ts
+++ b/apps/ai-gateway/src/harness/internal/contextBlock.spec.ts
@@ -46,11 +46,13 @@ describe("buildContextBlock", () => {
 		});
 
 		expect(out).toContain("## Current context");
-		expect(out).toContain('"targetId":"route-1"');
+		expect(out).toContain("targetId: route-1");
 		expect(out).toContain('"method":"GET"');
 		expect(out).toContain('"querySchema":{"dataType":"object"');
-		expect(out).toContain('"id":"blk_1"');
-		expect(out).toContain('"connections":[{"blockId":"blk_2"}]');
+		// The canvas is a block listing, not JSON — the agent already holds
+		// every block type's contract, so the shape around the values is waste.
+		expect(out).toContain("http_request blk_1");
+		expect(out).toContain("-> blk_2");
 		expect(out).toContain("Do NOT call find_resource");
 	});
 
@@ -83,8 +85,8 @@ describe("buildContextBlock", () => {
 			id: "cb-1",
 		});
 
-		expect(out).toContain('"targetId":"cb-1"');
-		expect(out).toContain('"id":"blk_1"');
+		expect(out).toContain("targetId: cb-1");
+		expect(out).toContain("entrypoint blk_1");
 		// the caller contract is what an agent editing this canvas writes against
 		expect(out).toContain("\"name\":\"message\"");
 		expect(out).toContain("Notify");

--- a/apps/ai-gateway/src/harness/internal/contextBlock.ts
+++ b/apps/ai-gateway/src/harness/internal/contextBlock.ts
@@ -1,6 +1,7 @@
 import { logger } from "@fluxify/common";
 import type { DbService } from "./dbService";
 import { fenceUntrusted } from "./untrusted";
+import { renderCanvas } from "./renderCanvas";
 import type { HarnessJobMetadata } from "../queue";
 
 function routeConfig(route: Record<string, unknown>) {
@@ -31,8 +32,18 @@ export async function buildContextBlock(
 	dbService: DbService,
 	projectId: string | undefined,
 	location: HarnessJobMetadata["location"],
+	as: "current" | "target" = "current",
 ): Promise<string | undefined> {
 	if (!location || !projectId) return undefined;
+
+	// The resource the user happened to be viewing is a default the task can
+	// override; a resolved target is not — hedging there is what sends the agent
+	// looking for a better candidate it does not need.
+	const heading = as === "target" ? "## Target canvas" : "## Current context";
+	const claim =
+		as === "target"
+			? "This is the resource this task edits."
+			: "Treat it as the target unless the task's direct dependency names another target.";
 
 	try {
 		if (location.where === "route-canvas") {
@@ -42,17 +53,18 @@ export async function buildContextBlock(
 			]);
 			if (!route) return undefined;
 
-			return `## Current context
+			// targetType/targetId sit outside the fence: the harness resolved them,
+			// they are not project data, and an agent must be able to trust them.
+			return `${heading}
+targetType: route
+targetId: ${location.id}
 ${fenceUntrusted(
 	"current_context",
-	JSON.stringify({
-		targetType: "route",
-		targetId: location.id,
-		route: routeConfig(route as Record<string, unknown>),
-		canvas: canvas ?? [],
-	}),
+	`route: ${JSON.stringify(routeConfig(route as Record<string, unknown>))}
+
+${renderCanvas(canvas)}`,
 )}
-This is the complete editable route configuration and canvas. Treat it as the target unless the task's direct dependency names another target.
+This is the complete editable route configuration and canvas. ${claim}
 Do NOT call find_resource or get_route_details to look this up — you already have it.`;
 		}
 
@@ -63,24 +75,23 @@ Do NOT call find_resource or get_route_details to look this up — you already h
 			]);
 			if (!canvas) return undefined;
 
-			return `## Current context
+			return `${heading}
+targetType: custom_block
+targetId: ${location.id}
 ${fenceUntrusted(
 	"current_context",
-	JSON.stringify({
-		targetType: "custom_block",
-		targetId: location.id,
-		customBlock: block
-			? {
-				id: block.id,
-				name: block.name,
-				label: block.label,
-				inputParams: block.inputParams ?? [],
-			}
-			: undefined,
-		canvas,
-	}),
+	`${
+		block
+			? `customBlock: ${JSON.stringify({
+					id: block.id,
+					name: block.name,
+					label: block.label,
+					inputParams: block.inputParams ?? [],
+				})}\n\n`
+			: ""
+	}${renderCanvas(canvas)}`,
 )}
-This is the complete editable custom-block configuration and canvas. Treat it as the target unless the task's direct dependency names another target.
+This is the complete editable custom-block configuration and canvas. ${claim}
 Do NOT call find_resource to look this up — you already have it.`;
 		}
 	} catch (e) {

--- a/apps/ai-gateway/src/harness/internal/renderCanvas.spec.ts
+++ b/apps/ai-gateway/src/harness/internal/renderCanvas.spec.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "bun:test";
+import { renderCanvas } from "./renderCanvas";
+
+const block = (over: Record<string, any> = {}) => ({
+	id: "0199-a",
+	blockType: "jsrunner",
+	blockName: "Build greeting",
+	blockDescription: "Creates the payload",
+	// As `dbService.getCanvas` returns it: the lifted fields are still in `data`.
+	data: {
+		blockName: "Build greeting",
+		blockDescription: "Creates the payload",
+		value: "return { message: 'hello' }",
+	},
+	position: { x: 240, y: 48 },
+	connections: [{ blockId: "0199-b", handle: "source" }],
+	...over,
+});
+
+describe("renderCanvas", () => {
+	it("renders a block as a stanza, not JSON", () => {
+		const out = renderCanvas([block()]);
+
+		expect(out).toContain('jsrunner 0199-a "Build greeting" @240,48');
+		expect(out).toContain("  # Creates the payload");
+		expect(out).toContain("  value: return { message: 'hello' }");
+		expect(out).toContain("  -> 0199-b");
+	});
+
+	it("states the name and description once", () => {
+		// They arrive twice — lifted onto the row and left inside `data`. The
+		// block builder's output contract forbids writing them into `data`, so
+		// showing them there teaches it the opposite of what it must emit.
+		const out = renderCanvas([block()]);
+
+		expect(out.match(/Build greeting/g)).toHaveLength(1);
+		expect(out.match(/Creates the payload/g)).toHaveLength(1);
+	});
+
+	it("names a handle only when it is not the default", () => {
+		const out = renderCanvas([
+			block({
+				blockType: "if",
+				connections: [
+					{ blockId: "0199-t", handle: "true" },
+					{ blockId: "0199-f", handle: "false" },
+					{ blockId: "0199-n", handle: "source" },
+				],
+			}),
+		]);
+
+		expect(out).toContain("  -> [true] 0199-t");
+		expect(out).toContain("  -> [false] 0199-f");
+		expect(out).toContain("  -> 0199-n");
+	});
+
+	it("keeps multi-line code readable", () => {
+		const out = renderCanvas([
+			block({ data: { value: "const x = 1;\nreturn x;" } }),
+		]);
+
+		expect(out).toContain("  value: |\n    const x = 1;\n    return x;");
+	});
+
+	it("does not let a string that looks like JSON read back as structure", () => {
+		const out = renderCanvas([block({ data: { value: '{"a":1}' } })]);
+
+		expect(out).toContain('  value: "{\\"a\\":1}"');
+	});
+
+	it("leaves template expressions alone", () => {
+		// `{{ ... }}` opens with a brace but is not JSON, and it is the most
+		// common value in a canvas — quoting every one of them is pure noise.
+		const out = renderCanvas([block({ data: { body: "{{ $jsrunner_4 }}" } })]);
+
+		expect(out).toContain("  body: {{ $jsrunner_4 }}");
+	});
+
+	it("teaches the notation it renders in", () => {
+		// An agent meeting `->` cold has to guess, and a guessed edge is a wrong
+		// graph. No call site can hand over the shape without the key to it.
+		expect(renderCanvas([block()])).toContain("Canvas notation:");
+	});
+
+	it("says a canvas is empty rather than rendering nothing", () => {
+		expect(renderCanvas([])).toContain("no blocks yet");
+		expect(renderCanvas(null)).toContain("no blocks yet");
+	});
+
+	it("costs a fraction of the JSON it replaces", () => {
+		const canvas = [block(), block({ id: "0199-b", connections: [] })];
+
+		expect(renderCanvas(canvas).length).toBeLessThan(
+			JSON.stringify(canvas).length,
+		);
+	});
+});

--- a/apps/ai-gateway/src/harness/internal/renderCanvas.ts
+++ b/apps/ai-gateway/src/harness/internal/renderCanvas.ts
@@ -1,0 +1,100 @@
+/**
+ * Renders a canvas as a compact block listing instead of raw JSON.
+ *
+ * Every agent that reads a canvas already carries each block type's data
+ * contract in its system prompt, so the JSON around the values buys nothing:
+ * a quoted key and a brace per field, `"position":{"x":240,"y":48}` for two
+ * numbers, and `blockName`/`blockDescription` a second time inside `data`
+ * because that is how the row is stored. What an agent actually needs is which
+ * blocks exist, how each is configured, and what points where.
+ *
+ * Deliberately NOT truncated. A half-canvas is worse than a big one: the agent
+ * cannot tell a canvas that ends from one that was cut, and the tool call it
+ * makes to find out re-sends the entire conversation so far.
+ */
+
+/** Taught once per render — an agent meeting this notation cold has to guess
+ *  otherwise, and a guessed edge is a wrong graph. */
+const CANVAS_NOTATION = `Canvas notation: one stanza per block — \`blockType id "name" @x,y\` — then its configuration one field per line, then one \`-> targetBlockId\` line per outgoing connection (\`-> [handle] targetBlockId\` when the handle is not \`source\`). A block with no \`->\` line is terminal. \`#\` is the block's description. \`|\` opens a multi-line value, indented under its key.`;
+
+type CanvasBlock = Record<string, any>;
+
+/** Fields the row carries at the top level and repeats inside `data`. The
+ *  block builder's own output contract tells it never to write these into
+ *  `data`, so echoing them back there teaches it the opposite. */
+const LIFTED_FIELDS = new Set(["blockName", "blockDescription"]);
+
+/**
+ * True only for a string that would read back as something other than itself —
+ * `"[]"` is a real ambiguity worth two quote characters. `{{ $var }}` opens
+ * with a brace but parses as nothing, and quoting every template expression in
+ * a canvas is noise on the most common value in the codebase.
+ */
+function isAmbiguous(value: string): boolean {
+	if (!/^[[{"]/.test(value)) return false;
+	try {
+		JSON.parse(value);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function renderValue(value: unknown, indent: string): string {
+	if (value === null || value === undefined) return "null";
+	if (typeof value === "string") {
+		if (value.includes("\n")) {
+			// A YAML block scalar. Block `data` carries user JavaScript, and
+			// flattening that onto one line is what makes it unreadable.
+			const body = value
+				.split("\n")
+				.map((line) => `${indent}  ${line}`)
+				.join("\n");
+			return `|\n${body}`;
+		}
+		return isAmbiguous(value) ? JSON.stringify(value) : value;
+	}
+	// ponytail: nested config (conditions, field maps) stays JSON — it is the
+	// minority of the bytes and the agent has to reproduce it exactly.
+	if (typeof value === "object") return JSON.stringify(value);
+	return String(value);
+}
+
+function renderBlock(block: CanvasBlock): string {
+	const position = block.position as { x?: number; y?: number } | undefined;
+	const head = [
+		block.blockType ?? "unknown",
+		block.id,
+		block.blockName ? JSON.stringify(block.blockName) : "",
+		position ? `@${position.x ?? 0},${position.y ?? 0}` : "",
+	]
+		.filter(Boolean)
+		.join(" ");
+
+	const lines = [head];
+	if (block.blockDescription) lines.push(`  # ${block.blockDescription}`);
+
+	for (const [key, value] of Object.entries(block.data ?? {})) {
+		if (LIFTED_FIELDS.has(key)) continue;
+		lines.push(`  ${key}: ${renderValue(value, "  ")}`);
+	}
+
+	for (const connection of block.connections ?? []) {
+		const handle =
+			connection.handle && connection.handle !== "source"
+				? `[${connection.handle}] `
+				: "";
+		lines.push(`  -> ${handle}${connection.blockId}`);
+	}
+
+	return lines.join("\n");
+}
+
+/** Renders a whole canvas, notation legend included so no call site can hand a
+ *  model the shape without the key to it. */
+export function renderCanvas(canvas: CanvasBlock[] | null | undefined): string {
+	if (!Array.isArray(canvas) || canvas.length === 0) {
+		return "(empty canvas — it has no blocks yet)";
+	}
+	return `${CANVAS_NOTATION}\n\n${canvas.map(renderBlock).join("\n\n")}`;
+}

--- a/apps/ai-gateway/src/harness/internal/targetCanvas.spec.ts
+++ b/apps/ai-gateway/src/harness/internal/targetCanvas.spec.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "bun:test";
+import { buildTargetCanvasContext } from "./targetCanvas";
+import type { DbService } from "./dbService";
+import { AgentNode, type Task } from "../types";
+
+const task = (dependsOnAgentId: string[], description = "Wire it up."): Task => ({
+	id: "build-1",
+	title: "Build profiles route",
+	description,
+	dependsOnAgentId,
+	status: "running",
+	assignedAgentNode: AgentNode.BLOCK_BUILDER,
+});
+
+const CANVAS = [
+	{
+		id: "b1",
+		blockType: "response",
+		blockName: "Reply",
+		data: { status: 200 },
+		position: { x: 336, y: 48 },
+		connections: [],
+	},
+];
+
+/** Counts what the agent would otherwise have spent tool calls on. */
+function stubDb(routes: Record<string, unknown> = { "route-9": { id: "route-9" } }) {
+	const calls: string[] = [];
+	return {
+		calls,
+		db: {
+			async getRouteDetails(_p: string, id: string) {
+				calls.push(`details:${id}`);
+				return routes[id] ?? null;
+			},
+			async getRouteCanvas(_p: string, id: string) {
+				calls.push(`canvas:${id}`);
+				return routes[id] ? CANVAS : null;
+			},
+			async getCustomBlockCanvas(_p: string, id: string) {
+				calls.push(`cbCanvas:${id}`);
+				return CANVAS;
+			},
+			async findCustomBlocks(_p: string, id: string) {
+				calls.push(`cb:${id}`);
+				return [{ id, name: "audit", label: "Audit", inputParams: [] }];
+			},
+		} as unknown as DbService,
+	};
+}
+
+describe("buildTargetCanvasContext", () => {
+	it("prefetches the canvas of a route a dependency already created", async () => {
+		const { db, calls } = stubDb();
+		const out = await buildTargetCanvasContext(
+			db,
+			{ projectId: "p1" },
+			task(["route-1"]),
+			{ "route-1": { action: "create", routeId: "route-9" } },
+		);
+
+		expect(out).toContain("## Target canvas");
+		expect(out).toContain("targetId: route-9");
+		// the canvas itself, with positions — this is what removes the round trips
+		expect(out).toContain("response b1");
+		expect(out).toContain("@336,48");
+		expect(out).toContain("Do NOT call find_resource");
+		expect(calls).toContain("canvas:route-9");
+	});
+
+	// The old context asserted `canvas: []` for anything a dependency created,
+	// which is a lie the moment that artifact is applied — the agent then wrote a
+	// second copy of the blocks that were already there.
+	it("says the target is not applied yet only when it really is not", async () => {
+		const { db } = stubDb({});
+		const out = await buildTargetCanvasContext(
+			db,
+			{ projectId: "p1" },
+			task(["route-1"]),
+			{ "route-1": { action: "create", routeId: "route-9" } },
+		);
+
+		expect(out).toContain("targetId: route-9");
+		expect(out).toContain("does not exist in the database yet");
+		expect(out).toContain("Do NOT call find_resource");
+	});
+
+	it("resolves a target from an inventory id quoted in the task", async () => {
+		const { db, calls } = stubDb();
+		const out = await buildTargetCanvasContext(
+			db,
+			{
+				projectId: "p1",
+				projectInventory: [
+					{ type: "route", id: "route-9", identifier: "GET /a", label: "A" },
+					{ type: "route", id: "route-8", identifier: "GET /b", label: "B" },
+				],
+			},
+			task([], "Add a log block to route-9."),
+			{},
+		);
+
+		expect(out).toContain("targetId: route-9");
+		expect(calls).toContain("canvas:route-9");
+	});
+
+	it("leaves an ambiguous target to the model", async () => {
+		const { db, calls } = stubDb();
+		const out = await buildTargetCanvasContext(
+			db,
+			{
+				projectId: "p1",
+				projectInventory: [
+					{ type: "route", id: "route-9", identifier: "GET /a", label: "A" },
+					{ type: "route", id: "route-8", identifier: "GET /b", label: "B" },
+				],
+			},
+			task([], "Copy route-9 into route-8."),
+			{},
+		);
+
+		expect(out).toBeUndefined();
+		expect(calls).toEqual([]);
+	});
+
+	it("does not restate the canvas the user was already viewing", async () => {
+		const { db, calls } = stubDb();
+		const out = await buildTargetCanvasContext(
+			db,
+			{ projectId: "p1", location: { where: "route-canvas", id: "route-9" } },
+			task(["route-1"]),
+			{ "route-1": { action: "update-partial", routeId: "route-9" } },
+		);
+
+		expect(out).toBeUndefined();
+		expect(calls).toEqual([]);
+	});
+
+	it("ignores a dependency that deleted its resource", async () => {
+		const { db } = stubDb();
+		const out = await buildTargetCanvasContext(db, { projectId: "p1" }, task(["route-1"]), {
+			"route-1": { action: "delete", routeId: "route-9" },
+		});
+
+		expect(out).toBeUndefined();
+	});
+
+	it("follows a prior block builder's chosen target", async () => {
+		const { db } = stubDb();
+		const out = await buildTargetCanvasContext(db, { projectId: "p1" }, task(["bb-1"]), {
+			"bb-1": { status: "success", targetType: "custom_block", targetId: "cb-3" },
+		});
+
+		expect(out).toContain("targetType: custom_block");
+		expect(out).toContain("targetId: cb-3");
+	});
+});

--- a/apps/ai-gateway/src/harness/internal/targetCanvas.ts
+++ b/apps/ai-gateway/src/harness/internal/targetCanvas.ts
@@ -1,0 +1,117 @@
+import { logger } from "@fluxify/common";
+import { buildContextBlock } from "./contextBlock";
+import type { DbService } from "./dbService";
+import type { ProjectInventoryEntry, SubAgentResult, Task } from "../types";
+import type { HarnessJobMetadata } from "../queue";
+
+type Target = NonNullable<HarnessJobMetadata["location"]>;
+
+/** `internal.metadata` is the job metadata plus what the run resolved onto it. */
+type RunMetadata = HarnessJobMetadata & {
+	projectInventory?: ProjectInventoryEntry[];
+};
+
+/**
+ * A canvas agent cannot start until it knows which canvas it is editing, and
+ * discovering that costs it two or three sequential tool calls: find_resource
+ * by name for the id, then another for the canvas. Each round trip re-sends the
+ * whole prompt, so on a slow model that is minutes of wall clock spent
+ * rediscovering an id the run already has.
+ *
+ * Every source below is deterministic, so the resolution belongs here rather
+ * than in the model's tool budget. `metadata.location` (the canvas the user was
+ * looking at) is already resolved at run start; this covers the rest.
+ */
+
+function targetOf(result: SubAgentResult | undefined): Target | undefined {
+	const value = (result ?? {}) as {
+		action?: string;
+		routeId?: string;
+		customBlockId?: string;
+		targetType?: string;
+		targetId?: string;
+	};
+	if (value.action === "delete") return undefined;
+	if (value.routeId) return { where: "route-canvas", id: value.routeId };
+	if (value.customBlockId) {
+		return { where: "custom-block-canvas", id: value.customBlockId };
+	}
+	// A prior block builder in the same chain already picked the target.
+	if (value.targetId && value.targetType) {
+		return value.targetType === "route"
+			? { where: "route-canvas", id: value.targetId }
+			: { where: "custom-block-canvas", id: value.targetId };
+	}
+	return undefined;
+}
+
+/** The task generator is told to copy exact inventory IDs into task text, so an
+ *  ID quoted there names the target. Only when it names exactly one — two
+ *  candidates is a genuine choice, and the model has the tools to make it. */
+function targetFromInventory(
+	task: Task,
+	inventory: ProjectInventoryEntry[] | undefined,
+): Target | undefined {
+	const text = `${task.title} ${task.description}`;
+	const hits = (inventory ?? []).filter(
+		(entry) =>
+			(entry.type === "route" || entry.type === "custom_block") &&
+			text.includes(entry.id),
+	);
+	if (hits.length !== 1) return undefined;
+	return hits[0].type === "route"
+		? { where: "route-canvas", id: hits[0].id }
+		: { where: "custom-block-canvas", id: hits[0].id };
+}
+
+function resolveTarget(
+	task: Task,
+	results: Record<string, SubAgentResult> | undefined,
+	inventory: ProjectInventoryEntry[] | undefined,
+): Target | undefined {
+	// A declared dependency outranks the inventory: it is what this run just built.
+	for (const id of task.dependsOnAgentId ?? []) {
+		const target = targetOf(results?.[id]);
+		if (target) return target;
+	}
+	return targetFromInventory(task, inventory);
+}
+
+/**
+ * Prefetches the canvas this task edits, when the run can name it without
+ * asking the model.
+ *
+ * Returns undefined when there is no resolvable target, or when the target is
+ * the canvas the user was already viewing — `metadata.contextBlock` holds that
+ * one, and stating it twice only invites the agent to treat them as two canvases.
+ */
+export async function buildTargetCanvasContext(
+	dbService: DbService | undefined,
+	metadata: RunMetadata | undefined,
+	task: Task | undefined,
+	results: Record<string, SubAgentResult> | undefined,
+): Promise<string | undefined> {
+	const projectId = metadata?.projectId;
+	if (!dbService || !projectId || !task) return undefined;
+
+	const target = resolveTarget(task, results, metadata?.projectInventory);
+	if (!target) return undefined;
+
+	const location = metadata?.location;
+	if (location?.where === target.where && location.id === target.id) {
+		return undefined;
+	}
+
+	const block = await buildContextBlock(dbService, projectId, target, "target");
+	if (block) return block;
+
+	// Nothing came back, so the resource is planned but its artifact has not been
+	// applied yet. Saying so is what stops the agent from hunting for a canvas
+	// that does not exist — and from assuming an existing one is the target.
+	logger.info("[TargetCanvas] Target is planned but not yet applied", target);
+	const targetType = target.where === "route-canvas" ? "route" : "custom_block";
+	return `## Target canvas
+targetType: ${targetType}
+targetId: ${target.id}
+This ${targetType} is being created by this run and does not exist in the database yet, so its canvas is empty. Build its initial blocks. Do NOT call find_resource or get_route_details for it, and do NOT fall back to an unrelated existing canvas.`;
+}

--- a/apps/ai-gateway/src/harness/models/base.ts
+++ b/apps/ai-gateway/src/harness/models/base.ts
@@ -550,7 +550,10 @@ export abstract class BaseAgentWrapper {
 				// ToolMessages don't line up with their tool_calls.
 				const results = await executeToolBatch(
 					toolCalls,
-					finalMessages,
+					// One wrapper is created per run and shared by every sub-agent,
+					// including the ones the orchestrator dispatches in parallel — so
+					// it is the lifetime a database read stays valid over.
+					{ invocation: finalMessages, run: this },
 					(tc) => {
 						if (tc === submit && submitParsed) {
 							// Answer the call so the history stays valid (a tool_call with

--- a/apps/ai-gateway/src/harness/models/toolExecution.spec.ts
+++ b/apps/ai-gateway/src/harness/models/toolExecution.spec.ts
@@ -59,4 +59,62 @@ describe("read-tool memoization", () => {
 		);
 		expect(replay?.content).toBe("result-1");
 	});
+
+	// One wrapper serves the whole run, so a route the orchestrator's first task
+	// looked up is a route its siblings should not pay to look up again.
+	it("shares database reads across invocations of the same wrapper", async () => {
+		const counts = { find_resource: 0, get_agent_output: 0 };
+		const toolNamed = (name: keyof typeof counts) =>
+			tool(async () => `${name}-${++counts[name]}`, {
+				name,
+				description: "read",
+				schema: z.object({ id: z.string() }),
+			}) as unknown as StructuredTool;
+
+		class SharedWrapper extends BaseAgentWrapper {
+			// `createModel` is called once per wrapper, so the script has to rewind
+			// for the second invocation rather than run off the end of the array.
+			step = 0;
+
+			protected createModel(): BaseChatModel {
+				const responses = [
+					new AIMessage({
+						content: "",
+						tool_calls: [
+							{ id: "c1", name: "find_resource", args: { id: "r-1" } },
+							{ id: "c2", name: "get_agent_output", args: { id: "t-1" } },
+						],
+					}),
+					new AIMessage({
+						content: "",
+						tool_calls: [{ id: "c3", name: SUBMIT_RESULT_TOOL, args: { blocks: ["a"] } }],
+					}),
+				];
+				const model: any = {
+					bindTools: () => model,
+					invoke: async () => responses[this.step++]!,
+				};
+				return model as BaseChatModel;
+			}
+
+			run() {
+				this.step = 0;
+				return this.invokeAgent({
+					zodSchema: resultSchema,
+					systemPrompt: "you are a builder",
+					userQuery: "build it",
+					tools: [toolNamed("find_resource"), toolNamed("get_agent_output")],
+				});
+			}
+		}
+
+		const wrapper = new SharedWrapper("test-model");
+		await wrapper.run();
+		await wrapper.run();
+
+		expect(counts.find_resource).toBe(1);
+		// Its answer is a snapshot of this invocation's sibling results, so it must
+		// not be replayed to a later sub-agent whose snapshot has more in it.
+		expect(counts.get_agent_output).toBe(2);
+	});
 });

--- a/apps/ai-gateway/src/harness/models/toolExecution.ts
+++ b/apps/ai-gateway/src/harness/models/toolExecution.ts
@@ -4,16 +4,30 @@ import type { StructuredTool } from "@langchain/core/tools";
 import { summarizeToolResult } from "./jsonUtils";
 import type { NormalizedToolCall } from "./toolLoop";
 
-/** These tools only read immutable-for-the-run data. Replaying a result for an
- * identical call avoids another DB/vector-store round trip without changing
- * agent-visible behaviour. Keep mutations out of this list. */
-const MEMOIZED_READ_TOOLS = new Set([
+/**
+ * These read the database and the doc store, which nothing mutates while a run
+ * is in flight — agents emit artifacts, and artifacts are applied after the run.
+ * So one read serves the whole run: a sub-agent inherits what an earlier or
+ * concurrent sibling already looked up, and a task re-run after a supervisor
+ * rejection starts with them too. Keep mutations out of this list.
+ */
+const RUN_SCOPED_READ_TOOLS = new Set([
 	"search_docs",
 	"find_resource",
 	"get_route_details",
+	"get_artifact",
+]);
+
+/**
+ * Also read-only, but over state that is snapshotted per agent invocation —
+ * `get_agent_output` closes over the `subAgentResults` that existed when its
+ * tool was built, and `get_custom_block_schemas` over that invocation's pending
+ * blocks. Sharing those across the run would replay one sub-agent's "not found"
+ * to a later one for which the answer exists.
+ */
+const INVOCATION_SCOPED_READ_TOOLS = new Set([
 	"get_custom_block_schemas",
 	"get_agent_output",
-	"get_artifact",
 ]);
 
 type ToolEvent = {
@@ -33,8 +47,9 @@ type ToolExecutionContext = {
 	emitToolEvent: (data: ToolEvent) => Promise<void>;
 };
 
-/** Message arrays are allocated once per agent invocation and discarded when it
- * completes, making them a natural key for invocation-scoped read caches. */
+/** Keyed by whatever object owns the lifetime being cached: the message array
+ * for one invocation, the agent wrapper for the whole run. Both are allocated
+ * once and discarded together with the cache they anchor. */
 const readToolCaches = new WeakMap<object, Map<string, Promise<ToolMessage>>>();
 
 function readToolCacheFor(scope: object): Map<string, Promise<ToolMessage>> {
@@ -44,6 +59,10 @@ function readToolCacheFor(scope: object): Map<string, Promise<ToolMessage>> {
 	readToolCaches.set(scope, cache);
 	return cache;
 }
+
+/** Where a tool's result may be reused from. `run` is optional so a caller that
+ *  has no run-level object still gets the invocation cache. */
+export type ToolCacheScope = { invocation: object; run?: object };
 
 function canonicalToolArgs(value: unknown): string {
 	if (value === null || typeof value !== "object") return JSON.stringify(value);
@@ -57,8 +76,26 @@ function canonicalToolArgs(value: unknown): string {
 export function memoizedReadToolKey(
 	call: NormalizedToolCall,
 ): string | undefined {
-	if (!MEMOIZED_READ_TOOLS.has(call.name)) return undefined;
+	if (
+		!RUN_SCOPED_READ_TOOLS.has(call.name) &&
+		!INVOCATION_SCOPED_READ_TOOLS.has(call.name)
+	) {
+		return undefined;
+	}
 	return `${call.name}:${canonicalToolArgs(call.args)}`;
+}
+
+/** The cache a memoizable call belongs in, or undefined when it belongs in none. */
+function cacheFor(
+	call: NormalizedToolCall,
+	scope: ToolCacheScope,
+): Map<string, Promise<ToolMessage>> | undefined {
+	if (!memoizedReadToolKey(call)) return undefined;
+	const owner =
+		RUN_SCOPED_READ_TOOLS.has(call.name) && scope.run
+			? scope.run
+			: scope.invocation;
+	return readToolCacheFor(owner);
 }
 
 /** A provider requires a result for each tool-call id, even when the work was
@@ -80,16 +117,16 @@ export function isFailedToolResult(result: ToolMessage): boolean {
 			result.content.startsWith("Tool ") && result.content.endsWith(" not found."));
 }
 
-/** Executes a read-only tool once per invocation and replays its result for
+/** Executes a read-only tool once per scope and replays its result for
  * equivalent later calls. The caller supplies execution because only the
  * wrapper owns model/run context and telemetry. */
 export function executeMemoizedReadTool(
 	call: NormalizedToolCall,
-	cache: Map<string, Promise<ToolMessage>>,
+	cache: Map<string, Promise<ToolMessage>> | undefined,
 	execute: () => Promise<ToolMessage>,
 ): Promise<ToolMessage> {
 	const cacheKey = memoizedReadToolKey(call);
-	if (!cacheKey) return execute();
+	if (!cacheKey || !cache) return execute();
 
 	const cached = cache.get(cacheKey);
 	if (cached) return cached.then((result) => replayToolResult(call, result));
@@ -104,19 +141,18 @@ export function executeMemoizedReadTool(
 }
 
 /** Executes a model-requested tool batch in call order. A submitted answer can
- * be replaced with corrective feedback while every other read call remains
- * memoized for this agent invocation. */
+ * be replaced with corrective feedback while every other read call is memoized
+ * at the scope its data is stable over. */
 export function executeToolBatch(
 	calls: NormalizedToolCall[],
-	scope: object,
+	scope: ToolCacheScope,
 	reject: (call: NormalizedToolCall) => ToolMessage | undefined,
 	execute: (call: NormalizedToolCall) => Promise<ToolMessage>,
 ): Promise<ToolMessage[]> {
-	const cache = readToolCacheFor(scope);
 	return Promise.all(
 		calls.map((call) =>
 			reject(call) ??
-			executeMemoizedReadTool(call, cache, () => execute(call)),
+			executeMemoizedReadTool(call, cacheFor(call, scope), () => execute(call)),
 		),
 	);
 }

--- a/apps/ai-gateway/src/harness/tools/findResource.ts
+++ b/apps/ai-gateway/src/harness/tools/findResource.ts
@@ -8,20 +8,7 @@ import {
 	type SearchMode,
 } from "../internal/dbService";
 import { ResourceType } from "../types";
-
-/**
- * Canvases are the fattest thing this tool returns, and the whole result is
- * re-sent on every subsequent tool iteration. Two cuts: no pretty-printing
- * (indentation alone was ~15% of the payload) and no `position`, which is
- * layout the model neither reads nor sets. `data` stays — the block builder
- * edits existing blocks, and making it fetch that separately would add back
- * the round trip this is trying to remove.
- */
-function renderCanvas(canvas: Array<Record<string, any>>): string {
-	return JSON.stringify(
-		canvas.map(({ position, ...block }) => block),
-	);
-}
+import { renderCanvas } from "../internal/renderCanvas";
 
 function isListRequest(keywords: string[], mode: SearchMode): boolean {
 	return (

--- a/apps/ai-gateway/src/harness/tools/getArtifact.spec.ts
+++ b/apps/ai-gateway/src/harness/tools/getArtifact.spec.ts
@@ -84,7 +84,7 @@ describe("get_artifact", () => {
 
 		expect(out).toContain("APPLIED");
 		expect(out).toContain('"path":"/users"');
-		expect(out).toContain('"blockType":"response"');
+		expect(out).toContain("response b1");
 		expect(out).not.toContain("/stale");
 	});
 

--- a/apps/ai-gateway/src/harness/tools/getArtifact.ts
+++ b/apps/ai-gateway/src/harness/tools/getArtifact.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { logger } from "@fluxify/common";
 import type { WorkflowMetadata } from "../types";
 import type { DbService } from "../internal/dbService";
+import { renderCanvas } from "../internal/renderCanvas";
 
 // ponytail: flat char cap so one fat canvas payload can't blow the context
 // window. If this starts truncating things users need, page per sub-artifact.
@@ -19,7 +20,7 @@ async function resolveLive(
 	dbService: DbService,
 	projectId: string | undefined,
 	row: { kind: string; payload: any },
-): Promise<Record<string, unknown> | null> {
+): Promise<string | null> {
 	if (!projectId) return null;
 	const p = (row.payload ?? {}) as Record<string, any>;
 	try {
@@ -27,10 +28,9 @@ async function resolveLive(
 			case "route": {
 				const route = await dbService.getRouteDetails(projectId, p.routeId);
 				if (!route) return null;
-				return {
-					route,
-					canvas: await dbService.getRouteCanvas(projectId, p.routeId),
-				};
+				return `route: ${JSON.stringify(route)}\n\n${renderCanvas(
+					await dbService.getRouteCanvas(projectId, p.routeId),
+				)}`;
 			}
 			case "custom_block": {
 				const [block] = await dbService.findCustomBlocks(
@@ -39,10 +39,9 @@ async function resolveLive(
 					"id",
 				);
 				if (!block) return null;
-				return {
-					customBlock: block,
-					canvas: await dbService.getCustomBlockCanvas(projectId, block.id),
-				};
+				return `customBlock: ${JSON.stringify(block)}\n\n${renderCanvas(
+					await dbService.getCustomBlockCanvas(projectId, block.id),
+				)}`;
 			}
 			case "canvas": {
 				const canvas =
@@ -50,7 +49,7 @@ async function resolveLive(
 						? await dbService.getCustomBlockCanvas(projectId, p.targetId)
 						: await dbService.getRouteCanvas(projectId, p.targetId);
 				return canvas
-					? { targetType: p.targetType, targetId: p.targetId, canvas }
+					? `targetType: ${p.targetType}\ntargetId: ${p.targetId}\n\n${renderCanvas(canvas)}`
 					: null;
 			}
 			default:
@@ -93,7 +92,7 @@ export const createGetArtifactTool = (
 					}
 					const live = await resolveLive(dbService, metadata.projectId, r);
 					return live
-						? `${head}\nAPPLIED — live in the project. Current state read from the database (use these ids; do not look it up again):\n${JSON.stringify(live)}`
+						? `${head}\nAPPLIED — live in the project. Current state read from the database (use these ids; do not look it up again):\n${live}`
 						: `${head}\nAPPLIED, but the resource it created is gone from the project (deleted since).\nWhat was applied: ${JSON.stringify(r.payload)}`;
 				}),
 			);

--- a/apps/portal/src/components/ai/PromptEditor.tsx
+++ b/apps/portal/src/components/ai/PromptEditor.tsx
@@ -21,7 +21,6 @@ import { KEY_ENTER_COMMAND, KEY_DOWN_COMMAND, COMMAND_PRIORITY_EDITOR, COMMAND_P
 import { ResourceNode } from "./lexical/ResourceNode";
 import { ResourcePlugin, INSERT_RESOURCE_COMMAND } from "./lexical/ResourcePlugin";
 import { markdownToLexical, lexicalToMarkdown, insertMarkdownAtSelection } from "./lexical/MarkdownTransformer";
-import { useModelConnectionTest } from "./useModelConnectionTest";
 
 const PLACEHOLDERS = [
 	"Generate a blog API with rate limiting, Redis cache...",
@@ -131,8 +130,6 @@ export function PromptEditor({
 
 	const [model, setModel] = useState<string>(selectedModelId || defaultModelId || "");
 
-	const connStatus = useModelConnectionTest(projectId, model);
-
 	// Popover & Search State
 	const [popoverOpen, setPopoverOpen] = useState(false);
 	const [searchQuery, setSearchQuery] = useState("");
@@ -215,7 +212,7 @@ export function PromptEditor({
 	// Stop while a run is live, but the editor's Enter handler calls submit()
 	// directly and was firing a second run over the top of the first.
 	const canSend =
-		trimmed.length > 0 && !isPending && !isDisabled && !isRunning && connStatus === "success";
+		trimmed.length > 0 && !isPending && !isDisabled && !isRunning;
 
 	const submit = () => {
 		if (!canSend) return;
@@ -404,7 +401,7 @@ export function PromptEditor({
 							className="rounded-xl h-8 w-8 shrink-0"
 							aria-label="Send"
 							isDisabled={!canSend}
-							isPending={isPending || connStatus === "testing"}
+							isPending={isPending}
 							onPress={submit}
 						>
 							<TbArrowUp size={18} />

--- a/packages/blocks/builtin/__snapshots__/compactSchemas.spec.ts.snap
+++ b/packages/blocks/builtin/__snapshots__/compactSchemas.spec.ts.snap
@@ -1,0 +1,219 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`compact block schemas renders a stable reference 1`] = `
+"type DbConditionSide = {
+	kind: "column";
+	value: string;  // column name / json path to compare against
+}
+| {
+	kind: "literal";
+	value: string | number | boolean;  // value to compare against
+}
+
+type DbWhereCondition = {
+	attribute: DbConditionSide;  // Required DB condition-side object: { kind: 'column', value: 'table.column' } or { kind: 'literal', value }. Never a bare string or number.
+	operator: "eq" | "neq" | "gt" | "gte" | "lt" | "lte";  // Database comparison operator, for example eq, neq, gt, gte, lt, lte.
+	value: DbConditionSide;  // Required DB condition-side object: { kind: 'literal', value } or { kind: 'column', value: 'table.column' }. Never a bare string or number.
+	chain: "and" | "or";  // How this condition joins to next WHERE condition.
+}
+
+type Condition = {
+	lhs: string | number | boolean;  // left-hand side operator (can be js expression)
+	rhs: string | number | boolean;  // right-hand side operator (can be js expression)
+	operator: "eq" | "neq" | "gt" | "gte" | "lt" | "lte" | "js" | "is_empty" | "is_not_empty";  // The operator to use for comparison
+	js?: string;  // javascript expression
+	chain: "and" | "or";  // condition chain to use for evaluation; default "and"
+}
+
+arrayops {
+	operation: "push" | "pop" | "shift" | "unshift" | "filter";  // type of operation to perform
+	value?: any;  // the value to insert (if insert operation is made)
+	useParamAsInput?: boolean;  // use the parameter as the datasource (passed from previous block's output)
+	datasource: string;  // global variable to perform the operation on
+	filterConditions?: Condition[];  // list of conditions which are evaluated
+}
+
+entrypoint {} // no configuration
+
+getvar {
+	key: string;
+}
+
+httprequest {
+	url: string;  // Server url (can be js expression)
+	method: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
+	headers: Record<string, string>;
+	body: any;
+	useParam: boolean;  // default false
+}
+
+if {
+	conditions: Condition[];  // list of conditions which are evaluated
+}
+
+jsrunner {
+	value: string;
+}
+
+response {
+	httpCode: string;
+}
+
+setvar {
+	key: string;  // The name of the variable
+	value: any;  // The value of the variable (can be number,bool,string,object or js expression)
+}
+
+sticky_note {
+	notes: string;
+	color: "red" | "blue" | "green" | "yellow";  // default "yellow"
+	size: {
+		width: number;  // default 100
+		height: number;  // default 100
+	};
+}
+
+transformer {
+	fieldMap: Record<string, string>;  // key value pairs which map the source key to destination object's key
+	js?: string;  // js code executed when useJs is enabled. A global variable 'input' which stores the source object
+	useJs: boolean;  // enable to run the js code; default false
+}
+
+db_delete {
+	connection: string;  // integration id
+	tableName: string;  // table name (supports js expression)
+	conditions: DbWhereCondition[];  // Database WHERE clause. Always emit an array of condition objects; never emit strings, SQL snippets, or if-block conditions. Each attribute and value must be a tagged object. Example: [{ attribute: { kind: 'column', value: 'status' }, operator: 'eq', value: { kind: 'literal', value: 'active' }, chain: 'and' }].
+}
+
+db_getall {
+	connection: string;  // integration id
+	tableName: string;  // table name (supports js expression)
+	conditions: DbWhereCondition[];  // Database WHERE clause. Always emit an array of condition objects; never emit strings, SQL snippets, or if-block conditions. Each attribute and value must be a tagged object. Example: [{ attribute: { kind: 'column', value: 'status' }, operator: 'eq', value: { kind: 'literal', value: 'active' }, chain: 'and' }].
+	joins?: {
+		table: string;  // table to join
+		alias?: string;  // alias for the table
+		attribute: string;  // attribute to join e.g. table1.id = table2.id
+		type: "inner" | "left" | "right" | "outer";  // type of join; default "inner"
+	}[];  // list of joins; default []
+	columns?: string[];  // list of columns to select with aliases if any (e.g. column1 or table.column2 AS column2 or table.*); default ["*"]
+	limit: number | string;  // limit (supports js expressions); default 1000
+	offset: number | string;  // skip count (supports js expressions); default 0
+	sort: {
+		attribute: string;  // sort attribute
+		direction: "asc" | "desc";  // type of sort
+	};  // default {"attribute":"id","direction":"asc"}
+}
+
+db_getsingle {
+	connection: string;  // integration id
+	tableName: string;  // table name (supports js expression)
+	conditions: DbWhereCondition[];  // Database WHERE clause. Always emit an array of condition objects; never emit strings, SQL snippets, or if-block conditions. Each attribute and value must be a tagged object. Example: [{ attribute: { kind: 'column', value: 'status' }, operator: 'eq', value: { kind: 'literal', value: 'active' }, chain: 'and' }].
+	joins?: {
+		table: string;  // table to join
+		alias?: string;  // alias for the table
+		attribute: string;  // attribute to join e.g. table1.id = table2.id
+		type: "inner" | "left" | "right" | "outer";  // type of join; default "inner"
+	}[];  // list of joins; default []
+	columns?: string[];  // list of columns to select with aliases if any (e.g. column1 or table.column2 AS column2 or table.*); default ["*"]
+}
+
+db_insert {
+	connection: string;  // integration id
+	tableName: string;  // table name (supports js expression)
+	data: {
+		source: "raw" | "js";  // source of the value
+		value: object;  // value to insert (object values can be js expression)
+	};
+	useParam: boolean;  // use parameter; default false
+}
+
+db_insertbulk {
+	connection: string;  // integration id
+	tableName: string;  // table name (supports js expression)
+	data: {
+		source: "raw" | "js";  // source of the value
+		value: object[] | string;  // value to insert
+	};
+	useParam: boolean;  // use parameter
+}
+
+db_native {
+	connection: string;  // integration id
+	js: string;  // js code to execute (has dbQuery(query: string) global function)
+}
+
+db_transaction {
+	connection: string;  // integration id
+	executor: string;  // block id to start a transaction (database adapter state changes to transaction)
+}
+
+db_update {
+	connection: string;  // integration id
+	tableName: string;  // table name (supports js expression)
+	conditions: DbWhereCondition[];  // Database WHERE clause. Always emit an array of condition objects; never emit strings, SQL snippets, or if-block conditions. Each attribute and value must be a tagged object. Example: [{ attribute: { kind: 'column', value: 'status' }, operator: 'eq', value: { kind: 'literal', value: 'active' }, chain: 'and' }].
+	data: {
+		source: "raw" | "js";  // source of the value
+		value: object | string;
+	};
+	useParam: boolean;  // use parameter
+}
+
+httpgetcookie {
+	name: string;  // name of the cookie (supports js expressions)
+}
+
+httpgetheader {
+	name: string;  // name of the header
+}
+
+httpgetparam {
+	name: string;  // parameter name (supports js expressions)
+	source: "query" | "path";  // source of the parameter
+}
+
+httpgetrequestbody {} // no configuration
+
+httpsetcookie {
+	name: string;  // cookie name (supports js expression)
+	value: string | number;  // cookie value (supports js expression)
+	domain?: string;  // domain (supports js expression)
+	path?: string;  // http path for the cookie (supports js expression)
+	expiry: string;  // expiry in date (ISO format, supports js expression)
+	httpOnly?: boolean;  // httponly cookie?
+	secure?: boolean;  // only in https?
+	samesite?: "" | "Lax" | "Strict" | "None";  // cookie samesite setting
+}
+
+httpsetheader {
+	name: string;  // header name (supports js expression)
+	value: string;  // header value (supports js expression)
+}
+
+consolelog {
+	message?: string;  // string message to log
+	level: "info" | "warn" | "error";  // log level; default "info"
+}
+
+forloop {
+	block?: string;  // block id for starting the execution
+	start: number | string;  // iteration start count (can be js expression)
+	end: number | string;  // iteration end count (can be js expression)
+	step: number | string;  // iteration step count (can be js expression); default 1
+}
+
+foreachloop {
+	block?: string;  // block id for starting the execution
+	values: any[];  // list of items to iterate on
+	useParam?: boolean;  // use parameter as the datasource to iterate on
+}
+
+cloud_logs {
+	connection: string;  // integration id; default ""
+	message?: string;  // string message to log
+	level: "info" | "warn" | "error";  // log level; default "info"
+}
+
+error_handler {
+	next: string;  // next block to execute; default ""
+}"
+`;

--- a/packages/blocks/builtin/compactSchemas.spec.ts
+++ b/packages/blocks/builtin/compactSchemas.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "bun:test";
+import { blockAiDescriptions } from "./blockAiDescriptions";
+import {
+	COMPACT_BLOCK_SCHEMAS_REFERENCE,
+	COMPACT_SHARED_TYPES,
+	renderCompactSchema,
+} from "./compactSchemas";
+
+describe("compact block schemas", () => {
+	/**
+	 * The gate. This reference is derived from the zod schemas, so editing a
+	 * block's params rewrites it — and this snapshot fails until someone has
+	 * read the diff and re-blessed it (`bun test -u`). A contract that drifts
+	 * away from what the block validates is the failure this exists to catch.
+	 */
+	it("renders a stable reference", () => {
+		expect(COMPACT_BLOCK_SCHEMAS_REFERENCE).toMatchSnapshot();
+	});
+
+	it("covers every block that has a schema", () => {
+		for (const block of blockAiDescriptions) {
+			if (!block.jsonSchema) continue;
+			expect(COMPACT_BLOCK_SCHEMAS_REFERENCE).toContain(`\n${block.name} {`);
+		}
+	});
+
+	it("states shared condition types once and references them by name", () => {
+		expect(COMPACT_SHARED_TYPES).toContain("type DbWhereCondition = {");
+		// The whole point of hoisting: the four condition-capable DB blocks
+		// name the type instead of each re-inlining its four fields.
+		expect(renderCompactSchema(JSON.stringify({
+			type: "object",
+			properties: { conditions: { type: "array", items: { type: "string" } } },
+			required: ["conditions"],
+		}))).toContain("conditions: string[];");
+		const inlined = COMPACT_BLOCK_SCHEMAS_REFERENCE.split("db_getall")[1] ?? "";
+		expect(inlined).toContain("conditions: DbWhereCondition[];");
+	});
+
+	it("drops the fields every block inherits", () => {
+		expect(COMPACT_BLOCK_SCHEMAS_REFERENCE).not.toContain("blockName");
+		expect(COMPACT_BLOCK_SCHEMAS_REFERENCE).not.toContain("blockDescription");
+	});
+
+	it("never renders a placeholder in place of a type", () => {
+		expect(COMPACT_BLOCK_SCHEMAS_REFERENCE).not.toContain("[object Object]");
+		expect(COMPACT_BLOCK_SCHEMAS_REFERENCE).not.toContain(": undefined");
+	});
+
+	it("costs a fraction of the JSON Schema it replaces", () => {
+		const jsonSchemaChars = blockAiDescriptions.reduce(
+			(total, block) => total + (block.jsonSchema?.length ?? 0),
+			0,
+		);
+		expect(COMPACT_BLOCK_SCHEMAS_REFERENCE.length).toBeLessThan(
+			jsonSchemaChars / 2,
+		);
+	});
+});

--- a/packages/blocks/builtin/compactSchemas.ts
+++ b/packages/blocks/builtin/compactSchemas.ts
@@ -1,0 +1,183 @@
+import z from "zod";
+import { conditionSchema } from "@fluxify/lib";
+import { blockAiDescriptions } from "./blockAiDescriptions";
+import { dbConditionSideSchema, whereConditionSchema } from "./db/schema";
+
+type JsonSchema = Record<string, any>;
+
+/**
+ * Renders a block's JSON Schema as a TypeScript-shaped contract.
+ *
+ * The catalogue in the block builder's system prompt is JSON Schema because
+ * that is what `z.toJSONSchema()` hands back, not because the model reads it
+ * better — and JSON Schema spends most of its characters on structure the
+ * model already infers (`"type": "string"` for a field whose value is plainly
+ * a string, a `required` array restating what the absence of `?` says). The
+ * same 29 contracts in this shape cost roughly a third of the tokens.
+ *
+ * Derived rather than hand-written on purpose: the source of truth stays the
+ * zod schema the block actually validates against, so `.describe()` text and
+ * enum members cannot drift away from what the block accepts at runtime.
+ */
+
+/** Fields every block inherits from `baseBlockDataSchema`. Stating them 29
+ * times tells the model nothing it did not learn the first time. */
+const BASE_FIELDS = new Set(["blockName", "blockDescription"]);
+
+/**
+ * Schemas shared by more than one block, hoisted so the contract is stated
+ * once and referenced by name. Order is dependency order — an entry may only
+ * reference names declared above it, because each is rendered against the
+ * types registered before it.
+ */
+const SHARED_TYPES: Array<[string, z.ZodType]> = [
+	["DbConditionSide", dbConditionSideSchema as unknown as z.ZodType],
+	["DbWhereCondition", whereConditionSchema as unknown as z.ZodType],
+	["Condition", conditionSchema as unknown as z.ZodType],
+];
+
+/** Identity of a schema's *shape*, ignoring the prose wrapped around it: the
+ * same condition type carries a different `.describe()` at each use site. */
+const shapeKey = (schema: JsonSchema): string =>
+	JSON.stringify(schema, (key, value) =>
+		key === "$schema" || key === "description" ? undefined : value,
+	);
+
+const sharedNames = new Map<string, string>();
+
+function typeOf(schema: JsonSchema, indent: string): string {
+	// An empty schema constrains nothing — that is `z.any()`, not `z.object()`,
+	// which still emits `{ type: "object" }` and lands in the switch below.
+	if (!schema || Object.keys(schema).length === 0) return "any";
+
+	const shared = sharedNames.get(shapeKey(schema));
+	if (shared) return shared;
+
+	if (schema.const !== undefined) return JSON.stringify(schema.const);
+	if (Array.isArray(schema.enum)) {
+		return schema.enum.map((value: unknown) => JSON.stringify(value)).join(" | ");
+	}
+
+	// zod emits `oneOf` for a discriminated union and `anyOf` for a plain one.
+	const union: JsonSchema[] | undefined = schema.oneOf ?? schema.anyOf;
+	if (union) return renderUnion(union, indent);
+
+	switch (schema.type) {
+		case "string":
+			return "string";
+		case "number":
+		case "integer":
+			return "number";
+		case "boolean":
+			return "boolean";
+		case "null":
+			return "null";
+		case "array":
+			return `${typeOf(schema.items ?? {}, indent)}[]`;
+		case "object": {
+			if (schema.properties && Object.keys(schema.properties).length) {
+				return renderObject(schema, indent, false);
+			}
+			// `z.record(z.string(), T)` types its values through additionalProperties.
+			const values = schema.additionalProperties;
+			if (values && typeof values === "object") {
+				return `Record<string, ${typeOf(values, indent)}>`;
+			}
+			return "object";
+		}
+		default:
+			return "any";
+	}
+}
+
+function renderUnion(members: JsonSchema[], indent: string): string {
+	const rendered = members.map((member) => typeOf(member, indent));
+	// Object members render across several lines; a one-line `A | B` join
+	// makes those unreadable, so give each its own arm instead.
+	return rendered.some((member) => member.includes("\n"))
+		? rendered.join(`\n${indent}| `)
+		: rendered.join(" | ");
+}
+
+function renderObject(
+	schema: JsonSchema,
+	indent: string,
+	dropBaseFields: boolean,
+): string {
+	const properties: JsonSchema = schema.properties ?? {};
+	const required = new Set<string>(schema.required ?? []);
+	const inner = `${indent}\t`;
+	const lines: string[] = [];
+
+	for (const [name, raw] of Object.entries(properties)) {
+		if (dropBaseFields && BASE_FIELDS.has(name)) continue;
+		const property = raw as JsonSchema;
+
+		const notes: string[] = [];
+		if (property.description) notes.push(property.description);
+		if (property.default !== undefined) {
+			notes.push(`default ${JSON.stringify(property.default)}`);
+		}
+
+		const optional = required.has(name) ? "" : "?";
+		const comment = notes.length ? `  // ${notes.join("; ")}` : "";
+		lines.push(`${inner}${name}${optional}: ${typeOf(property, inner)};${comment}`);
+	}
+
+	if (!lines.length) return "{}";
+	return `{\n${lines.join("\n")}\n${indent}}`;
+}
+
+/** Renders one block's JSON Schema (the string form stored on its AI
+ *  description, or an already-parsed object) as a compact contract body. */
+export function renderCompactSchema(jsonSchema: string | JsonSchema): string {
+	const parsed =
+		typeof jsonSchema === "string" ? JSON.parse(jsonSchema) : jsonSchema;
+	return renderObject(parsed, "", true);
+}
+
+/** `type X = ...` declarations for every shared schema, in dependency order.
+ *  Registering each only after it is rendered is what stops a type from
+ *  collapsing into a reference to itself. */
+export const COMPACT_SHARED_TYPES: string = SHARED_TYPES.map(
+	([name, schema]) => {
+		const jsonSchema = z.toJSONSchema(schema) as JsonSchema;
+		// Through `typeOf`, not `renderObject`: a shared type is not always an
+		// object — `dbConditionSideSchema` is a union at its top level.
+		const body = typeOf(jsonSchema, "");
+		sharedNames.set(shapeKey(jsonSchema), name);
+		return `type ${name} = ${body}`;
+	},
+).join("\n\n");
+
+/** Drop-in replacement for `BUILTIN_BLOCK_SCHEMAS_REFERENCE`: the same 29
+ *  contracts, shared types stated once, in one fence rather than 29. */
+export const COMPACT_BLOCK_SCHEMAS_REFERENCE: string = [
+	COMPACT_SHARED_TYPES,
+	...blockAiDescriptions
+		.filter(
+			(block): block is (typeof blockAiDescriptions)[number] & { jsonSchema: string } =>
+				typeof block.jsonSchema === "string" && block.jsonSchema.length > 0,
+		)
+		.map(({ name, jsonSchema }) => {
+			const body = renderCompactSchema(jsonSchema);
+			return `${name} ${body === "{}" ? "{} // no configuration" : body}`;
+		}),
+].join("\n\n");
+
+// `bun run builtin/compactSchemas.ts` prints the reference and what it saves.
+// Guarded on argv rather than `import.meta.main` because this package compiles
+// under a module target that rejects `import.meta`.
+if (process.argv[1]?.endsWith("compactSchemas.ts")) {
+	const before = blockAiDescriptions.reduce(
+		(total, block) => total + (block.jsonSchema?.length ?? 0),
+		0,
+	);
+	const after = COMPACT_BLOCK_SCHEMAS_REFERENCE.length;
+	console.log(COMPACT_BLOCK_SCHEMAS_REFERENCE);
+	console.log(
+		`\n--- json schema ${before} chars | compact ${after} chars | ${Math.round(
+			(1 - after / before) * 100,
+		)}% smaller`,
+	);
+}

--- a/packages/blocks/index.ts
+++ b/packages/blocks/index.ts
@@ -47,5 +47,6 @@ export * from "./builtin/log";
 export * from "./builtin/log/cloudLogs";
 export * from "./builtin/log/console";
 export * from "./builtin/blockAiDescriptions";
+export * from "./builtin/compactSchemas";
 export * from "./builtin/blockSchemasMap";
 export * from "./builtin/errorHandler";


### PR DESCRIPTION
Closes #293. Part of #291.

## Why

Two costs, both paid on every run:

- **Prompt size.** Builtin block schemas and canvases reached agents as raw JSON. Most of it is punctuation the model does not read.
- **Round trips.** The block builder had to discover which canvas it was editing. `find_resource` by name → id → fetch canvas. Each round trip re-sends the entire prompt prefix, so on a ~25 tps model a one-edge change took ~4 minutes, almost all of it spent rediscovering an id the run already had.

## What

**Compact rendering**
- Block schemas render as TypeScript-shaped signatures instead of JSON Schema. Measured on a real run: 21,300 → 18,469 prompt tokens.
- `renderCanvas` emits one line per block (`id`, type, `@x,y`), shared by the context block, `find_resource` and `get_artifact`.

**Target canvas resolved without the model**
- `buildTargetCanvasContext` derives the target from a direct dependency's `routeId`/`customBlockId`/`targetId`, or from a single inventory id quoted in the task text, then prefetches it in one DB read issued alongside the doc fetch. An ambiguous target (two candidates) is left to the model — it has the tools for that.
- The agent is now told whether the artifact is applied. The old `plannedNewRouteContext` asserted `canvas: []` for anything a dependency created, which stops being true the moment that artifact is applied — the agent then wrote a second copy of the blocks already there. Applied → the real canvas with ids and positions. Not applied → an explicit "does not exist yet, build its initial blocks". Both endings tell it not to go searching.

**Read-tool memoization widened to the run**
- It was scoped to one agent invocation, so parallel sub-agents and supervisor re-runs each paid again for the same lookup. Nothing mutates the database or doc store mid-run, so `search_docs`, `find_resource`, `get_route_details` and `get_artifact` are cached on the run's agent wrapper.
- `get_agent_output` and `get_custom_block_schemas` deliberately stay per-invocation: they close over that invocation's snapshot, and sharing them would replay one sub-agent's "not found" to a later one that would have found it.

**Fewer model calls**
- A run with no failures and no open questions is summarized deterministically from its own results. The summarizer model is called only when there is something to reason about.

## Fixes along the way

- **Blocks appeared to scatter on edit.** `formattedCanvasChanges` anchored a changed block against the wrong origin, so every edit re-placed the graph instead of nudging it. Anchor logic moved to `artifacts/canvasLayout.ts` with tests, which also takes `normalize.ts` back under the FTA cap.
- **Harness UI:** the prompt editor gated Send on a model connection probe, so a slow or failing probe blocked a prompt the run would have handled fine.

## Not done, deliberately

`PREFETCH_DOC_TITLES` gating was in the issue scope and is dropped. Those docs live in the **system prompt**, so they are prefix-cached across every turn of a run. Gating them per task makes the prompt vary by task and busts that cache — more expensive on a multi-turn run than the ~3K it saves.

## Testing

`bun run lint` clean, unit tests green, all touched files under the FTA cap. New tests: `compactSchemas`, `renderCanvas`, `canvasLayout`, `targetCanvas` (7 cases incl. ambiguity, delete, and the applied/not-applied split), and a memoization test asserting `find_resource` runs once across two wrapper invocations while `get_agent_output` runs twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
