### PR TITLE
feat(ai-gateway): move the harness queue off BullMQ onto NATS JetStream

### DIFF
--- a/apps/ai-gateway/package.json
+++ b/apps/ai-gateway/package.json
@@ -42,7 +42,6 @@
 		"@orama/plugin-data-persistence": "^3.1.18",
 		"@socket.io/bun-engine": "^0.1.1",
 		"ai": "^7.0.0",
-		"bullmq": "^5.79.1",
 		"drizzle-orm": "0.44.7",
 		"hono": "^4.12.27",
 		"hono-openapi": "^1.3.0",

--- a/apps/ai-gateway/src/harness/callbacks.ts
+++ b/apps/ai-gateway/src/harness/callbacks.ts
@@ -72,8 +72,8 @@ export interface HarnessCallbackContext {
  * `graph.streamEvents`. Each node execution:
  *  - upserts a step + saves live working-memory to Postgres (HarnessService)
  *  - caches a structured event to Redis (RedisService)
- *  - pushes the event through the BullMQ job (job.updateProgress) which the
- *    QueueEvents -> EventEmitter bridge fans out to SSE subscribers.
+ *  - publishes the event on NATS (`conversations.<userId>`), which the SSE
+ *    endpoint fans out to subscribers.
  */
 export class HarnessCallbacks {
 	protected state: Partial<GlobalGraphState>;

--- a/apps/ai-gateway/src/harness/index.ts
+++ b/apps/ai-gateway/src/harness/index.ts
@@ -319,7 +319,7 @@ export class FluxifyHarness {
 			await callbacks.flush().catch(() => {});
 
 			// User interrupt is a clean terminal, not a failure — finalize as
-			// `interrupted` and don't rethrow (so BullMQ doesn't retry the job).
+			// `interrupted` and don't rethrow (nothing to retry; the job is already acked).
 			// A bare AbortError only means "interrupted" if this run's controller
 			// actually fired — provider-side timeouts abort too, and those are
 			// failures, not user stops.

--- a/apps/ai-gateway/src/harness/internal/enqueue.spec.ts
+++ b/apps/ai-gateway/src/harness/internal/enqueue.spec.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, spyOn, mock, afterEach } from "bun:test";
+import * as serverModule from "@fluxify/server";
+import { HarnessService } from "./harnessService";
+import { RedisService } from "./redisService";
+import { enqueueHarnessStart, enqueueHarnessContinue } from "./enqueue";
+
+/** every publish this test file made: [subject, data, opts] */
+function stubPublish() {
+	const calls: Array<{ subject: string; data: any; opts: any }> = [];
+	spyOn(serverModule, "publishJob").mockImplementation(
+		async (subject: string, data: any, opts: any = {}) => {
+			calls.push({ subject, data, opts });
+			return true;
+		},
+	);
+	return calls;
+}
+
+afterEach(() => mock.restore());
+
+describe("enqueueHarnessStart", () => {
+	it("claims the conversation, then publishes the job with its key as the msg id", async () => {
+		spyOn(HarnessService.prototype, "ensureConversation").mockResolvedValue("conv1");
+		spyOn(HarnessService.prototype, "createRun").mockResolvedValue("run1");
+		spyOn(RedisService.prototype, "setActiveRun").mockResolvedValue(undefined);
+		const published = stubPublish();
+
+		const result = await enqueueHarnessStart({
+			conversationId: "conv1",
+			query: "build me a route",
+			metadata: { userId: "u1", projectId: "p1" },
+		});
+
+		expect(result).toEqual({ conversationId: "conv1", runId: "run1" });
+		expect(published).toHaveLength(1);
+		expect(published[0].subject).toBe("fluxify.harness.start.conv1");
+		expect(published[0].data).toMatchObject({
+			type: "start",
+			conversationId: "conv1",
+			runId: "run1",
+			query: "build me a route",
+		});
+		// the id on the wire and the id in the payload must be the same value,
+		// or the dedupe window guards nothing the logs can be traced back to
+		expect(published[0].opts.msgId).toBe(published[0].data.idempotencyKey);
+		expect(published[0].opts.msgId).toStartWith("start:run1:");
+	});
+
+	it("refuses and publishes nothing when the conversation claim is lost", async () => {
+		spyOn(HarnessService.prototype, "ensureConversation").mockResolvedValue("conv1");
+		spyOn(HarnessService.prototype, "createRun").mockResolvedValue(null);
+		const published = stubPublish();
+
+		expect(
+			enqueueHarnessStart({ conversationId: "conv1", query: "hi" }),
+		).rejects.toThrow(serverModule.ConflictError);
+		expect(published).toHaveLength(0);
+	});
+
+	it("gives two racing starts on one conversation two different msg ids", async () => {
+		spyOn(HarnessService.prototype, "ensureConversation").mockResolvedValue("conv1");
+		spyOn(RedisService.prototype, "setActiveRun").mockResolvedValue(undefined);
+		const createRun = spyOn(HarnessService.prototype, "createRun");
+		createRun.mockResolvedValueOnce("runA").mockResolvedValueOnce("runB");
+		const published = stubPublish();
+
+		await enqueueHarnessStart({ conversationId: "conv1", query: "a" });
+		await enqueueHarnessStart({ conversationId: "conv1", query: "b" });
+
+		expect(published[0].opts.msgId).not.toBe(published[1].opts.msgId);
+	});
+});
+
+describe("enqueueHarnessContinue", () => {
+	it("publishes on the continue subject once the parked conversation is claimed", async () => {
+		spyOn(
+			HarnessService.prototype,
+			"claimConversationForContinue",
+		).mockResolvedValue(true);
+		const published = stubPublish();
+
+		const result = await enqueueHarnessContinue({
+			conversationId: "conv1",
+			runId: "run1",
+			action: { type: "approve" },
+		});
+
+		expect(result).toEqual({ conversationId: "conv1", runId: "run1" });
+		expect(published[0].subject).toBe("fluxify.harness.continue.conv1");
+		expect(published[0].data).toMatchObject({
+			type: "continue",
+			runId: "run1",
+			action: { type: "approve" },
+		});
+		expect(published[0].opts.msgId).toStartWith("continue:run1:");
+	});
+
+	it("refuses when the run is no longer awaiting review", async () => {
+		spyOn(
+			HarnessService.prototype,
+			"claimConversationForContinue",
+		).mockResolvedValue(false);
+		const published = stubPublish();
+
+		expect(
+			enqueueHarnessContinue({
+				conversationId: "conv1",
+				runId: "run1",
+				action: { type: "approve" },
+			}),
+		).rejects.toThrow(serverModule.ConflictError);
+		expect(published).toHaveLength(0);
+	});
+
+	it("does not reuse the start key, so a continue is never eaten as a duplicate", async () => {
+		spyOn(HarnessService.prototype, "ensureConversation").mockResolvedValue("conv1");
+		spyOn(HarnessService.prototype, "createRun").mockResolvedValue("run1");
+		spyOn(RedisService.prototype, "setActiveRun").mockResolvedValue(undefined);
+		spyOn(
+			HarnessService.prototype,
+			"claimConversationForContinue",
+		).mockResolvedValue(true);
+		const published = stubPublish();
+
+		await enqueueHarnessStart({ conversationId: "conv1", query: "hi" });
+		await enqueueHarnessContinue({
+			conversationId: "conv1",
+			runId: "run1",
+			action: { type: "approve" },
+		});
+		// and a second, legitimate HITL decision on the same run
+		await enqueueHarnessContinue({
+			conversationId: "conv1",
+			runId: "run1",
+			action: { type: "review", comments: ["tighten it"] },
+		});
+
+		const ids = published.map((p) => p.opts.msgId);
+		expect(new Set(ids).size).toBe(3);
+	});
+});

--- a/apps/ai-gateway/src/harness/internal/enqueue.ts
+++ b/apps/ai-gateway/src/harness/internal/enqueue.ts
@@ -1,10 +1,11 @@
 import { generateID } from "@fluxify/lib";
+import { ConflictError, publishJob } from "@fluxify/server";
 import { HarnessService, type HitlPlanAction } from "./harnessService";
 import { RedisService } from "./redisService";
 import {
-	harnessQueue,
-	HARNESS_START_JOB,
-	HARNESS_CONTINUE_JOB,
+	harnessContinueSubject,
+	harnessStartSubject,
+	type HarnessJobData,
 	type HarnessJobMetadata,
 } from "../queue";
 
@@ -28,9 +29,22 @@ export interface EnqueueContinueParams {
 }
 
 /**
- * Bootstraps a conversation + run and enqueues a `start` job. Returns the ids so
- * the caller can subscribe to the harness event emitter by conversationId.
- * (Used by demo.ts now; API endpoints will call this later.)
+ * `Nats-Msg-Id` for one publish. Unique per *intent*, so the stream's dedupe
+ * window swallows a republish of the same message (an ambiguous publish that the
+ * caller retried) without ever swallowing a second, legitimate HITL decision on
+ * the same run.
+ */
+function idempotencyKey(type: HarnessJobData["type"], runId: string): string {
+	return `${type}:${runId}:${generateID()}`;
+}
+
+/**
+ * Bootstraps a conversation + run and queues a `start` job. Returns the ids so
+ * the caller can subscribe to the run's events by conversationId.
+ *
+ * Throws `ConflictError` when the conversation already has a live run — the
+ * claim inside `createRun` is atomic, unlike the status check the API does
+ * first, so this is the one that survives two requests arriving together.
  */
 export async function enqueueHarnessStart(
 	params: EnqueueStartParams,
@@ -47,32 +61,42 @@ export async function enqueueHarnessStart(
 		userQuery: params.query,
 		integrationId: params.integrationId,
 	});
+	if (!runId) {
+		throw new ConflictError("This conversation already has a run in progress");
+	}
 	await new RedisService().setActiveRun(conversationId, runId);
 
-	await harnessQueue.add(
-		HARNESS_START_JOB,
+	const key = idempotencyKey("start", runId);
+	await publishJob<HarnessJobData>(
+		harnessStartSubject(conversationId),
 		{
 			type: "start",
 			conversationId,
 			runId,
 			query: params.query,
 			metadata: params.metadata,
+			idempotencyKey: key,
 		},
-		// jobId = conversationId: one active run per conversation, and the running
-		// job is addressable by conversationId. Removed on finish so the next
-		// message/continue can reuse the id.
-		{ jobId: conversationId, removeOnComplete: true, removeOnFail: true },
+		{ msgId: key },
 	);
 
 	return { conversationId, runId };
 }
 
-/** Enqueues a `continue` job to resume a parked (awaiting_hitl) run. */
+/** Queues a `continue` job to resume a parked (awaiting_hitl) run. Throws
+ *  `ConflictError` when the run is no longer parked or has moved on. */
 export async function enqueueHarnessContinue(
 	params: EnqueueContinueParams,
 ): Promise<{ conversationId: string; runId: string }> {
-	await harnessQueue.add(
-		HARNESS_CONTINUE_JOB,
+	const service = new HarnessService(params.conversationId);
+	const claimed = await service.claimConversationForContinue(params.runId);
+	if (!claimed) {
+		throw new ConflictError("Conversation is not awaiting review");
+	}
+
+	const key = idempotencyKey("continue", params.runId);
+	await publishJob<HarnessJobData>(
+		harnessContinueSubject(params.conversationId),
 		{
 			type: "continue",
 			conversationId: params.conversationId,
@@ -80,8 +104,9 @@ export async function enqueueHarnessContinue(
 			query: params.query,
 			action: params.action,
 			metadata: params.metadata,
+			idempotencyKey: key,
 		},
-		{ jobId: params.conversationId, removeOnComplete: true, removeOnFail: true },
+		{ msgId: key },
 	);
 
 	return { conversationId: params.conversationId, runId: params.runId };

--- a/apps/ai-gateway/src/harness/internal/harnessService.ts
+++ b/apps/ai-gateway/src/harness/internal/harnessService.ts
@@ -8,7 +8,7 @@ import {
 	agentHarnessArtifactsEntity,
 	agentHarnessSubArtifactsEntity,
 } from "@fluxify/server";
-import { eq, and } from "drizzle-orm";
+import { eq, and, notInArray } from "drizzle-orm";
 import { logger } from "@fluxify/common";
 import type { BaseMessage } from "@langchain/core/messages";
 import type { GlobalGraphState } from "../types";
@@ -171,7 +171,9 @@ export class HarnessService {
 					userId: input.userId,
 					projectId: input.projectId,
 					title: input.title ?? "New Chat",
-					status: "running",
+					// `createRun` is the single place a conversation becomes `running`,
+					// and it does so conditionally — see the claim there.
+					status: "idle",
 					metadata: input.metadata,
 				})
 				.returning({ id: agentHarnessConversationsEntity.id });
@@ -190,13 +192,20 @@ export class HarnessService {
 	}
 
 	/**
-	 * Creates a new run for this conversation and marks it as the active run.
-	 * Returns the new runId. The run starts in `queued`.
+	 * Creates a new run for this conversation and claims the conversation for it.
+	 * Returns the new runId, or **null** when another run already holds the
+	 * conversation — the claim is a conditional UPDATE, so two requests racing
+	 * here (double click, retried POST) cannot both win. The loser's run row is
+	 * removed again, and the caller turns null into a 409.
+	 *
+	 * This claim, plus `claimRun` on the worker side, is what actually keeps one
+	 * run per conversation; the queue's message dedupe only covers a republished
+	 * message, never a second intent.
 	 */
 	async createRun(input: {
 		userQuery: string;
 		integrationId?: string;
-	}): Promise<string> {
+	}): Promise<string | null> {
 		try {
 			const [run] = await db
 				.insert(agentHarnessRunsEntity)
@@ -208,10 +217,29 @@ export class HarnessService {
 				})
 				.returning({ id: agentHarnessRunsEntity.id });
 
-			await db
+			const claimed = await db
 				.update(agentHarnessConversationsEntity)
 				.set({ activeRunId: run.id, status: "running", updatedAt: new Date() })
-				.where(eq(agentHarnessConversationsEntity.id, this.conversationId));
+				.where(
+					and(
+						eq(agentHarnessConversationsEntity.id, this.conversationId),
+						notInArray(agentHarnessConversationsEntity.status, [
+							"running",
+							"paused_hitl",
+						]),
+					),
+				)
+				.returning({ id: agentHarnessConversationsEntity.id });
+
+			if (claimed.length === 0) {
+				await db
+					.delete(agentHarnessRunsEntity)
+					.where(eq(agentHarnessRunsEntity.id, run.id));
+				logger.warn("[HarnessService] Conversation already has a live run", {
+					conversationId: this.conversationId,
+				});
+				return null;
+			}
 
 			logger.info("[HarnessService] Run created", {
 				runId: run.id,
@@ -225,6 +253,52 @@ export class HarnessService {
 			});
 			throw error;
 		}
+	}
+
+	/**
+	 * Claims a parked conversation for a `continue`: `paused_hitl` -> `running`,
+	 * only while `runId` is still the active run. False means the HITL decision
+	 * lost a race (the user double-submitted, or the run moved on), and the
+	 * caller must not queue the job.
+	 */
+	async claimConversationForContinue(runId: string): Promise<boolean> {
+		const claimed = await db
+			.update(agentHarnessConversationsEntity)
+			.set({ status: "running", updatedAt: new Date() })
+			.where(
+				and(
+					eq(agentHarnessConversationsEntity.id, this.conversationId),
+					eq(agentHarnessConversationsEntity.status, "paused_hitl"),
+					eq(agentHarnessConversationsEntity.activeRunId, runId),
+				),
+			)
+			.returning({ id: agentHarnessConversationsEntity.id });
+		return claimed.length > 0;
+	}
+
+	/**
+	 * Worker-side idempotency gate: moves the run out of its pre-execution status
+	 * in one conditional UPDATE. False means this job must not run — the message
+	 * was delivered twice, or the run was already picked up, finished or
+	 * interrupted. Called before any model work, so a duplicate costs a query
+	 * rather than a run's worth of tokens.
+	 */
+	async claimRun(
+		runId: string,
+		from: "queued" | "awaiting_hitl",
+		to: "routing" | "executing",
+	): Promise<boolean> {
+		const claimed = await db
+			.update(agentHarnessRunsEntity)
+			.set({ status: to, updatedAt: new Date() })
+			.where(
+				and(
+					eq(agentHarnessRunsEntity.id, runId),
+					eq(agentHarnessRunsEntity.status, from),
+				),
+			)
+			.returning({ id: agentHarnessRunsEntity.id });
+		return claimed.length > 0;
 	}
 
 	/** Updates the conversation-level status. */

--- a/apps/ai-gateway/src/harness/internal/runContext.ts
+++ b/apps/ai-gateway/src/harness/internal/runContext.ts
@@ -1,5 +1,4 @@
-import type { Job } from "bullmq";
-import type { HarnessJobData, HarnessJobMetadata } from "../queue";
+import type { HarnessJobMetadata } from "../queue";
 import type { HitlPlanAction } from "./harnessService";
 
 /** Everything one harness pass needs to identify and describe itself. Lives
@@ -11,5 +10,4 @@ export interface HarnessRunContext {
 	query?: string;
 	action?: HitlPlanAction;
 	metadata?: HarnessJobMetadata;
-	job?: Job<HarnessJobData>;
 }

--- a/apps/ai-gateway/src/harness/interrupt.ts
+++ b/apps/ai-gateway/src/harness/interrupt.ts
@@ -5,8 +5,8 @@ import { publishMessage, subscribeToChannel } from "@fluxify/server";
  * RUN INTERRUPT DELIVERY
  * ----------------------------------------------------------------------------
  * A run executes in the worker thread; the interrupt request arrives on the API
- * (main thread). BullMQ can't message a running job, so the request is delivered
- * over NATS: the API publishes `harness.interrupt.<conversationId>`, the worker
+ * (main thread). a work-queue job can't be messaged once it is running, so the request is
+ * delivered over NATS: the API publishes `harness.interrupt.<conversationId>`, the worker
  * subscribes and aborts the matching run's AbortController.
  * ========================================================================== */
 

--- a/apps/ai-gateway/src/harness/notification-implementation.md
+++ b/apps/ai-gateway/src/harness/notification-implementation.md
@@ -10,8 +10,8 @@ did not survive reconnects and scaled poorly (single QueueEvents connection per
 process, no cross-instance fan-out). A user can also run **multiple** harness
 sessions at once, so updates are keyed per **conversation owner**, not per job.
 
-BullMQ still owns **triggering** runs (persistent, retry-safe). Only the
-**progress stream** moved to NATS.
+Triggering runs moved to NATS JetStream too (see `harness/queue.ts`); this
+document covers only the **progress stream**.
 
 ## Subject scheme
 
@@ -64,7 +64,7 @@ Nothing new was added to the server package.
 ## Producer side (worker thread)
 
 ```
-BullMQ job → FluxifyHarness.executeGraph
+JetStream job → FluxifyHarness.executeGraph
   └─ getOwnerUserId() once per run  (conversations.userId, FK → system_users)
   └─ HarnessCallbacks.emit(event)   per node lifecycle event
   └─ emitTerminal(event)            on completed / failed / awaiting_hitl

--- a/apps/ai-gateway/src/harness/queue.ts
+++ b/apps/ai-gateway/src/harness/queue.ts
@@ -1,11 +1,40 @@
-import { Queue } from "bullmq";
 import { logger } from "@fluxify/common";
-import { REDIS_HOST, REDIS_PASS, REDIS_PORT, REDIS_USER } from "../lib/env";
+import { ensureWorkQueue, type WorkQueueSpec } from "@fluxify/server";
 import type { HitlPlanAction } from "./internal/harnessService";
 
-export const HARNESS_QUEUE_NAME = "AGENT_HARNESS_QUEUE";
-export const HARNESS_START_JOB = "HARNESS_START_JOB";
-export const HARNESS_CONTINUE_JOB = "HARNESS_CONTINUE_JOB";
+/**
+ * Harness jobs travel on a JetStream work queue. Requests survive a gateway
+ * restart, several gateway replicas share one durable consumer (that is the
+ * load balancing), and a run is handled exactly once.
+ */
+
+export const HARNESS_STREAM = "FLUXIFY_HARNESS";
+export const HARNESS_CONSUMER = "fluxify_harness";
+
+const SUBJECT_ROOT = "fluxify.harness";
+/** everything the harness worker consumes */
+export const HARNESS_SUBJECTS = [`${SUBJECT_ROOT}.>`];
+
+export const harnessStartSubject = (conversationId: string) =>
+	`${SUBJECT_ROOT}.start.${conversationId}`;
+export const harnessContinueSubject = (conversationId: string) =>
+	`${SUBJECT_ROOT}.continue.${conversationId}`;
+
+export const HARNESS_QUEUE: WorkQueueSpec = {
+	stream: HARNESS_STREAM,
+	subjects: HARNESS_SUBJECTS,
+	consumer: HARNESS_CONSUMER,
+	// A run is expensive and not idempotent: replaying one from the top after a
+	// worker dies would re-spend the tokens and re-emit every step. The user
+	// re-sends instead. Acking on dispatch (see worker.ts) makes this explicit.
+	maxDeliver: 1,
+	// Only covers the window between delivery and the dispatch ack, not the run.
+	ackWaitMs: 30_000,
+	// Guards a *retried publish* of one intent. It is not what stops a second
+	// run on a conversation — the two DB claims do that (see enqueue.ts).
+	dedupeWindowMs: 2 * 60_000,
+	maxAgeMs: 60 * 60_000,
+};
 
 export interface HarnessJobMetadata {
 	projectId?: string;
@@ -49,28 +78,17 @@ export interface HarnessJobData {
 	query?: string;
 	action?: HitlPlanAction;
 	metadata?: HarnessJobMetadata;
+	/** `Nats-Msg-Id` of this publish; carried for log correlation. */
+	idempotencyKey?: string;
 }
-
-function connection() {
-	return {
-		host: REDIS_HOST,
-		port: parseInt(REDIS_PORT),
-		password: REDIS_PASS,
-		username: REDIS_USER,
-	};
-}
-
-export let harnessQueue: Queue<HarnessJobData> = null!;
 
 let initialized = false;
 
-export function initializeHarnessQueue() {
+/** Declares the stream + durable consumer. Idempotent; called from both the
+ *  API thread (publisher) and the worker thread (consumer). */
+export async function initializeHarnessQueue() {
 	if (initialized) return;
-
-	harnessQueue = new Queue<HarnessJobData>(HARNESS_QUEUE_NAME, {
-		connection: connection(),
-	});
-
+	await ensureWorkQueue(HARNESS_QUEUE);
 	initialized = true;
 	logger.info("Initialized", "HarnessQueue");
 }

--- a/apps/ai-gateway/src/harness/worker.spec.ts
+++ b/apps/ai-gateway/src/harness/worker.spec.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, spyOn, mock, afterEach } from "bun:test";
+import type { QueueJob } from "@fluxify/server";
+import { FluxifyHarness } from "./index";
+import { HarnessService } from "./internal/harnessService";
+import * as projectConfig from "./models/projectConfig";
+import { __runJob, __releaseRun } from "./worker";
+import type { HarnessJobData } from "./queue";
+
+const job = (data: Partial<HarnessJobData>): QueueJob<HarnessJobData> =>
+	({
+		subject: "fluxify.harness.start.conv1",
+		data: {
+			type: "start",
+			conversationId: "conv1",
+			runId: "run1",
+			metadata: { projectId: "p1" },
+			...data,
+		} as HarnessJobData,
+		msg: {} as any,
+	}) as QueueJob<HarnessJobData>;
+
+/** Stubs everything past the claim so a claimed job doesn't reach a model. */
+function stubHarness() {
+	spyOn(projectConfig, "resolveAgentOptionsFromProjectId").mockResolvedValue(
+		{} as any,
+	);
+	spyOn(projectConfig, "resolveAgentOptionsFromIntegrationId").mockReturnValue(
+		{} as any,
+	);
+	return {
+		start: spyOn(FluxifyHarness.prototype, "start").mockResolvedValue(undefined),
+		cont: spyOn(FluxifyHarness.prototype, "continue").mockResolvedValue(undefined),
+	};
+}
+
+afterEach(() => mock.restore());
+
+describe("harness worker job handling", () => {
+	it("claims a start job out of `queued` before doing any AI work", async () => {
+		const claim = spyOn(HarnessService.prototype, "claimRun").mockResolvedValue(true);
+		const harness = stubHarness();
+
+		await __runJob(job({ type: "start" }));
+
+		expect(claim).toHaveBeenCalledWith("run1", "queued", "routing");
+		expect(harness.start).toHaveBeenCalledTimes(1);
+		expect(harness.cont).not.toHaveBeenCalled();
+	});
+
+	it("claims a continue job out of `awaiting_hitl`", async () => {
+		const claim = spyOn(HarnessService.prototype, "claimRun").mockResolvedValue(true);
+		const harness = stubHarness();
+
+		await __runJob(job({ type: "continue", action: { type: "approve" } }));
+
+		expect(claim).toHaveBeenCalledWith("run1", "awaiting_hitl", "executing");
+		expect(harness.cont).toHaveBeenCalledTimes(1);
+		expect(harness.start).not.toHaveBeenCalled();
+	});
+
+	it("drops a duplicate delivery without running the graph", async () => {
+		spyOn(HarnessService.prototype, "claimRun").mockResolvedValue(false);
+		const harness = stubHarness();
+
+		await __runJob(job({}));
+
+		expect(harness.start).not.toHaveBeenCalled();
+		expect(harness.cont).not.toHaveBeenCalled();
+	});
+
+	it("rejects a job with no projectId before it can claim the run", async () => {
+		const claim = spyOn(HarnessService.prototype, "claimRun").mockResolvedValue(true);
+
+		expect(__runJob(job({ metadata: {} }))).rejects.toThrow("missing projectId");
+		expect(claim).not.toHaveBeenCalled();
+	});
+
+	it("passes the job's own metadata through to the run context", async () => {
+		spyOn(HarnessService.prototype, "claimRun").mockResolvedValue(true);
+		const harness = stubHarness();
+		const metadata = { projectId: "p1", userId: "u1", applyMode: "auto" as const };
+
+		await __runJob(job({ query: "hi", metadata }));
+
+		expect(harness.start.mock.calls[0][0]).toMatchObject({
+			conversationId: "conv1",
+			runId: "run1",
+			query: "hi",
+			metadata,
+		});
+	});
+});
+
+describe("releaseRun", () => {
+	it("fails the run and the conversation so the claim can't strand them", async () => {
+		const updateRun = spyOn(HarnessService.prototype, "updateRun").mockResolvedValue(
+			undefined as any,
+		);
+		const updateConversation = spyOn(
+			HarnessService.prototype,
+			"updateConversationStatus",
+		).mockResolvedValue(undefined as any);
+
+		await __releaseRun({
+			type: "start",
+			conversationId: "conv1",
+			runId: "run1",
+		});
+
+		expect(updateRun).toHaveBeenCalledWith({ runId: "run1", status: "failed" });
+		expect(updateConversation).toHaveBeenCalledWith("failed");
+	});
+
+	it("swallows a database error — it is already the error path", async () => {
+		spyOn(HarnessService.prototype, "updateRun").mockRejectedValue(
+			new Error("db down"),
+		);
+
+		expect(
+			__releaseRun({ type: "start", conversationId: "conv1", runId: "run1" }),
+		).resolves.toBeUndefined();
+	});
+});

--- a/apps/ai-gateway/src/harness/worker.ts
+++ b/apps/ai-gateway/src/harness/worker.ts
@@ -1,91 +1,129 @@
-import { Worker } from "bullmq";
 import { logger } from "@fluxify/common";
-import { initializePubSub } from "@fluxify/server";
-import { REDIS_HOST, REDIS_PASS, REDIS_PORT, REDIS_USER } from "../lib/env";
-import { HARNESS_QUEUE_NAME, type HarnessJobData } from "./queue";
+import { consumeJobs, initializePubSub, type QueueJob } from "@fluxify/server";
+import { HARNESS_CONCURRENT_JOBS } from "../lib/env";
+import {
+	HARNESS_QUEUE,
+	initializeHarnessQueue,
+	type HarnessJobData,
+} from "./queue";
 import { AgentFactory } from "./models/factory";
 import {
 	resolveAgentOptionsFromIntegrationId,
 	resolveAgentOptionsFromProjectId,
 } from "./models/projectConfig";
 import { FluxifyHarness, type HarnessRunContext } from "./index";
+import { HarnessService } from "./internal/harnessService";
 import { subscribeInterrupts } from "./interrupt";
 
-let worker: Worker<HarnessJobData> | null = null;
+let stop: (() => Promise<void>) | null = null;
 
 /**
- * Starts the BullMQ worker that consumes harness jobs and drives a run through
- * the graph. Runs in the gateway worker thread (see worker.ts -> runWorker).
+ * Consumes harness jobs off the JetStream work queue and drives each one
+ * through the graph. Runs in the gateway worker thread (see worker.ts ->
+ * runWorker); several gateway replicas share one durable consumer, so this
+ * scales out by starting more of them.
  */
 export async function initializeHarnessWorker() {
-	if (worker) return worker;
+	if (stop) return stop;
 
 	// The worker publishes progress to NATS (`conversations.<userId>`); ensure the
 	// pub/sub client is connected before any job runs. Idempotent.
 	await initializePubSub();
+	await initializeHarnessQueue();
 	// Listen for user interrupt requests targeting runs on this worker.
 	await subscribeInterrupts();
 
-	worker = new Worker<HarnessJobData>(
-		HARNESS_QUEUE_NAME,
-		async (job) => {
-			const data = job.data;
-
-			const projectId = data.metadata?.projectId;
-			if (!projectId) {
-				throw new Error("Harness job missing projectId; cannot resolve AI config");
-			}
-
-			// AI provider/keys come from the run's picked integration (never env);
-			// fall back to the project default when the user didn't choose one.
-			const integrationId = data.metadata?.integrationId;
-			const agentOptions = integrationId
-				? resolveAgentOptionsFromIntegrationId(integrationId)
-				: await resolveAgentOptionsFromProjectId(projectId);
-			// No maxToolIterations override — the wrapper default (8) is already
-			// well above what a correct sub-agent run needs (2-4). Reaching the
-			// cap means the agent is thrashing, and every iteration costs a full
-			// round trip carrying the whole history.
-			const harness = new FluxifyHarness(new AgentFactory(agentOptions));
-			const ctx: HarnessRunContext = {
-				conversationId: data.conversationId,
-				runId: data.runId,
-				query: data.query,
-				action: data.action,
-				metadata: data.metadata,
-				job,
-			};
-
-			logger.info("[HarnessWorker] Processing job", {
-				jobId: job.id,
-				type: data.type,
-				conversationId: data.conversationId,
-				runId: data.runId,
-			});
-
-			if (data.type === "continue") {
-				return await harness.continue(ctx);
-			}
-			return await harness.start(ctx);
-		},
-		{
-			connection: {
-				host: REDIS_HOST,
-				port: parseInt(REDIS_PORT),
-				password: REDIS_PASS,
-				username: REDIS_USER,
-			},
-		},
-	);
-
-	worker.on("failed", (job, err) => {
-		logger.error("[HarnessWorker] Job failed", {
-			jobId: job?.id,
-			conversationId: job?.data?.conversationId,
-			error: err,
-		});
+	stop = await consumeJobs<HarnessJobData>(HARNESS_QUEUE, runJob, {
+		concurrency: HARNESS_CONCURRENT_JOBS,
+		// The queue never redelivers (maxDeliver 1), so holding the ack for the
+		// length of a run would buy nothing but an ack_wait heartbeat to maintain.
+		// Acking on dispatch also means a slot is what limits concurrency, not the
+		// consumer's pull window.
+		ack: "on-dispatch",
+		onError: (_error, job) => void releaseRun(job.data),
 	});
 
-	logger.info("Initialized", "HarnessWorker");
-	return worker;
+	logger.info(
+		`Initialized (concurrency ${HARNESS_CONCURRENT_JOBS})`,
+		"HarnessWorker",
+	);
+	return stop;
 }
+
+async function runJob({ data }: QueueJob<HarnessJobData>) {
+	const projectId = data.metadata?.projectId;
+	if (!projectId) {
+		throw new Error("Harness job missing projectId; cannot resolve AI config");
+	}
+
+	// Idempotency gate. Nothing past this point is cheap or repeatable, so a
+	// duplicate delivery is dropped here rather than after a model call.
+	const service = new HarnessService(data.conversationId);
+	const claimed =
+		data.type === "continue"
+			? await service.claimRun(data.runId, "awaiting_hitl", "executing")
+			: await service.claimRun(data.runId, "queued", "routing");
+	if (!claimed) {
+		logger.warn("[HarnessWorker] Skipping job; run is not claimable", {
+			runId: data.runId,
+			conversationId: data.conversationId,
+			type: data.type,
+			idempotencyKey: data.idempotencyKey,
+		});
+		return;
+	}
+
+	// AI provider/keys come from the run's picked integration (never env);
+	// fall back to the project default when the user didn't choose one.
+	const integrationId = data.metadata?.integrationId;
+	const agentOptions = integrationId
+		? resolveAgentOptionsFromIntegrationId(integrationId)
+		: await resolveAgentOptionsFromProjectId(projectId);
+	// No maxToolIterations override — the wrapper default (8) is already
+	// well above what a correct sub-agent run needs (2-4). Reaching the
+	// cap means the agent is thrashing, and every iteration costs a full
+	// round trip carrying the whole history.
+	const harness = new FluxifyHarness(new AgentFactory(agentOptions));
+	const ctx: HarnessRunContext = {
+		conversationId: data.conversationId,
+		runId: data.runId,
+		query: data.query,
+		action: data.action,
+		metadata: data.metadata,
+	};
+
+	logger.info("[HarnessWorker] Processing job", {
+		type: data.type,
+		conversationId: data.conversationId,
+		runId: data.runId,
+	});
+
+	if (data.type === "continue") {
+		await harness.continue(ctx);
+		return;
+	}
+	await harness.start(ctx);
+}
+
+/**
+ * Frees a conversation whose job threw before the harness took over its own
+ * error handling (a missing projectId, an unresolvable integration). Without
+ * this the claim taken above would leave the conversation `running` forever
+ * with nothing to finish it, and the user could never send another message.
+ */
+async function releaseRun(data: HarnessJobData) {
+	try {
+		const service = new HarnessService(data.conversationId);
+		await service.updateRun({ runId: data.runId, status: "failed" });
+		await service.updateConversationStatus("failed");
+	} catch (error) {
+		logger.error("[HarnessWorker] Failed to release run", {
+			runId: data.runId,
+			error,
+		});
+	}
+}
+
+/** Exported for tests: the job handler without the consumer around it. */
+export const __runJob = runJob;
+export const __releaseRun = releaseRun;

--- a/apps/ai-gateway/src/lib/env.ts
+++ b/apps/ai-gateway/src/lib/env.ts
@@ -45,6 +45,15 @@ export const aiGatewayEnvSchema = baseEnvSchema.extend({
 		)
 		.describe("Sampling rate for LLM traces (0.0 to 1.0)"),
 
+	HARNESS_CONCURRENT_JOBS: z
+		.string()
+		.optional()
+		.refine(
+			(val) => !val || (Number.isInteger(Number(val)) && Number(val) >= 1 && Number(val) <= 100),
+			{ message: "HARNESS_CONCURRENT_JOBS must be an integer between 1 and 100" },
+		)
+		.describe("Harness runs one gateway worker executes at once (1-100, default 10)"),
+
 	DOCS_INDEX_FILE_PATH: z
 		.string()
 		.max(500)
@@ -78,6 +87,9 @@ export const REDIS_HOST = getEnv("REDIS_HOST")!;
 export const REDIS_PORT = getEnv("REDIS_PORT")!;
 export const REDIS_USER = getEnv("REDIS_USER")!;
 export const REDIS_PASS = getEnv("REDIS_PASS")!;
+/** How many harness runs one worker executes concurrently. Tune to available
+ *  memory and expected AI workload — every slot holds a full graph run. */
+export const HARNESS_CONCURRENT_JOBS = Number(getEnv("HARNESS_CONCURRENT_JOBS")) || 10;
 export const AI_GATEWAY_PORT = Number(getEnv("AI_GATEWAY_PORT")) || 8001;
 export const DOCS_INDEX_FILE_PATH =
 	getEnv("DOCS_INDEX_FILE_PATH")! || "../dist/docs-index.bin";

--- a/apps/ai-gateway/src/server.ts
+++ b/apps/ai-gateway/src/server.ts
@@ -35,7 +35,7 @@ initializeRedis(true);
 await initializePubSub();
 await drizzleInit(false);
 
-initializeHarnessQueue();
+await initializeHarnessQueue();
 
 if (isMainThread) {
 	// Spawn the worker thread targeting index.ts

--- a/apps/server/index.ts
+++ b/apps/server/index.ts
@@ -2,6 +2,7 @@ import zodErrorCallbackParser from "./src/middlewares/zodErrorCallbackParser";
 
 export * from "./src/db";
 export * from "./src/db/redis";
+export * from "./src/db/natsQueue";
 export * from "./src/lib/project-settings";
 export * from "./src/loaders/appconfigLoader";
 export * from "./src/loaders/integrationsLoader";

--- a/apps/server/src/db/natsQueue.ts
+++ b/apps/server/src/db/natsQueue.ts
@@ -1,0 +1,218 @@
+import { logger } from "@fluxify/common";
+import {
+	AckPolicy,
+	JSONCodec,
+	RetentionPolicy,
+	type ConsumerMessages,
+	type JsMsg,
+} from "nats";
+import { natsConnection } from "./nats";
+
+/**
+ * A JetStream work queue: durable job delivery for anything that must survive a
+ * restart and be handled exactly once. The compile pipeline hand-rolled this
+ * shape first (see `modules/compiler/consumer.ts`); this is the same thing with
+ * the knobs that differ between queues pulled out, so a second queue is a
+ * config object rather than another copy of the ensure/consume dance.
+ *
+ * What it is NOT: a general pub/sub (that's `pubsub.ts`) or a request/response
+ * bus (that's `natsRpc.ts`). Work queue retention means a message is *removed*
+ * once acked, so exactly one consumer gets each job.
+ */
+
+const codec = JSONCodec<unknown>();
+const MS_TO_NS = 1_000_000;
+
+export interface WorkQueueSpec {
+	/** JetStream stream name, e.g. `FLUXIFY_HARNESS`. */
+	stream: string;
+	/** Subjects the stream captures, e.g. `["fluxify.harness.>"]`. */
+	subjects: string[];
+	/** Durable pull-consumer name. Shared across replicas — that IS the load balancing. */
+	consumer: string;
+	/**
+	 * Delivery attempts per message. Default 1: a job that dies with its worker
+	 * is NOT retried. Raise it only for handlers that are safe to re-run from
+	 * the top.
+	 */
+	maxDeliver?: number;
+	/** How long a message may go unacked before redelivery. Default 60s. */
+	ackWaitMs?: number;
+	/** How long an unhandled job stays in the stream. Default 24h. */
+	maxAgeMs?: number;
+	/**
+	 * Server-side dedupe window for `Nats-Msg-Id`. A publish carrying a msgId
+	 * seen within this window is dropped and its ack comes back `duplicate`.
+	 * Default 0 (off).
+	 */
+	dedupeWindowMs?: number;
+}
+
+export interface QueueJob<T> {
+	subject: string;
+	data: T;
+	/** Raw message — for `msg.redelivered`, headers, or a manual ack. */
+	msg: JsMsg;
+}
+
+export interface ConsumeOptions<T> {
+	/** Max handlers running at once. Also the pull buffer size. Default 1. */
+	concurrency?: number;
+	/**
+	 * - `on-dispatch`: ack as soon as a concurrency slot is taken, before the
+	 *   handler runs. The right choice when `maxDeliver` is 1 — the job will
+	 *   never be redelivered anyway, and it means a handler that runs for
+	 *   minutes never has to heartbeat `msg.working()` to hold its ack.
+	 * - `on-complete` (default): ack after the handler resolves; on a throw the
+	 *   message is naked (redelivered) or termed, per `maxDeliver`.
+	 */
+	ack?: "on-dispatch" | "on-complete";
+	/** Redelivery delay after a failed handler, when `maxDeliver > 1`. Default 5s. */
+	nakDelayMs?: number;
+	/** Called on a handler throw, after the ack/nak decision. */
+	onError?: (error: unknown, job: QueueJob<T>) => void;
+}
+
+/**
+ * Creates the stream and durable consumer if they don't exist. Idempotent, so
+ * every process that touches the queue can call it at startup.
+ */
+export async function ensureWorkQueue(spec: WorkQueueSpec): Promise<void> {
+	const jsm = await natsConnection().jetstreamManager();
+
+	try {
+		await jsm.streams.add({
+			name: spec.stream,
+			subjects: spec.subjects,
+			// work queue: acked jobs are removed, so a restart never replays
+			// everything ever asked for
+			retention: RetentionPolicy.Workqueue,
+			max_age: (spec.maxAgeMs ?? 24 * 60 * 60 * 1000) * MS_TO_NS,
+			duplicate_window: (spec.dedupeWindowMs ?? 0) * MS_TO_NS,
+		});
+	} catch {
+		// exists — keep the subject list current, leave the rest alone
+		await jsm.streams.update(spec.stream, { subjects: spec.subjects });
+	}
+
+	try {
+		await jsm.consumers.add(spec.stream, {
+			durable_name: spec.consumer,
+			ack_policy: AckPolicy.Explicit,
+			ack_wait: (spec.ackWaitMs ?? 60_000) * MS_TO_NS,
+			max_deliver: spec.maxDeliver ?? 1,
+		});
+	} catch {
+		// already exists
+	}
+}
+
+/**
+ * Publishes a job. Returns false when the server recognised `msgId` as a
+ * duplicate within the stream's dedupe window and dropped it — callers that
+ * care can treat that as "someone already queued this".
+ */
+export async function publishJob<T>(
+	subject: string,
+	data: T,
+	opts: { msgId?: string } = {},
+): Promise<boolean> {
+	const ack = await natsConnection()
+		.jetstream()
+		.publish(subject, codec.encode(data), {
+			...(opts.msgId ? { msgID: opts.msgId } : {}),
+		});
+	return !ack.duplicate;
+}
+
+/**
+ * Starts consuming. Returns a stop function that halts delivery; in-flight
+ * handlers are left to finish.
+ */
+export async function consumeJobs<T>(
+	spec: WorkQueueSpec,
+	handler: (job: QueueJob<T>) => Promise<void>,
+	opts: ConsumeOptions<T> = {},
+): Promise<() => Promise<void>> {
+	const concurrency = Math.max(1, opts.concurrency ?? 1);
+	const ackMode = opts.ack ?? "on-complete";
+	const slots = createSemaphore(concurrency);
+
+	const consumer = await natsConnection()
+		.jetstream()
+		.consumers.get(spec.stream, spec.consumer);
+	const messages: ConsumerMessages = await consumer.consume({
+		max_messages: concurrency,
+	});
+
+	(async () => {
+		for await (const msg of messages) {
+			// Backpressure: with every slot busy we stop pulling, and the job stays
+			// in the stream instead of piling up in this process's heap.
+			await slots.acquire();
+			if (ackMode === "on-dispatch") msg.ack();
+			void run(msg).finally(() => slots.release());
+		}
+	})();
+
+	async function run(msg: JsMsg) {
+		const job: QueueJob<T> = {
+			subject: msg.subject,
+			data: codec.decode(msg.data) as T,
+			msg,
+		};
+		try {
+			await handler(job);
+			if (ackMode === "on-complete") msg.ack();
+		} catch (error) {
+			if (ackMode === "on-complete") {
+				// nothing left to retry with when max_deliver is 1 — term, so the
+				// message leaves the queue instead of waiting out its ack_wait
+				if ((spec.maxDeliver ?? 1) > 1) msg.nak(opts.nakDelayMs ?? 5000);
+				else msg.term();
+			}
+			logger.error(
+				`[${spec.stream}] ${msg.subject} failed: ${String(error)}`,
+				"NATS_QUEUE",
+			);
+			opts.onError?.(error, job);
+		}
+	}
+
+	logger.info(
+		`[${spec.stream}] consuming as ${spec.consumer} (concurrency ${concurrency}, ack ${ackMode})`,
+		"NATS_QUEUE",
+	);
+
+	return async () => {
+		await messages.close();
+	};
+}
+
+/**
+ * Counting semaphore. `release` hands the slot straight to the next waiter
+ * rather than decrementing — decrementing first would let a fresh `acquire`
+ * steal the slot before the waiter resumes, putting the pool over its limit.
+ */
+export function createSemaphore(limit: number) {
+	let active = 0;
+	const waiting: Array<() => void> = [];
+
+	return {
+		async acquire(): Promise<void> {
+			if (active < limit) {
+				active++;
+				return;
+			}
+			await new Promise<void>((resolve) => waiting.push(resolve));
+		},
+		release(): void {
+			const next = waiting.shift();
+			if (next) next();
+			else active--;
+		},
+		get active() {
+			return active;
+		},
+	};
+}

--- a/apps/server/src/db/tests/natsQueue.spec.ts
+++ b/apps/server/src/db/tests/natsQueue.spec.ts
@@ -1,0 +1,298 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { AckPolicy, JSONCodec, RetentionPolicy, type JsMsg } from "nats";
+
+const codec = JSONCodec<unknown>();
+
+/* ------------------------------------------------------------------ fake JS */
+
+type Published = { subject: string; data: unknown; opts: any };
+const published: Published[] = [];
+let duplicate = false;
+const streamCalls: any[] = [];
+const consumerCalls: any[] = [];
+let streamAddFails = false;
+/** messages the fake consumer will deliver */
+let inbox: JsMsg[] = [];
+let closed = false;
+
+/** A JsMsg stub that records what the queue did to it. */
+function fakeMsg(subject: string, body: unknown): JsMsg & { acks: string[] } {
+	const acks: string[] = [];
+	return {
+		subject,
+		data: codec.encode(body),
+		acks,
+		ack: () => acks.push("ack"),
+		nak: (delay?: number) => acks.push(`nak:${delay}`),
+		term: () => acks.push("term"),
+	} as unknown as JsMsg & { acks: string[] };
+}
+
+// Spread the real module: `mock.module` replaces it for every test file in the
+// run, and `pubsub.ts` imports `closeNats`/`initializeNats` from it.
+const actualNats = await import("../nats");
+
+mock.module("../nats", () => ({
+	...actualNats,
+	natsConnection: () => ({
+		jetstream: () => ({
+			publish: async (subject: string, data: Uint8Array, opts: any) => {
+				published.push({ subject, data: codec.decode(data), opts });
+				return { duplicate };
+			},
+			consumers: {
+				get: async () => ({
+					consume: async (opts: any) => {
+						consumerCalls.push(opts);
+						return Object.assign(
+							(async function* () {
+								for (const m of inbox) yield m;
+							})(),
+							{ close: async () => void (closed = true) },
+						);
+					},
+				}),
+			},
+		}),
+		jetstreamManager: async () => ({
+			streams: {
+				add: async (cfg: any) => {
+					streamCalls.push(cfg);
+					if (streamAddFails) throw new Error("stream exists");
+				},
+				update: async (name: string, cfg: any) =>
+					streamCalls.push({ update: name, ...cfg }),
+			},
+			consumers: {
+				add: async (stream: string, cfg: any) =>
+					consumerCalls.push({ stream, ...cfg }),
+			},
+		}),
+	}),
+}));
+
+const { ensureWorkQueue, publishJob, consumeJobs, createSemaphore } =
+	await import("../natsQueue");
+
+const SPEC = {
+	stream: "TEST_STREAM",
+	subjects: ["test.>"],
+	consumer: "test_consumer",
+};
+
+/** the consume loop runs detached; let its microtasks drain */
+const settle = () => new Promise((r) => setTimeout(r, 5));
+
+beforeEach(() => {
+	published.length = 0;
+	streamCalls.length = 0;
+	consumerCalls.length = 0;
+	duplicate = false;
+	streamAddFails = false;
+	closed = false;
+	inbox = [];
+});
+
+describe("ensureWorkQueue", () => {
+	it("creates a work-queue stream and an explicit-ack durable consumer", async () => {
+		await ensureWorkQueue({ ...SPEC, maxDeliver: 1, dedupeWindowMs: 2000 });
+
+		expect(streamCalls[0]).toMatchObject({
+			name: "TEST_STREAM",
+			subjects: ["test.>"],
+			retention: RetentionPolicy.Workqueue,
+			duplicate_window: 2_000_000_000, // ms -> ns
+		});
+		expect(consumerCalls[0]).toMatchObject({
+			stream: "TEST_STREAM",
+			durable_name: "test_consumer",
+			ack_policy: AckPolicy.Explicit,
+			max_deliver: 1,
+		});
+	});
+
+	it("updates the subject list when the stream already exists", async () => {
+		streamAddFails = true;
+
+		await ensureWorkQueue(SPEC);
+
+		expect(streamCalls[1]).toMatchObject({
+			update: "TEST_STREAM",
+			subjects: ["test.>"],
+		});
+	});
+});
+
+describe("publishJob", () => {
+	it("passes the idempotency key as Nats-Msg-Id", async () => {
+		const accepted = await publishJob("test.a", { hello: 1 }, { msgId: "k1" });
+
+		expect(accepted).toBe(true);
+		expect(published[0]).toMatchObject({
+			subject: "test.a",
+			data: { hello: 1 },
+			opts: { msgID: "k1" },
+		});
+	});
+
+	it("reports false when the server dropped the publish as a duplicate", async () => {
+		duplicate = true;
+
+		expect(await publishJob("test.a", {}, { msgId: "k1" })).toBe(false);
+	});
+
+	it("omits the header entirely when no key is given", async () => {
+		await publishJob("test.a", {});
+
+		expect(published[0].opts.msgID).toBeUndefined();
+	});
+});
+
+describe("consumeJobs", () => {
+	it("decodes the payload and acks after the handler on the default mode", async () => {
+		const msg = fakeMsg("test.a", { n: 1 });
+		inbox = [msg];
+		const seen: unknown[] = [];
+
+		await consumeJobs(SPEC, async (job) => void seen.push(job.data));
+		await settle();
+
+		expect(seen).toEqual([{ n: 1 }]);
+		expect(msg.acks).toEqual(["ack"]);
+	});
+
+	it("acks before the handler runs in on-dispatch mode", async () => {
+		const msg = fakeMsg("test.a", {});
+		inbox = [msg];
+		let ackedBeforeHandler = false;
+
+		await consumeJobs(
+			SPEC,
+			async () => {
+				ackedBeforeHandler = msg.acks.length === 1;
+			},
+			{ ack: "on-dispatch" },
+		);
+		await settle();
+
+		expect(ackedBeforeHandler).toBe(true);
+		expect(msg.acks).toEqual(["ack"]); // and not acked a second time after
+	});
+
+	it("terms a failed job when there is no delivery left to retry with", async () => {
+		const msg = fakeMsg("test.a", {});
+		inbox = [msg];
+
+		await consumeJobs(SPEC, async () => {
+			throw new Error("boom");
+		});
+		await settle();
+
+		expect(msg.acks).toEqual(["term"]);
+	});
+
+	it("naks a failed job when redelivery is allowed", async () => {
+		const msg = fakeMsg("test.a", {});
+		inbox = [msg];
+
+		await consumeJobs(
+			{ ...SPEC, maxDeliver: 3 },
+			async () => {
+				throw new Error("boom");
+			},
+			{ nakDelayMs: 1234 },
+		);
+		await settle();
+
+		expect(msg.acks).toEqual(["nak:1234"]);
+	});
+
+	it("reports the failure to onError without killing the consumer", async () => {
+		inbox = [fakeMsg("test.a", { n: 1 }), fakeMsg("test.b", { n: 2 })];
+		const errors: string[] = [];
+
+		await consumeJobs(
+			SPEC,
+			async (job) => {
+				throw new Error(`failed ${(job.data as any).n}`);
+			},
+			{ onError: (e) => errors.push(String(e)) },
+		);
+		await settle();
+
+		expect(errors).toEqual(["Error: failed 1", "Error: failed 2"]);
+	});
+
+	it("never runs more handlers at once than the concurrency allows", async () => {
+		inbox = Array.from({ length: 10 }, (_, i) => fakeMsg("test.a", { i }));
+		let running = 0;
+		let peak = 0;
+		const release: Array<() => void> = [];
+
+		await consumeJobs(
+			SPEC,
+			async () => {
+				running++;
+				peak = Math.max(peak, running);
+				await new Promise<void>((r) => release.push(r));
+				running--;
+			},
+			{ concurrency: 3, ack: "on-dispatch" },
+		);
+		await settle();
+
+		expect(peak).toBe(3);
+		// only the first 3 were dispatched; the rest wait in the stream
+		expect(release).toHaveLength(3);
+
+		release.splice(0, 3).forEach((r) => r());
+		await settle();
+		expect(peak).toBe(3);
+	});
+
+	it("sizes the pull buffer to the concurrency", async () => {
+		await consumeJobs(SPEC, async () => {}, { concurrency: 7 });
+
+		expect(consumerCalls.at(-1)).toMatchObject({ max_messages: 7 });
+	});
+
+	it("stops delivery when the returned stop function is called", async () => {
+		const stop = await consumeJobs(SPEC, async () => {});
+
+		await stop();
+
+		expect(closed).toBe(true);
+	});
+});
+
+describe("createSemaphore", () => {
+	it("hands a released slot to the waiter instead of letting a newcomer steal it", async () => {
+		const sem = createSemaphore(1);
+		await sem.acquire();
+
+		const order: string[] = [];
+		const waiter = sem.acquire().then(() => order.push("waiter"));
+		sem.release();
+		// a newcomer arriving in the same tick must not get in first
+		const newcomer = sem.acquire().then(() => order.push("newcomer"));
+
+		await waiter;
+		expect(order).toEqual(["waiter"]);
+		expect(sem.active).toBe(1);
+
+		sem.release();
+		await newcomer;
+		expect(order).toEqual(["waiter", "newcomer"]);
+	});
+
+	it("drops back to zero once every slot is released", async () => {
+		const sem = createSemaphore(2);
+		await sem.acquire();
+		await sem.acquire();
+
+		sem.release();
+		sem.release();
+
+		expect(sem.active).toBe(0);
+	});
+});

--- a/bun.lock
+++ b/bun.lock
@@ -53,7 +53,6 @@
         "@orama/plugin-data-persistence": "^3.1.18",
         "@socket.io/bun-engine": "^0.1.1",
         "ai": "^7.0.0",
-        "bullmq": "^5.79.1",
         "drizzle-orm": "0.44.7",
         "hono": "^4.12.27",
         "hono-openapi": "^1.3.0",
@@ -884,18 +883,6 @@
     "@mongodb-js/saslprep": ["@mongodb-js/saslprep@1.4.12", "", { "dependencies": { "sparse-bitfield": "^3.0.3" } }, "sha512-QAfAMwNgnYxZ2C6D1HgeP7Gc4i/uvJRim415PCIL9ptRxWMNbWeLBYb2/9R4pGKny/s1FVu2JA2cxCUBUOggrA=="],
 
     "@msgpack/msgpack": ["@msgpack/msgpack@3.1.3", "", {}, "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA=="],
-
-    "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ=="],
-
-    "@msgpackr-extract/msgpackr-extract-darwin-x64": ["@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w=="],
-
-    "@msgpackr-extract/msgpackr-extract-linux-arm": ["@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4", "", { "os": "linux", "cpu": "arm" }, "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw=="],
-
-    "@msgpackr-extract/msgpackr-extract-linux-arm64": ["@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw=="],
-
-    "@msgpackr-extract/msgpackr-extract-linux-x64": ["@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ=="],
-
-    "@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4", "", { "os": "win32", "cpu": "x64" }, "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ=="],
 
     "@napi-rs/snappy-android-arm-eabi": ["@napi-rs/snappy-android-arm-eabi@7.3.3", "", { "os": "android", "cpu": "arm" }, "sha512-d4vUFFzNBvazGfB/KU8MnEax6itTIgRWXodPdZDnWKHy9HwVBndpCiedQDcSNHcZNYV36rx034rpn7SAuTL2NA=="],
 
@@ -1747,8 +1734,6 @@
 
     "buildcheck": ["buildcheck@0.0.7", "", {}, "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA=="],
 
-    "bullmq": ["bullmq@5.81.0", "", { "dependencies": { "cron-parser": "4.9.0", "ioredis": "5.11.1", "msgpackr": "2.0.4", "node-abort-controller": "3.1.1", "semver": "7.8.5", "tslib": "2.8.1" }, "peerDependencies": { "redis": ">=5.0.0" }, "optionalPeers": ["redis"] }, "sha512-hyNrmq4/NN3l96VVD0wZnq6w4+GyInI3lO9JnPovAHBe5lyfCMOMkA/K7pUveHYcXTqUsYGdWuh1xf/Yus2bQQ=="],
-
     "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
@@ -1836,8 +1821,6 @@
     "cpu-features": ["cpu-features@0.0.10", "", { "dependencies": { "buildcheck": "~0.0.6", "nan": "^2.19.0" } }, "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA=="],
 
     "crelt": ["crelt@1.0.7", "", {}, "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA=="],
-
-    "cron-parser": ["cron-parser@4.9.0", "", { "dependencies": { "luxon": "^3.2.1" } }, "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -2571,8 +2554,6 @@
 
     "lru.min": ["lru.min@1.1.4", "", {}, "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA=="],
 
-    "luxon": ["luxon@3.7.2", "", {}, "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew=="],
-
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "make-asynchronous": ["make-asynchronous@1.1.0", "", { "dependencies": { "p-event": "^6.0.0", "type-fest": "^4.6.0", "web-worker": "^1.5.0" } }, "sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg=="],
@@ -2719,10 +2700,6 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "msgpackr": ["msgpackr@2.0.4", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.4" } }, "sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA=="],
-
-    "msgpackr-extract": ["msgpackr-extract@3.0.4", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw=="],
-
     "mustache": ["mustache@4.2.0", "", { "bin": { "mustache": "bin/mustache" } }, "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ=="],
 
     "mysql2": ["mysql2@3.23.1", "", { "dependencies": { "aws-ssl-profiles": "^1.1.2", "denque": "^2.1.0", "generate-function": "^2.3.1", "iconv-lite": "^0.7.2", "long": "^5.3.2", "lru.min": "^1.1.4", "named-placeholders": "^1.1.6", "sql-escaper": "^1.5.1" }, "peerDependencies": { "@types/node": ">= 8" } }, "sha512-tTuRnC7qCet2IOfSNMYZ5SwXuBnfvBPAcIA28P0gtruXyZlU1LMxA6uha32kYypoFgyYklMqhLWwt4laYwXR/Q=="],
@@ -2749,15 +2726,11 @@
 
     "nkeys.js": ["nkeys.js@1.1.0", "", { "dependencies": { "tweetnacl": "1.0.3" } }, "sha512-tB/a0shZL5UZWSwsoeyqfTszONTt4k2YS0tuQioMOD180+MbombYVgzDUYHlx+gejYK6rgf08n/2Df99WY0Sxg=="],
 
-    "node-abort-controller": ["node-abort-controller@3.1.1", "", {}, "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ=="],
-
     "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
 
     "node-exports-info": ["node-exports-info@1.6.2", "", { "dependencies": { "array.prototype.flatmap": "^1.3.3", "es-errors": "^1.3.0", "object.entries": "^1.1.9", "semver": "^6.3.1" } }, "sha512-kXs9Go0cah0qHVV2v389IXQLdLCeE1xfFtjOAF+iobu0OIoG1pje8At2vMHyaPMiPMnG/LWP50twML21eMcAag=="],
 
     "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
-
-    "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
 
     "node-releases": ["node-releases@2.0.51", "", {}, "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ=="],
 

--- a/env.example
+++ b/env.example
@@ -37,6 +37,8 @@ WORKER_PORT=5600
 PROXY_PORT=8080
 # AI Gateway service server port
 AI_GATEWAY_PORT=8001
+# Harness runs a single AI gateway worker executes at once (1-100)
+HARNESS_CONCURRENT_JOBS=10
 # Upstream worker address for proxy routing when using scale-out topology (e.g. worker:5600)
 WORKER_UPSTREAM=
 # Public hostname for production deployments (e.g. www.fluxify.rest)


### PR DESCRIPTION
Closes #295.

## Why

The gateway already spoke NATS for progress events, interrupts and artifacts. BullMQ was left owning nothing but job transport — a second broker to run, a Redis dependency purely for the queue, and a worker concurrency pinned at 1 (BullMQ's default), which is what #295 asked for a knob on.

## What

**A reusable work-queue helper in `@fluxify/server`** (`src/db/natsQueue.ts`), so this isn't harness-specific:

- `ensureWorkQueue(spec)` — work-queue stream + durable explicit-ack pull consumer, driven by a `WorkQueueSpec` (`maxDeliver`, `ackWaitMs`, `maxAgeMs`, `dedupeWindowMs`)
- `publishJob(subject, data, { msgId })` — returns `false` when the server dropped the publish as a duplicate
- `consumeJobs(spec, handler, { concurrency, ack, nakDelayMs, onError })` — returns a stop function; `ack: "on-dispatch" | "on-complete"`, and on failure terms or naks depending on whether a redelivery is left
- `createSemaphore(limit)` — a released slot is handed to the waiter, so the pool cannot overshoot

**The harness on JetStream**: stream `FLUXIFY_HARNESS`, subjects `fluxify.harness.{start,continue}.<conversationId>`, consumed at `HARNESS_CONCURRENT_JOBS` (default 10, 1–100, validated) — the deliverable for #295.

**No redelivery, by design** (`max_deliver: 1`): a run lost to a crashed node must not be replayed. That also means holding the ack for the length of a run would buy nothing but an `ack_wait` heartbeat to maintain across a multi-minute AI run, so the worker acks on dispatch and lets the semaphore be what limits concurrency.

**Duplicate work is kept out by three gates instead of an ack:**

1. `Nats-Msg-Id` = `<type>:<runId>:<nonce>` inside a 2-minute dedupe window — swallows a republished message without ever swallowing a second, legitimate HITL decision on the same run
2. a conditional `UPDATE` claim on the conversation at enqueue — `createRun` now returns `null` when it loses the race (deleting its orphan run row) and the API answers 409; `ensureConversation` inserts `idle` so `createRun` is the only place a conversation becomes `running`
3. a run-row claim in the worker (`queued → routing`, `awaiting_hitl → executing`) before any model call

A job that throws before the harness owns its own error handling releases the run, so a claim can't strand a conversation as `running` with nothing left to finish it.

BullMQ is uninstalled; `job?: Job` is gone from the run context (it was never read) and the stale BullMQ comments are corrected.

## Testing

- 28 new tests: `natsQueue.spec.ts` (stream/consumer config, exists-path update, msg-id passthrough and duplicate reporting, both ack modes, term vs nak, `onError` continuity, the concurrency cap, pull sizing, stop, semaphore fairness), `enqueue.spec.ts`, `worker.spec.ts`
- `bun test apps/ai-gateway` 386 pass / 0 fail, `bun test apps/server` 417 pass / 0 fail, both lints clean
- Verified end to end against local NATS/Postgres/Redis: enqueue → JetStream → worker → `queued → routing → completed` in 10s with a real model response; live stream reported `retention=workqueue`, `duplicate_window=120s`, `max_deliver=1`, `redelivered=0`, and `messages: 0` after the ack. A repeat publish with the same `Nats-Msg-Id` was rejected as a duplicate.

## Follow-up (not in this PR)

`apps/server/src/modules/compiler/{publisher,consumer}.ts` still hand-rolls the same stream/consumer setup and could collapse onto `natsQueue`; kept out to avoid touching the compile pipeline in a transport change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UWwcvHoSQt8r2b3PhYmir
